### PR TITLE
fix(sign): prevent concurrent sign-in race conditions

### DIFF
--- a/src/plugins/nonebot_plugin_sign/__main__.py
+++ b/src/plugins/nonebot_plugin_sign/__main__.py
@@ -220,6 +220,8 @@ async def _(matcher: Matcher, user_id: str = get_user_id()) -> None:
             }
             data.last_sign = date.today()
             await session.commit()
-            image = await render_template("sign.html.jinja", await lang.text("image.title", user_id), user_id, templates)
+            image = await render_template(
+                "sign.html.jinja", await lang.text("image.title", user_id), user_id, templates
+            )
             msg = UniMessage().image(raw=image)
             await matcher.finish(await msg.export(), at_sender=True)


### PR DESCRIPTION
Add per-user asyncio locks to serialize sign-in operations and prevent data inconsistency from simultaneous command invocations by the same user.