### PR TITLE
允许在 QuickMath 中复活

### DIFF
--- a/src/lang/zh_hans/quick_math.yaml
+++ b/src/lang/zh_hans/quick_math.yaml
@@ -1,8 +1,5 @@
 main:
-  wait: |
-    [Moonlark Quick Math]
-    挑战将在 {}s 后开始，请等待初始化
-  timeout: 您已超时，挑战结束！
+  timeout: 您已超时
   checkout: |
     # Quick Math 挑战结果
 
@@ -24,6 +21,7 @@ main:
     | {}       | {}      | {}          |
 
   wrong: 重试次数过多，挑战结束！
+  respawn_prompt: 您可以在此重生（这将失去本次挑战中的 {} 积分） [Y/n] (20s)
   skipped: |
     已跳过本题
   markdown: |

--- a/src/lang/zh_hans/quick_math.yaml
+++ b/src/lang/zh_hans/quick_math.yaml
@@ -120,7 +120,7 @@ achievements:
 help:
   desc: 快速数学
   details: 以计算为核心的玩法。找到问题的答案，并在排行榜中获取更高的积分。
-  u1: quick-math (开始挑战)
+  u1: quick-math [-l|--level <开始的等级>] (开始挑战)
   u2: quick-math rank [{{max|total}}] (积分排行榜)
   u3: quick-math award (查看奖励详情)
 award:

--- a/src/plugins/nonebot_plugin_quick_math/__main__.py
+++ b/src/plugins/nonebot_plugin_quick_math/__main__.py
@@ -1,5 +1,5 @@
 from typing import Literal
-from nonebot_plugin_alconna import Alconna, Args, Subcommand, on_alconna
+from nonebot_plugin_alconna import Alconna, Args, Subcommand, on_alconna, Option
 
 from src.plugins.nonebot_plugin_larkuser.utils.matcher import patch_matcher
 from ..nonebot_plugin_larklang import LangHelper
@@ -10,6 +10,8 @@ quick_math = on_alconna(
         "quick-math",
         Subcommand("rank", Args["rank_type", Literal["total", "max"], "max"]),
         Subcommand("award"),
+        Option("--level|-l", Args["start_level", int, 1]),
+        Option("--respawn|-r", Args["enable_respawn", bool, True])
     )
 )
 lang = LangHelper()

--- a/src/plugins/nonebot_plugin_quick_math/__main__.py
+++ b/src/plugins/nonebot_plugin_quick_math/__main__.py
@@ -10,8 +10,7 @@ quick_math = on_alconna(
         "quick-math",
         Subcommand("rank", Args["rank_type", Literal["total", "max"], "max"]),
         Subcommand("award"),
-        Option("--level|-l", Args["start_level", int, 1]),
-        Option("--respawn|-r", Args["enable_respawn", bool, True])
+        Option("--level|-l", Args["start_level", int, 1])
     )
 )
 lang = LangHelper()

--- a/src/plugins/nonebot_plugin_quick_math/__main__.py
+++ b/src/plugins/nonebot_plugin_quick_math/__main__.py
@@ -10,7 +10,7 @@ quick_math = on_alconna(
         "quick-math",
         Subcommand("rank", Args["rank_type", Literal["total", "max"], "max"]),
         Subcommand("award"),
-        Option("--level|-l", Args["start_level", int, 1])
+        Option("--level|-l", Args["start_level", int, 1]),
     )
 )
 lang = LangHelper()

--- a/src/plugins/nonebot_plugin_quick_math/commands/main.py
+++ b/src/plugins/nonebot_plugin_quick_math/commands/main.py
@@ -62,10 +62,7 @@ async def _(start_level: Match[int], user_id: str = get_user_id()) -> None:
         if resp is None:
             end_time = datetime.now()
             if point >= 400 and not is_respawned:
-                resp = await prompt(
-                    await lang.text("main.respawn_prompt", user_id, point // 2),
-                    timeout=20
-                )
+                resp = await prompt(await lang.text("main.respawn_prompt", user_id, point // 2), timeout=20)
                 if resp is None or not resp.extract_plain_text().lower().startswith("y"):
                     break
                 point -= point // 2

--- a/src/plugins/nonebot_plugin_quick_math/commands/main.py
+++ b/src/plugins/nonebot_plugin_quick_math/commands/main.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from nonebot.adapters import Message
-from nonebot_plugin_alconna import UniMessage
+from nonebot_plugin_alconna import UniMessage, Match
 from nonebot_plugin_htmlrender import md_to_pic
-from nonebot_plugin_waiter import prompt_until
+from nonebot_plugin_waiter import prompt_until, prompt
 import re
 
 from ...nonebot_plugin_achievement.utils.unlock import unlock_achievement
@@ -21,12 +21,16 @@ from ..__main__ import lang, quick_math
 
 
 @quick_math.assign("$main")
-async def _(user_id: str = get_user_id()) -> None:
+async def _(start_level: Match[int], user_id: str = get_user_id()) -> None:
     point = 0
     answered = 0
-    max_level = 1
+    if start_level.available and 1 <= start_level.result <= get_max_level():
+        max_level = start_level.result
+    else:
+        max_level = 1
     total_skipping_count = 1
     skipped_question = 0
+    is_respawned = False
     total_answered = 0
 
     def check_input(msg: Message) -> bool:
@@ -37,8 +41,9 @@ async def _(user_id: str = get_user_id()) -> None:
             or (message.lower() in ["skip", "tg"] and total_skipping_count > skipped_question)
         )
 
-    await lang.send("main.wait", user_id, config.qm_wait_time)
-    await asyncio.sleep(config.qm_wait_time)
+    for sec in range(config.qm_wait_time):
+        await quick_math.send(str(config.qm_wait_time - sec))
+        await asyncio.sleep(1)
     start_time = datetime.now()
     while True:
         image, question = await get_question(
@@ -56,6 +61,15 @@ async def _(user_id: str = get_user_id()) -> None:
         )
         if resp is None:
             end_time = datetime.now()
+            if point >= 400 and not is_respawned:
+                resp = await prompt(
+                    await lang.text("main.respawn_prompt", user_id, point // 2),
+                    timeout=20
+                )
+                if resp is None or not resp.extract_plain_text().lower().startswith("y"):
+                    break
+                point -= point // 2
+                is_respawned = True
             break
         elif resp.extract_plain_text().lower() in ["skip", "tg"]:
             skipped_question += 1
@@ -65,6 +79,8 @@ async def _(user_id: str = get_user_id()) -> None:
             if question["level"] == 7:
                 await unlock_achievement(get_achievement_location("calculus"), user_id)
             add_point = get_point(question, send_time)
+            if start_level.available and start_level.result > 1:
+                add_point = int(add_point * 0.8)
             answered += 1
             point += add_point
             await lang.send("answer.right", user_id, add_point)


### PR DESCRIPTION
- [ ] 此 Pull Requests 进行的更改已经过测试

### 有关问题链接

Fixes #136

### 描述

1. 允许在 QuickMath 积分超过 400 但超时后复活，但会失去一半积分
2. 允许指定开始的等级，但每题只有 80% 的积分
3. 将 QuickMath 开始前的等待时间改为倒计时
4. 同步更新 QuickMath 的帮助文本

