### PR TITLE
feat(larkuser): add setnick command

### DIFF
--- a/src/lang/en_us/larkuser.yaml
+++ b/src/lang/en_us/larkuser.yaml
@@ -88,8 +88,9 @@ welcome:
   - 注册成功。很高兴认识你，{}！
   - 注册成功。你好喵~，{}！
 setnick:
-  usage: "Usage: setnick <nickname>"
+  usage: "Usage: setnick <nickname> (without argument to unlock nickname)"
   too_long: "Nickname is too long, max 27 characters."
+  unlocked: "Nickname lock has been removed."
   current: "Current nickname: {}"
   success: "Nickname changed successfully! New nickname: {}"
   same: "New nickname is the same as the current one."
@@ -97,8 +98,8 @@ setnick:
   failed: "Nickname change failed."
 help_setnick:
   description: Change Nickname
-  details: Change your nickname on Moonlark
-  usage: "setnick <nickname> (change nickname)"
+  details: "Change your nickname on Moonlark, or unlock nickname lock without argument"
+  usage: "setnick <nickname> (change nickname, unlock without argument)"
 input:
   user_nickname: |
     Moonlark 没有办法读取您的展示名称（昵称）。请发送您的展示名称，也可以发送“q”留空。

--- a/src/lang/en_us/larkuser.yaml
+++ b/src/lang/en_us/larkuser.yaml
@@ -87,6 +87,18 @@ welcome:
   - 注册成功。你就是我的 Master 吗，{}？
   - 注册成功。很高兴认识你，{}！
   - 注册成功。你好喵~，{}！
+setnick:
+  current: "Current nickname: {}"
+  input: "Please enter a new nickname (max 27 characters):"
+  success: "Nickname changed successfully! New nickname: {}"
+  same: "New nickname is the same as the current one, cancelled."
+  timeout: "Failed to read input: timeout!"
+  review_failed: "Nickname review failed: {}\nPlease try again."
+  failed: "Nickname change failed: max retries exceeded."
+help_setnick:
+  description: Change Nickname
+  details: Change your nickname on Moonlark
+  usage: setnick (change nickname)
 input:
   user_nickname: |
     Moonlark 没有办法读取您的展示名称（昵称）。请发送您的展示名称，也可以发送“q”留空。

--- a/src/lang/en_us/larkuser.yaml
+++ b/src/lang/en_us/larkuser.yaml
@@ -88,17 +88,17 @@ welcome:
   - 注册成功。很高兴认识你，{}！
   - 注册成功。你好喵~，{}！
 setnick:
+  usage: "Usage: setnick <nickname>"
+  too_long: "Nickname is too long, max 27 characters."
   current: "Current nickname: {}"
-  input: "Please enter a new nickname (max 27 characters):"
   success: "Nickname changed successfully! New nickname: {}"
-  same: "New nickname is the same as the current one, cancelled."
-  timeout: "Failed to read input: timeout!"
-  review_failed: "Nickname review failed: {}\nPlease try again."
-  failed: "Nickname change failed: max retries exceeded."
+  same: "New nickname is the same as the current one."
+  review_failed: "Nickname review failed: {}"
+  failed: "Nickname change failed."
 help_setnick:
   description: Change Nickname
   details: Change your nickname on Moonlark
-  usage: setnick (change nickname)
+  usage: "setnick <nickname> (change nickname)"
 input:
   user_nickname: |
     Moonlark 没有办法读取您的展示名称（昵称）。请发送您的展示名称，也可以发送“q”留空。

--- a/src/lang/zh_hans/larkuser.yaml
+++ b/src/lang/zh_hans/larkuser.yaml
@@ -91,6 +91,18 @@ welcome:
   - 注册成功。你就是我的 Master 吗，{}？
   - 注册成功。很高兴认识你，{}！
   - 注册成功。你好喵~，{}！
+setnick:
+  current: "当前昵称: {}"
+  input: "请输入新昵称（不超过27个字符）："
+  success: "昵称修改成功！新昵称: {}"
+  same: "新昵称与当前昵称相同，已取消。"
+  timeout: "读取输入失败：已超时！"
+  review_failed: "昵称审查不通过：{}\n请重新输入。"
+  failed: "昵称修改失败，已达最大重试次数。"
+help_setnick:
+  description: 修改昵称
+  details: 修改自己在 Moonlark 中的昵称
+  usage: setnick (修改昵称)
 input:
   user_nickname: |
     Moonlark 没有办法读取您的展示名称（昵称）。请发送您的展示名称，也可以发送“q”留空。

--- a/src/lang/zh_hans/larkuser.yaml
+++ b/src/lang/zh_hans/larkuser.yaml
@@ -92,17 +92,17 @@ welcome:
   - 注册成功。很高兴认识你，{}！
   - 注册成功。你好喵~，{}！
 setnick:
+  usage: "用法：setnick <昵称>"
+  too_long: "昵称过长，不能超过27个字符。"
   current: "当前昵称: {}"
-  input: "请输入新昵称（不超过27个字符）："
   success: "昵称修改成功！新昵称: {}"
-  same: "新昵称与当前昵称相同，已取消。"
-  timeout: "读取输入失败：已超时！"
-  review_failed: "昵称审查不通过：{}\n请重新输入。"
-  failed: "昵称修改失败，已达最大重试次数。"
+  same: "新昵称与当前昵称相同。"
+  review_failed: "昵称审查不通过：{}"
+  failed: "昵称修改失败。"
 help_setnick:
   description: 修改昵称
   details: 修改自己在 Moonlark 中的昵称
-  usage: setnick (修改昵称)
+  usage: "setnick <昵称> (修改昵称)"
 input:
   user_nickname: |
     Moonlark 没有办法读取您的展示名称（昵称）。请发送您的展示名称，也可以发送“q”留空。

--- a/src/lang/zh_hans/larkuser.yaml
+++ b/src/lang/zh_hans/larkuser.yaml
@@ -92,8 +92,9 @@ welcome:
   - 注册成功。很高兴认识你，{}！
   - 注册成功。你好喵~，{}！
 setnick:
-  usage: "用法：setnick <昵称>"
+  usage: "用法：setnick <昵称>（不带参数则解锁昵称锁定）"
   too_long: "昵称过长，不能超过27个字符。"
+  unlocked: "昵称锁定已解除。"
   current: "当前昵称: {}"
   success: "昵称修改成功！新昵称: {}"
   same: "新昵称与当前昵称相同。"
@@ -101,8 +102,8 @@ setnick:
   failed: "昵称修改失败。"
 help_setnick:
   description: 修改昵称
-  details: 修改自己在 Moonlark 中的昵称
-  usage: "setnick <昵称> (修改昵称)"
+  details: "修改自己在 Moonlark 中的昵称，不带参数则解锁昵称锁定"
+  usage: "setnick <昵称> (修改昵称，不带参数解锁锁定)"
 input:
   user_nickname: |
     Moonlark 没有办法读取您的展示名称（昵称）。请发送您的展示名称，也可以发送“q”留空。

--- a/src/lang/zh_tw/larkuser.yaml
+++ b/src/lang/zh_tw/larkuser.yaml
@@ -88,17 +88,17 @@ welcome:
   - 注册成功。很高兴认识你，{}！
   - 注册成功。你好喵~，{}！
 setnick:
+  usage: "用法：setnick <暱稱>"
+  too_long: "暱稱過長，不能超過27個字元。"
   current: "當前暱稱: {}"
-  input: "請輸入新暱稱（不超過27個字元）："
   success: "暱稱修改成功！新暱稱: {}"
-  same: "新暱稱與當前暱稱相同，已取消。"
-  timeout: "讀取輸入失敗：已超時！"
-  review_failed: "暱稱審查不通過：{}\n請重新輸入。"
-  failed: "暱稱修改失敗，已達最大重試次數。"
+  same: "新暱稱與當前暱稱相同。"
+  review_failed: "暱稱審查不通過：{}"
+  failed: "暱稱修改失敗。"
 help_setnick:
   description: 修改暱稱
   details: 修改自己在 Moonlark 中的暱稱
-  usage: setnick (修改暱稱)
+  usage: "setnick <暱稱> (修改暱稱)"
 input:
   user_nickname: |
     Moonlark 没有办法读取您的展示名称（昵称）。请发送您的展示名称，也可以发送“q”留空。

--- a/src/lang/zh_tw/larkuser.yaml
+++ b/src/lang/zh_tw/larkuser.yaml
@@ -87,6 +87,18 @@ welcome:
   - 注册成功。你就是我的 Master 吗，{}？
   - 注册成功。很高兴认识你，{}！
   - 注册成功。你好喵~，{}！
+setnick:
+  current: "當前暱稱: {}"
+  input: "請輸入新暱稱（不超過27個字元）："
+  success: "暱稱修改成功！新暱稱: {}"
+  same: "新暱稱與當前暱稱相同，已取消。"
+  timeout: "讀取輸入失敗：已超時！"
+  review_failed: "暱稱審查不通過：{}\n請重新輸入。"
+  failed: "暱稱修改失敗，已達最大重試次數。"
+help_setnick:
+  description: 修改暱稱
+  details: 修改自己在 Moonlark 中的暱稱
+  usage: setnick (修改暱稱)
 input:
   user_nickname: |
     Moonlark 没有办法读取您的展示名称（昵称）。请发送您的展示名称，也可以发送“q”留空。

--- a/src/lang/zh_tw/larkuser.yaml
+++ b/src/lang/zh_tw/larkuser.yaml
@@ -88,8 +88,9 @@ welcome:
   - 注册成功。很高兴认识你，{}！
   - 注册成功。你好喵~，{}！
 setnick:
-  usage: "用法：setnick <暱稱>"
+  usage: "用法：setnick <暱稱>（不帶參數則解鎖暱稱鎖定）"
   too_long: "暱稱過長，不能超過27個字元。"
+  unlocked: "暱稱鎖定已解除。"
   current: "當前暱稱: {}"
   success: "暱稱修改成功！新暱稱: {}"
   same: "新暱稱與當前暱稱相同。"
@@ -97,8 +98,8 @@ setnick:
   failed: "暱稱修改失敗。"
 help_setnick:
   description: 修改暱稱
-  details: 修改自己在 Moonlark 中的暱稱
-  usage: "setnick <暱稱> (修改暱稱)"
+  details: "修改自己在 Moonlark 中的暱稱，不帶參數則解鎖暱稱鎖定"
+  usage: "setnick <暱稱> (修改暱稱，不帶參數解鎖鎖定)"
 input:
   user_nickname: |
     Moonlark 没有办法读取您的展示名称（昵称）。请发送您的展示名称，也可以发送“q”留空。

--- a/src/plugins/nonebot_plugin_larkuser/__init__.py
+++ b/src/plugins/nonebot_plugin_larkuser/__init__.py
@@ -17,7 +17,7 @@ require("nonebot_plugin_preview")
 require("nonebot_plugin_waiter")
 
 
-from .matchers import recorder, panel, whoami, register
+from .matchers import recorder, panel, whoami, register, setnick
 from .utils.matcher import patch_matcher
 from .utils.level import get_level_by_experience
 from .utils.user import get_user, MoonlarkUser, get_registered_users, get_registered_user_list, get_registered_user_ids

--- a/src/plugins/nonebot_plugin_larkuser/help.yaml
+++ b/src/plugins/nonebot_plugin_larkuser/help.yaml
@@ -12,3 +12,9 @@ commands:
     usages:
       - help_whoami.usage
     category: setting
+  setnick:
+    description: help_setnick.description
+    details: help_setnick.details
+    usages:
+      - help_setnick.usage
+    category: setting

--- a/src/plugins/nonebot_plugin_larkuser/matchers/setnick.py
+++ b/src/plugins/nonebot_plugin_larkuser/matchers/setnick.py
@@ -1,0 +1,74 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2025  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+import json
+
+from nonebot import on_command
+from nonebot_plugin_orm import get_session
+
+from nonebot_plugin_larkutils import get_user_id, review_text
+
+from ..utils.matcher import patch_matcher
+from ..utils.user import get_user
+from ..utils.waiter import prompt
+from ..exceptions import PromptTimeout
+from ..models import UserData
+from ..lang import lang
+
+setnick = patch_matcher(on_command("setnick"))
+
+
+@setnick.handle()
+async def _(
+    user_id: str = get_user_id(),
+) -> None:
+    current_user = await get_user(user_id)
+    current_nick = current_user.get_nickname()
+
+    await lang.send("setnick.current", user_id, current_nick)
+
+    prompt_text = await lang.text("setnick.input", user_id)
+
+    for i in range(3):
+        try:
+            new_nick = await prompt(
+                prompt_text, user_id, checker=lambda msg: len(msg) <= 27, ignore_error_details=False
+            )
+        except PromptTimeout:
+            await lang.finish("setnick.timeout", user_id)
+
+        if new_nick == current_nick:
+            await lang.finish("setnick.same", user_id)
+
+        review_result = await review_text(new_nick)
+        if review_result["conclusion"]:
+            async with get_session() as session:
+                user = await session.get(UserData, user_id)
+                if user is None:
+                    await lang.finish("setnick.failed", user_id)
+                    return
+                user.nickname = new_nick
+                config = json.loads(user.config)
+                config["lock_nickname"] = True
+                user.config = json.dumps(config)
+                await session.commit()
+
+            await lang.finish("setnick.success", user_id, new_nick)
+
+        prompt_text = await lang.text("setnick.review_failed", user_id, review_result["message"])
+
+    await lang.finish("setnick.failed", user_id)

--- a/src/plugins/nonebot_plugin_larkuser/matchers/setnick.py
+++ b/src/plugins/nonebot_plugin_larkuser/matchers/setnick.py
@@ -39,8 +39,18 @@ async def _(
 ) -> None:
     new_nick = args.extract_plain_text().strip()
 
+    # No argument: unlock nickname
     if not new_nick:
-        await lang.finish("setnick.usage", user_id)
+        async with get_session() as session:
+            user = await session.get(UserData, user_id)
+            if user is None:
+                await lang.finish("setnick.failed", user_id)
+                return
+            config = json.loads(user.config)
+            config["lock_nickname"] = False
+            user.config = json.dumps(config)
+            await session.commit()
+        await lang.finish("setnick.unlocked", user_id)
 
     if len(new_nick) > 27:
         await lang.finish("setnick.too_long", user_id)

--- a/src/plugins/nonebot_plugin_larkuser/matchers/setnick.py
+++ b/src/plugins/nonebot_plugin_larkuser/matchers/setnick.py
@@ -18,14 +18,14 @@
 import json
 
 from nonebot import on_command
+from nonebot.adapters import Message
+from nonebot.params import CommandArg
 from nonebot_plugin_orm import get_session
 
 from nonebot_plugin_larkutils import get_user_id, review_text
 
 from ..utils.matcher import patch_matcher
 from ..utils.user import get_user
-from ..utils.waiter import prompt
-from ..exceptions import PromptTimeout
 from ..models import UserData
 from ..lang import lang
 
@@ -34,41 +34,36 @@ setnick = patch_matcher(on_command("setnick"))
 
 @setnick.handle()
 async def _(
+    args: Message = CommandArg(),
     user_id: str = get_user_id(),
 ) -> None:
+    new_nick = args.extract_plain_text().strip()
+
+    if not new_nick:
+        await lang.finish("setnick.usage", user_id)
+
+    if len(new_nick) > 27:
+        await lang.finish("setnick.too_long", user_id)
+
     current_user = await get_user(user_id)
     current_nick = current_user.get_nickname()
 
-    await lang.send("setnick.current", user_id, current_nick)
+    if new_nick == current_nick:
+        await lang.finish("setnick.same", user_id)
 
-    prompt_text = await lang.text("setnick.input", user_id)
+    review_result = await review_text(new_nick)
+    if not review_result["conclusion"]:
+        await lang.finish("setnick.review_failed", user_id, review_result["message"])
 
-    for i in range(3):
-        try:
-            new_nick = await prompt(
-                prompt_text, user_id, checker=lambda msg: len(msg) <= 27, ignore_error_details=False
-            )
-        except PromptTimeout:
-            await lang.finish("setnick.timeout", user_id)
+    async with get_session() as session:
+        user = await session.get(UserData, user_id)
+        if user is None:
+            await lang.finish("setnick.failed", user_id)
+            return
+        user.nickname = new_nick
+        config = json.loads(user.config)
+        config["lock_nickname"] = True
+        user.config = json.dumps(config)
+        await session.commit()
 
-        if new_nick == current_nick:
-            await lang.finish("setnick.same", user_id)
-
-        review_result = await review_text(new_nick)
-        if review_result["conclusion"]:
-            async with get_session() as session:
-                user = await session.get(UserData, user_id)
-                if user is None:
-                    await lang.finish("setnick.failed", user_id)
-                    return
-                user.nickname = new_nick
-                config = json.loads(user.config)
-                config["lock_nickname"] = True
-                user.config = json.dumps(config)
-                await session.commit()
-
-            await lang.finish("setnick.success", user_id, new_nick)
-
-        prompt_text = await lang.text("setnick.review_failed", user_id, review_result["message"])
-
-    await lang.finish("setnick.failed", user_id)
+    await lang.finish("setnick.success", user_id, new_nick)


### PR DESCRIPTION
为 larkuser 插件添加 `setnick` 命令，允许用户修改昵称及管理昵称锁定状态。

## 用法

```
setnick <昵称>    # 修改昵称，同时锁定昵称
setnick           # 解除昵称锁定
```

## 实现内容

- 新增 `setnick.py` 命令处理器
- 复用已有的昵称审查流程（`review_text`）
- 带参数时：更新昵称 + 设置 `lock_nickname: true`
- 不带参数时：设置 `lock_nickname: false`（解锁昵称）
- 昵称长度限制 27 字符
- 添加 zh_hans / en_us / zh_tw 三语言文案
- 添加帮助条目