### PR TITLE
refactor(chat): 修改笔记默认过期时间为10年

### DIFF
--- a/src/plugins/nonebot_plugin_chat/matcher/group.py
+++ b/src/plugins/nonebot_plugin_chat/matcher/group.py
@@ -298,7 +298,7 @@ class MessageProcessor:
                     ),
                     "expire_days": FunctionParameter(
                         type="integer",
-                        description="笔记的过期天数。如果未指定，则默认为 7 天。",
+                        description="笔记的过期天数。如果一条笔记有一定时效性（例如它在某个日期前才有用），一定要指定本参数，默认为十年。",
                         required=False,
                     ),
                     "keywords": FunctionParameter(

--- a/src/plugins/nonebot_plugin_chat/utils/tools/note.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tools/note.py
@@ -40,12 +40,12 @@ def get_note_poster(context_id: str) -> Callable[[str, Optional[int], Optional[s
         note_manager = await get_context_notes(context_id)
 
         # Create the note
-        note = await note_manager.create_note(content=text, keywords=keywords or "", expire_days=expire_days or 7)
+        note = await note_manager.create_note(content=text, keywords=keywords or "", expire_days=expire_days or 3650)
 
         # Return a confirmation message
         created_time = datetime.fromtimestamp(note.created_time).strftime("%Y-%m-%d %H:%M:%S")
         if note.expire_time:
-            expire_time = datetime.fromtimestamp(note.expire_time).strftime("%Y-%m-%d %H:%M:%S")
+            expire_time = note.expire_time.strftime("%Y-%m-%d %H:%M:%S")
             return f"Note created successfully at {created_time}, will expire at {expire_time}."
         else:
             return f"Note created successfully at {created_time} with no expiration."


### PR DESCRIPTION
- [ ] 此 Pull Requests 进行的更改已经过测试
- [ ] 在合并前需要等待 CI 执行完成
- [x] 更改内容为紧急更新 (hotfix)

### 有关问题链接

Fixes #

### 描述

1. 修复 post_note 工具报错的问题
2. 将 note 默认过期时间修改为 3650 天
