### PR TITLE
添加发送协议内容失败时的处理内容

### DIFF
--- a/src/lang/zh_hans/registry.yaml
+++ b/src/lang/zh_hans/registry.yaml
@@ -12,6 +12,26 @@ command:
     如果您还没有阅读，请前往 https://github.com/orgs/Moonlark-Dev/discussions/3 阅读后继续使用 Moonlark。
 
     如果您不同意其中的任何条款，请立即停止使用 Moonlark，这是最后的警告。
+  tip_without_url: |
+    在开始之前，我们相信您已经阅读并接受《Moonlark 最终许可协议》中的所有内容，它总结起来无非是这几点：
+
+    1. 您在使用 Moonlark 时应遵守最终许可协议和相关法律法规；
+    2. 您不能使用 Moonlark 进行任何违法活动和任何可能侵犯他人合法权益的目的；
+    3. 您需要承担所有由于不当使用 Moonlark 造成的后果及责任；
+    4. Moonlark 在运行时需要收集数据，您应当允许 Moonlark 收集和使用相关数据；
+    5. 在您没有同意《Moonlark 最终许可协议》时，您没有权利使用 Moonlark。
+
+    具体的协议内容如下，如果您不同意其中的任何条款，请立即停止使用 Moonlark，这是最后的警告。
+  tip_failed_to_send_content: |
+    在开始之前，我们相信您已经阅读并接受《Moonlark 最终许可协议》中的所有内容，它总结起来无非是这几点：
+
+    1. 您在使用 Moonlark 时应遵守最终许可协议和相关法律法规；
+    2. 您不能使用 Moonlark 进行任何违法活动和任何可能侵犯他人合法权益的目的；
+    3. 您需要承担所有由于不当使用 Moonlark 造成的后果及责任；
+    4. Moonlark 在运行时需要收集数据，您应当允许 Moonlark 收集和使用相关数据；
+    5. 在您没有同意《Moonlark 最终许可协议》时，您没有权利使用 Moonlark。
+
+    协议内容发送失败，请自行前往 GitHub 搜索 Moonlark-Dev/Moonlark 仓库后进入 Discussions 阅读 《Moonlark 最终许可协议》。
   cancel: 已取消
   confirm: 注册成功！欢迎你，{}
   invalid: 输入无效，请重新输入：

--- a/src/plugins/nonebot_plugin_registry/__main__.py
+++ b/src/plugins/nonebot_plugin_registry/__main__.py
@@ -10,9 +10,12 @@ from sqlalchemy import select
 
 from ..nonebot_plugin_preview.preview import screenshot
 from ..nonebot_plugin_larkuser.models import UserData
+from nonebot.exception import ActionFailed
 from ..nonebot_plugin_larkutils.user import get_user_id
 from .lang import lang
 from src.plugins.nonebot_plugin_larkuser.user.utils import is_user_registered
+import traceback
+from nonebot.log import logger
 from nonebot_plugin_userinfo import EventUserInfo, UserInfo
 
 register = on_command("register")
@@ -22,10 +25,15 @@ register = on_command("register")
 async def _(user_id: str = get_user_id()) -> None:
     if await is_user_registered(user_id):
         await lang.finish("command.registered", user_id)
-    await lang.send("command.tip", user_id)
-    await UniMessage().image(
-        raw=await screenshot("https://github.com/orgs/Moonlark-Dev/discussions/3", 1), name="image.png"
-    ).send()
+    try:
+        await lang.send("command.tip", user_id)
+    except ActionFailed:
+        try:
+            await UniMessage().text(await lang.text("command.tip_without_url", user_id)).image(
+                raw=await screenshot("https://github.com/orgs/Moonlark-Dev/discussions/3", 1), name="image.png"
+            ).send()
+        except Exception:
+            await lang.send("command.tip_failed_to_send_content", user_id)
     await lang.send("input.g", user_id)
 
 


### PR DESCRIPTION
- [ ] 此 Pull Requests 进行的更改已经过测试

### 描述

在使用 0x07 节点时，发送 `register` 指令注册会因为各种原因导致 EULA 发送失败，本 PR 添加了对于有关错误的处置措施，确保协议消息能被正常发送。

