### PR TITLE
修改 Render 的插件根目录

### DIFF
--- a/docs/plugins/render.md
+++ b/docs/plugins/render.md
@@ -104,6 +104,10 @@ Render 支持主题，主题基模板储存在 `src/templates/base` 中，主题
 
 所有向用户展示的文本都要被本地化。
 
+## 本地文件引用
+
+可以使用 `{% include "xx" %}` 块或 `src=xxx` 引入本地文件。 使用相对引入时，基路径为 `src/templates`。
+
 ## 使用
 
 这是 Boothill 插件中渲染的代码：

--- a/src/plugins/nonebot_plugin_render/render.py
+++ b/src/plugins/nonebot_plugin_render/render.py
@@ -9,6 +9,7 @@ from nonebot_plugin_htmlrender import html_to_pic
 from .lang import lang
 from .config import config
 from . import theme
+from os import getcwd
 
 file_loader = FileSystemLoader(Path("./src/templates"))
 env = Environment(
@@ -47,5 +48,7 @@ async def render_template(name: str, title: str, user_id: str, templates: dict) 
     footer = await lang.text("render.footer", user_id, plugin_name)
     base = await get_base(user_id)
     return await html_to_pic(
-        await render_template_to_text(name, title, footer, templates, base), viewport=config.render_viewport
+        await render_template_to_text(name, title, footer, templates, base),
+        template_path=Path(getcwd()).joinpath(f"src/templates").as_uri(),
+        viewport=config.render_viewport
     )

--- a/src/plugins/nonebot_plugin_render/render.py
+++ b/src/plugins/nonebot_plugin_render/render.py
@@ -50,5 +50,5 @@ async def render_template(name: str, title: str, user_id: str, templates: dict) 
     return await html_to_pic(
         await render_template_to_text(name, title, footer, templates, base),
         template_path=Path(getcwd()).joinpath(f"src/templates").as_uri(),
-        viewport=config.render_viewport
+        viewport=config.render_viewport,
     )


### PR DESCRIPTION
将 PlayWright 渲染时候的相对引用基目录设为 `src/templates`