### PR TITLE
feat(chat): add blog list API endpoint

### DIFF
--- a/src/plugins/nonebot_plugin_chat/startup.py
+++ b/src/plugins/nonebot_plugin_chat/startup.py
@@ -54,6 +54,7 @@ from .utils.blog import get_blog_posts
 
 app = nonebot.get_app()
 
+
 @app.get("/chat/blog")
 async def blog_list(
     page: int = Query(1, ge=1, description="Page number"),

--- a/src/plugins/nonebot_plugin_chat/startup.py
+++ b/src/plugins/nonebot_plugin_chat/startup.py
@@ -48,6 +48,20 @@ async def _init_file_server():
     app.mount("/chat/files", StaticFiles(directory=FILE_DIR), name="chat_files")
 
 
+import nonebot
+from fastapi import Query
+from .utils.blog import get_blog_posts
+
+app = nonebot.get_app()
+
+@app.get("/chat/blog")
+async def blog_list(
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(10, ge=1, le=100, description="Items per page"),
+):
+    return await get_blog_posts(page=page, page_size=page_size)
+
+
 @driver.on_startup
 async def _init_main_session():
     from .core.ego.main_session import init_main_session

--- a/src/plugins/nonebot_plugin_chat/utils/blog.py
+++ b/src/plugins/nonebot_plugin_chat/utils/blog.py
@@ -50,7 +50,12 @@ async def get_blog_posts(page: int = 1, page_size: int = 10) -> dict:
 
     return {
         "items": [
-            {"id": p.id, "title": p.title, "content": p.content, "create_at": p.create_at.isoformat() if p.create_at else None}
+            {
+                "id": p.id,
+                "title": p.title,
+                "content": p.content,
+                "create_at": p.create_at.isoformat() if p.create_at else None,
+            }
             for p in posts
         ],
         "total": total,

--- a/src/plugins/nonebot_plugin_chat/utils/blog.py
+++ b/src/plugins/nonebot_plugin_chat/utils/blog.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from nonebot_plugin_orm import get_session
+from sqlalchemy import select, func
 
 from ..models import BlogPost
 
@@ -24,3 +25,35 @@ async def create_blog_post(title: str, content: str) -> BlogPost:
         await session.refresh(blog_post)
 
     return blog_post
+
+
+async def get_blog_posts(page: int = 1, page_size: int = 10) -> dict:
+    """
+    Get blog posts with pagination
+
+    Args:
+        page: Page number (1-indexed)
+        page_size: Number of posts per page
+
+    Returns:
+        Dict with items, total, page, page_size
+    """
+    offset = (page - 1) * page_size
+
+    async with get_session() as session:
+        total_result = await session.execute(select(func.count()).select_from(BlogPost))
+        total = total_result.scalar() or 0
+
+        stmt = select(BlogPost).order_by(BlogPost.create_at.desc()).offset(offset).limit(page_size)
+        result = await session.execute(stmt)
+        posts = result.scalars().all()
+
+    return {
+        "items": [
+            {"id": p.id, "title": p.title, "content": p.content, "create_at": p.create_at.isoformat() if p.create_at else None}
+            for p in posts
+        ],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }


### PR DESCRIPTION
Implement a new GET endpoint `/chat/blog` to retrieve paginated blog posts.

- Add `get_blog_posts` utility function with SQLAlchemy pagination support.
- Register the `/chat/blog` route in the FastAPI application instance.
- Include pagination parameters `page` and `page_size` in the API request.