### PR TITLE
关于 LarkHelp 的优化

### DIFF
--- a/src/lang/zh_hans/larkhelp.yaml
+++ b/src/lang/zh_hans/larkhelp.yaml
@@ -14,5 +14,5 @@ command:
 help:
   description: 命令帮助
   details: 获取命令用法
-  usage_list: help (获取命令列表)
-  usage_command: help <命令名> (查看命令帮助)
+  usage1: help (获取命令列表)
+  usage2: help <命令名> (查看命令帮助)

--- a/src/plugins/nonebot_plugin_larkhelp/__init__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__init__.py
@@ -9,4 +9,4 @@ require("nonebot_plugin_alconna")
 require("nonebot_plugin_larklang")
 require("nonebot_plugin_render")
 
-from . import __main__
+from . import __main__, api

--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -15,6 +15,7 @@ from .collector import collect_command_help
 
 help_list = {}
 
+
 @get_driver().on_startup
 async def _() -> None:
     global help_list
@@ -24,8 +25,10 @@ async def _() -> None:
 help_cmd = on_alconna(Alconna("help", Args["command?", str]))
 lang = LangHelper()
 
+
 def get_help_list() -> dict[str, CommandHelp]:
     return help_list
+
 
 @help_cmd.assign("command")
 async def _(command: str, user_id: str = get_user_id()) -> None:
@@ -52,31 +55,24 @@ async def get_help_dict(name: str, user_id: str, data: Optional[CommandHelp] = N
         "description": await (plugin_lang := LangHelper(data.plugin)).text(data.description, user_id),
         "details": await plugin_lang.text(data.details, user_id),
         "usages": [
-            (await lang.text("list.usage", user_id, await plugin_lang.text(usage, user_id)))
-            for usage in data.usages
+            (await lang.text("list.usage", user_id, await plugin_lang.text(usage, user_id))) for usage in data.usages
         ],
     }
+
 
 async def get_templates(user_id: str) -> dict[str, Any]:
     if not help_list:
         raise ValueError("No Command")
     return dict(
         usages_text=await lang.text("list.usage_text", user_id),
-        commands=[
-            await get_help_dict(name, user_id, data)
-            for name, data in help_list.items()
-        ],
+        commands=[await get_help_dict(name, user_id, data) for name, data in help_list.items()],
     )
 
 
 @creator("help.html.jinja")
 async def render(user_id: str) -> bytes:
     return await render_template(
-        "help.html.jinja",
-        await lang.text("list.title", user_id),
-        user_id,
-        await get_templates(user_id),
-        True
+        "help.html.jinja", await lang.text("list.title", user_id), user_id, await get_templates(user_id), True
     )
 
 

--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from nonebot import get_driver
 from nonebot_plugin_alconna import Alconna, Args, on_alconna
@@ -10,8 +10,10 @@ from ..nonebot_plugin_render.cache import creator
 
 from ..nonebot_plugin_larklang.__main__ import LangHelper
 from ..nonebot_plugin_larkutils import get_user_id
+from .models import CommandHelp
 from .collector import collect_command_help
 
+help_list = {}
 
 @get_driver().on_startup
 async def _() -> None:
@@ -22,6 +24,8 @@ async def _() -> None:
 help_cmd = on_alconna(Alconna("help", Args["command?", str]))
 lang = LangHelper()
 
+def get_help_list() -> dict[str, CommandHelp]:
+    return help_list
 
 @help_cmd.assign("command")
 async def _(command: str, user_id: str = get_user_id()) -> None:
@@ -41,19 +45,25 @@ async def _(command: str, user_id: str = get_user_id()) -> None:
     await help_cmd.finish()
 
 
+async def get_help_dict(name: str, user_id: str, data: Optional[CommandHelp] = None) -> dict[str, str | list[str]]:
+    data = data or help_list[name]
+    return {
+        "name": name,
+        "description": await (plugin_lang := LangHelper(data.plugin)).text(data.description, user_id),
+        "details": await plugin_lang.text(data.details, user_id),
+        "usages": [
+            (await lang.text("list.usage", user_id, await plugin_lang.text(usage, user_id)))
+            for usage in data.usages
+        ],
+    }
+
 async def get_templates(user_id: str) -> dict[str, Any]:
+    if not help_list:
+        raise ValueError("No Command")
     return dict(
         usages_text=await lang.text("list.usage_text", user_id),
         commands=[
-            {
-                "name": name,
-                "description": await (plugin_lang := LangHelper(data.plugin)).text(data.description, user_id),
-                "details": await plugin_lang.text(data.details, user_id),
-                "usages": [
-                    (await lang.text("list.usage", user_id, await plugin_lang.text(usage, user_id)))
-                    for usage in data.usages
-                ],
-            }
+            await get_help_dict(name, user_id, data)
             for name, data in help_list.items()
         ],
     )
@@ -62,7 +72,11 @@ async def get_templates(user_id: str) -> dict[str, Any]:
 @creator("help.html.jinja")
 async def render(user_id: str) -> bytes:
     return await render_template(
-        "help.html.jinja", await lang.text("list.title", user_id), user_id, await get_templates(user_id), True
+        "help.html.jinja",
+        await lang.text("list.title", user_id),
+        user_id,
+        await get_templates(user_id),
+        True
     )
 
 

--- a/src/plugins/nonebot_plugin_larkhelp/api.py
+++ b/src/plugins/nonebot_plugin_larkhelp/api.py
@@ -1,0 +1,40 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2024  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from nonebot import get_app
+from typing import cast
+from fastapi import FastAPI, HTTPException, status
+
+from ..nonebot_plugin_larkuid.session import get_user_id
+from .__main__ import lang, get_help_list, get_help_dict
+
+app = cast(FastAPI, get_app())
+
+
+@app.get("/api/help/commands")
+async def _() -> list[str]:
+    return list(get_help_list().keys())
+
+
+@app.get("/api/help/commands/{name}")
+async def _(name: str, user_id: str = get_user_id("-1")) -> dict[str, str | list[str]]:
+    try:
+        return await get_help_dict(name, user_id)
+    except KeyError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+

--- a/src/plugins/nonebot_plugin_larkhelp/api.py
+++ b/src/plugins/nonebot_plugin_larkhelp/api.py
@@ -36,5 +36,3 @@ async def _(name: str, user_id: str = get_user_id("-1")) -> dict[str, str | list
         return await get_help_dict(name, user_id)
     except KeyError:
         raise HTTPException(status.HTTP_404_NOT_FOUND)
-
-

--- a/src/plugins/nonebot_plugin_larkhelp/collector.py
+++ b/src/plugins/nonebot_plugin_larkhelp/collector.py
@@ -23,7 +23,7 @@ async def get_plugin_help(plugin: Plugin) -> dict[str, CommandHelp]:
         if isinstance(value, str):
             if ";" in value:
                 usage_count = int((l := value.split(";"))[-1])
-                value = l[1]
+                value = l[0] or "help"
             else:
                 usage_count = 1
             help_list[key] = CommandHelp(

--- a/src/plugins/nonebot_plugin_larkhelp/collector.py
+++ b/src/plugins/nonebot_plugin_larkhelp/collector.py
@@ -30,7 +30,7 @@ async def get_plugin_help(plugin: Plugin) -> dict[str, CommandHelp]:
                 plugin=data.plugin,
                 description=f"{value}.description",
                 details=f"{value}.details",
-                usages=[f"{value}.usage{i}" for i in range(1, usage_count + 1)]
+                usages=[f"{value}.usage{i}" for i in range(1, usage_count + 1)],
             )
         else:
             help_list[key] = CommandHelp(**value, plugin=data.plugin)

--- a/src/plugins/nonebot_plugin_larkhelp/help.yaml
+++ b/src/plugins/nonebot_plugin_larkhelp/help.yaml
@@ -1,8 +1,8 @@
 plugin: larkhelp
 commands:
-  help:
-    description: help.description
-    details: help.details
-    usages:
-      - help.usage_list
-      - help.usage_command
+  help: help;2
+#    description: help.description
+#    details: help.details
+#    usages:
+#      - help.usage1
+#      - help.usage2

--- a/src/plugins/nonebot_plugin_larkhelp/models.py
+++ b/src/plugins/nonebot_plugin_larkhelp/models.py
@@ -10,4 +10,4 @@ class CommandHelp(BaseModel):
 
 class CommandHelpData(BaseModel):
     plugin: str
-    commands: dict
+    commands: dict[str, str | dict[str, str | list[str]]]


### PR DESCRIPTION
- [x] 此 Pull Requests 进行的更改已经过测试

### 描述

1. 添加一个接口用于获取命令列表和命令帮助
2. 支持使用 `str` 类型作为 `help.yaml` 中帮助内容

### 新接口用法

#### 命令列表

```http request
GET /api/help/commands
```

#### 命令帮助

```http request
GET /api/help/commands/:name
```

