### PR TITLE
加好友自动同意和开场白

### DIFF
--- a/src/lang/zh_hans/friend_add.yaml
+++ b/src/lang/zh_hans/friend_add.yaml
@@ -1,0 +1,3 @@
+text:
+  default: 你好，喵~我是由 IT Craft Development Team 下属 Moonlark-Dev 开发的开源多功能机器人 Moonlark。很高兴和你相遇，在往后的日子里请多多指教喵~发送“{__prefix__}help”即可了解我的全部功能！
+  more_with_nickname: {}，很高兴再次见到你。

--- a/src/lang/zh_hans/join_message.yaml
+++ b/src/lang/zh_hans/join_message.yaml
@@ -1,2 +1,2 @@
 join:
-  message: 大家好喵！我是由 IT Craft Development Team 下属 Moonlark-Dev 开发的多功能机器人 Moonlark。使用“{__prefix__}help”可以查看我的能力喵~
+  message: 大家好，喵！我是由 IT Craft Development Team 下属 Moonlark-Dev 开发的多功能机器人 Moonlark。使用“{__prefix__}help”可以查看我的能力喵~

--- a/src/plugins/nonebot_plugin_friend_add/__init__.py
+++ b/src/plugins/nonebot_plugin_friend_add/__init__.py
@@ -15,5 +15,3 @@ __plugin_meta__ = PluginMetadata(
     usage="",
     config=Config,
 )
-
-

--- a/src/plugins/nonebot_plugin_friend_add/__init__.py
+++ b/src/plugins/nonebot_plugin_friend_add/__init__.py
@@ -1,0 +1,19 @@
+from nonebot import require
+from nonebot.plugin import PluginMetadata
+from .config import Config
+
+require("nonebot_plugin_larklang")
+require("nonebot_plugin_larkutils")
+require("nonebot_plugin_larkuser")
+require("nonebot_plugin_localstore")
+
+from . import __main__
+
+__plugin_meta__ = PluginMetadata(
+    name="nonebot-plugin-friend-add",
+    description="",
+    usage="",
+    config=Config,
+)
+
+

--- a/src/plugins/nonebot_plugin_friend_add/__main__.py
+++ b/src/plugins/nonebot_plugin_friend_add/__main__.py
@@ -72,7 +72,7 @@ async def _(bot: BotOB, event: FriendRequestEvent, user_id: str = get_user_id())
     user = await get_user(user_id)
     if user.get_fav() <= 0.05:
         await event.reject(bot)
-    elif user_id in (friends := await get_friends()) and (datetime.now() - datetime.fromtimestamp(friends[user_id])).total_seconds() < 43200:
+    elif user_id in (friends := await get_friends()) and (datetime.now() - datetime.fromtimestamp(friends[user_id])).total_seconds() < 1800:
         await event.reject(bot)
     else:
         await event.approve(bot)

--- a/src/plugins/nonebot_plugin_friend_add/__main__.py
+++ b/src/plugins/nonebot_plugin_friend_add/__main__.py
@@ -27,7 +27,7 @@ from nonebot import on_type
 from datetime import datetime
 from ..nonebot_plugin_larklang import LangHelper
 from ..nonebot_plugin_larkuser import get_user
-from ..nonebot_plugin_larkutils import  get_user_id
+from ..nonebot_plugin_larkutils import get_user_id
 from .config import config
 
 lang = LangHelper()
@@ -36,6 +36,7 @@ friend_request = on_type(FriendRequestEvent)
 friend_add_ob = on_type(FriendAddNoticeEvent)
 friend_add_ob12 = on_type(FriendIncreaseEvent)
 data_file = get_data_file("nonebot_plugin_friend_add", "friends.json")
+
 
 async def get_friends() -> dict[str, float]:
     try:
@@ -72,10 +73,14 @@ async def _(bot: BotOB, event: FriendRequestEvent, user_id: str = get_user_id())
     user = await get_user(user_id)
     if user.get_fav() <= 0.05:
         await event.reject(bot)
-    elif user_id in (friends := await get_friends()) and (datetime.now() - datetime.fromtimestamp(friends[user_id])).total_seconds() < 1800:
+    elif (
+        user_id in (friends := await get_friends())
+        and (datetime.now() - datetime.fromtimestamp(friends[user_id])).total_seconds() < 1800
+    ):
         await event.reject(bot)
     else:
         await event.approve(bot)
+
 
 @friend_add_ob12.handle()
 @friend_add_ob.handle()
@@ -90,6 +95,3 @@ async def _(user_id: str = get_user_id()) -> None:
         await lang.finish("text.more_with_nickname", user_id, user.get_nickname())
     else:
         await lang.finish("text.default", user_id)
-
-
-

--- a/src/plugins/nonebot_plugin_friend_add/__main__.py
+++ b/src/plugins/nonebot_plugin_friend_add/__main__.py
@@ -1,0 +1,93 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2024  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+import json
+
+import aiofiles
+from nonebot.adapters.onebot.v11.event import FriendAddNoticeEvent, FriendRequestEvent
+from nonebot.adapters.qq.event import FriendAddEvent
+from nonebot.adapters.qq import Bot as BotQQ
+from nonebot.adapters.onebot.v11 import Bot as BotOB
+from nonebot_plugin_localstore import get_data_file
+from nonebot import on_type
+from datetime import datetime
+from ..nonebot_plugin_larklang import LangHelper
+from ..nonebot_plugin_larkuser import get_user
+from ..nonebot_plugin_larkutils import  get_user_id
+from .config import config
+
+lang = LangHelper()
+friend_add_qq = on_type(FriendAddEvent)
+friend_request = on_type(FriendRequestEvent)
+friend_add_ob = on_type(FriendAddNoticeEvent)
+data_file = get_data_file("nonebot_plugin_friend_add", "friends.json")
+
+async def get_friends() -> dict[str, float]:
+    try:
+        async with aiofiles.open(data_file, "r", encoding="utf-8") as f:
+            return json.loads(await f.read())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+async def write_friends_file(data: dict[str, float]) -> None:
+    async with aiofiles.open(data_file, "w", encoding="utf-8") as f:
+        await f.write(json.dumps(data))
+
+
+@friend_add_qq.handle()
+async def _(bot: BotQQ, event: FriendAddEvent, user_id: str = get_user_id()) -> None:
+    user = await get_user(user_id)
+    if user_id not in (friends := await get_friends()):
+        await user.add_fav(config.friend_add_award_fav)
+        friends[user_id] = datetime.now().timestamp()
+        await write_friends_file(friends)
+        await bot.send_to_c2c(event.openid, await lang.text("text.default", user_id))
+    elif (datetime.now() - datetime.fromtimestamp(friends[user_id])).days < 1:
+        pass
+    elif user.has_nickname():
+        await bot.send_to_c2c(event.openid, await lang.text("text.more_with_nickname", user_id, user.get_nickname()))
+    else:
+        await bot.send_to_c2c(event.openid, await lang.text("text.default", user_id))
+    await friend_add_qq.finish()
+
+
+@friend_request.handle()
+async def _(bot: BotOB, event: FriendRequestEvent, user_id: str = get_user_id()) -> None:
+    user = await get_user(user_id)
+    if user.get_fav() <= 0.05:
+        await event.reject(bot)
+    elif user_id in (friends := await get_friends()) and (datetime.now() - datetime.fromtimestamp(friends[user_id])).total_seconds() < 43200:
+        await event.reject(bot)
+    else:
+        await event.approve(bot)
+
+
+@friend_add_ob.handle()
+async def _(user_id: str = get_user_id()) -> None:
+    user = await get_user(user_id)
+    if user_id not in (friends := await get_friends()):
+        await user.add_fav(config.friend_add_award_fav)
+        friends[user_id] = datetime.now().timestamp()
+        await write_friends_file(friends)
+        await lang.finish("text.default", user_id)
+    elif user.has_nickname():
+        await lang.finish("text.more_with_nickname", user_id, user.get_nickname())
+    else:
+        await lang.finish("text.default", user_id)
+
+
+

--- a/src/plugins/nonebot_plugin_friend_add/__main__.py
+++ b/src/plugins/nonebot_plugin_friend_add/__main__.py
@@ -18,6 +18,7 @@ import json
 
 import aiofiles
 from nonebot.adapters.onebot.v11.event import FriendAddNoticeEvent, FriendRequestEvent
+from nonebot.adapters.onebot.v12.event import FriendIncreaseEvent
 from nonebot.adapters.qq.event import FriendAddEvent
 from nonebot.adapters.qq import Bot as BotQQ
 from nonebot.adapters.onebot.v11 import Bot as BotOB
@@ -33,6 +34,7 @@ lang = LangHelper()
 friend_add_qq = on_type(FriendAddEvent)
 friend_request = on_type(FriendRequestEvent)
 friend_add_ob = on_type(FriendAddNoticeEvent)
+friend_add_ob12 = on_type(FriendIncreaseEvent)
 data_file = get_data_file("nonebot_plugin_friend_add", "friends.json")
 
 async def get_friends() -> dict[str, float]:
@@ -75,7 +77,7 @@ async def _(bot: BotOB, event: FriendRequestEvent, user_id: str = get_user_id())
     else:
         await event.approve(bot)
 
-
+@friend_add_ob12.handle()
 @friend_add_ob.handle()
 async def _(user_id: str = get_user_id()) -> None:
     user = await get_user(user_id)

--- a/src/plugins/nonebot_plugin_friend_add/config.py
+++ b/src/plugins/nonebot_plugin_friend_add/config.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+from nonebot import get_plugin_config
+
+
+class Config(BaseModel):
+    """Plugin Config Here"""
+    friend_add_award_fav: float = 0.05
+
+
+config = get_plugin_config(Config)

--- a/src/plugins/nonebot_plugin_friend_add/config.py
+++ b/src/plugins/nonebot_plugin_friend_add/config.py
@@ -4,6 +4,7 @@ from nonebot import get_plugin_config
 
 class Config(BaseModel):
     """Plugin Config Here"""
+
     friend_add_award_fav: float = 0.05
 
 

--- a/src/plugins/nonebot_plugin_larkuser/utils/user.py
+++ b/src/plugins/nonebot_plugin_larkuser/utils/user.py
@@ -52,6 +52,9 @@ class MoonlarkUser:
     def get_nickname(self) -> str:
         return self.nickname
 
+    def has_nickname(self) -> bool:
+        return bool(self.nickname)
+
     def get_avatar(self) -> Optional[bytes]:
         return self.avatar
 


### PR DESCRIPTION
- [x] 此 Pull Requests 进行的更改已经过测试

### 有关问题链接

Fixes #178

### 描述

对 OneBot V11、OneBot V12、QQ 适配器的加好友相关事件进行响应，自动同意好感度大于 `0.05` 且 30min 内没发送好友请求的用户，并发送加好友开场白（QQ 适配器有 1d 的冷却 ）

在主、子账户中可能存在类似随机不触发的问题，可以使用实际帐号 ID 代替 MoonlarkUID 进行处理，如需请将此 PR 标记为 Change Request