### PR TITLE
fix: resolve merge conflicts in chat.yaml

### DIFF
--- a/src/lang/en_us/chat.yaml
+++ b/src/lang/en_us/chat.yaml
@@ -1186,11 +1186,7 @@ main_session:
     sleep:
       completed: "你计划睡 {} 分钟，实际睡了 {} 分钟。"
       in_progress: "你正在睡觉（已睡 {} 分钟，计划睡 {} 分钟）。"
-<<<<<<< HEAD
     write_blog: "你写了一篇博客，标题为“{}”。"
-=======
-    write_blog: "你写了一篇博客，标题为"{}"。"
->>>>>>> origin/main
     do:
       completed: "你 {}，持续了 {} 分钟。"
       in_progress: "你正在{}（预计 {} 分钟）。"

--- a/src/lang/zh_tw/chat.yaml
+++ b/src/lang/zh_tw/chat.yaml
@@ -1186,11 +1186,7 @@ main_session:
     sleep:
       completed: "你计划睡 {} 分钟，实际睡了 {} 分钟。"
       in_progress: "你正在睡觉（已睡 {} 分钟，计划睡 {} 分钟）。"
-<<<<<<< HEAD
     write_blog: "你写了一篇博客，标题为“{}”。"
-=======
-    write_blog: "你写了一篇博客，标题为"{}"。"
->>>>>>> origin/main
     do:
       completed: "你 {}，持续了 {} 分钟。"
       in_progress: "你正在{}（预计 {} 分钟）。"


### PR DESCRIPTION
This PR resolves merge conflicts in src/lang/en_us/chat.yaml and src/lang/zh_tw/chat.yaml by removing git merge markers and unifying the write_blog translation.