### PR TITLE
fix(db): correct down_revision for b29767cc9c3d to depend on 7e2901072e70

### DIFF
--- a/migrations/versions/b29767cc9c3d_.py
+++ b/migrations/versions/b29767cc9c3d_.py
@@ -14,7 +14,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "b29767cc9c3d"
-down_revision: str | Sequence[str] | None = "7e2901072e70"
+down_revision: str | Sequence[str] | None = "d025fa75554d"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/b29767cc9c3d_.py
+++ b/migrations/versions/b29767cc9c3d_.py
@@ -14,7 +14,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "b29767cc9c3d"
-down_revision: str | Sequence[str] | None = "623fed631343"
+down_revision: str | Sequence[str] | None = "7e2901072e70"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
Fix the migration dependency chain. 

The migration  was attempting to drop the  table without depending on the migration that created it (), causing  errors in CI.

Changed  of  from  to  to ensure correct execution order.