### PR TITLE
fix: 修复事件模板时间重复

### DIFF
--- a/src/lang/en_us/chat.yaml
+++ b/src/lang/en_us/chat.yaml
@@ -328,12 +328,12 @@ help_rua:
 prompt:
   warning:
     excessive_messages: "[系统警告]: 你已连续发送 {} 条消息，请等待用户回复后再继续发言，避免刷屏。"
-  timer_triggered: "[{}]: 计时器 {} 已触发。"
-  recall: "[{}]: 消息 {} ({}) 被撤回。"
+  timer_triggered: "计时器 {} 已触发。"
+  recall: "消息 {} ({}) 被撤回。"
   poke:
-    to_me: "[{}]: {} 戳了戳你。"
-    to_other: "[{}]: {} 戳了戳 {}。"
-  reaction: "[{}]: {} 回应了你的消息“{}”: {}"
+    to_me: "{} 戳了戳你。"
+    to_other: "{} 戳了戳 {}。"
+  reaction: "{} 回应了你的消息“{}”: {}"
   event_template: "[{}]: {}"
   note:
     format: "- {} (#{}，创建于 {})"

--- a/src/lang/zh_hans/chat.yaml
+++ b/src/lang/zh_hans/chat.yaml
@@ -336,12 +336,12 @@ help_rua:
 prompt:
   warning:
     excessive_messages: "[系统警告]: 你已连续发送 {} 条消息，请等待用户回复后再继续发言，避免刷屏。"
-  timer_triggered: "[{}]: 计时器 {} 已触发。"
-  recall: "[{}]: 消息 {} ({}) 被撤回。"
+  timer_triggered: "计时器 {} 已触发。"
+  recall: "消息 {} ({}) 被撤回。"
   poke:
-    to_me: "[{}]: {} 戳了戳你。"
-    to_other: "[{}]: {} 戳了戳 {}。"
-  reaction: "[{}]: {} 回应了你的消息“{}”: {}"
+    to_me: "{} 戳了戳你。"
+    to_other: "{} 戳了戳 {}。"
+  reaction: "{} 回应了你的消息“{}”: {}"
   event_template: "[{}]: {}"
   note:
     format: "- {} (#{}，创建于 {})"

--- a/src/lang/zh_tw/chat.yaml
+++ b/src/lang/zh_tw/chat.yaml
@@ -328,12 +328,12 @@ help_rua:
 prompt:
   warning:
     excessive_messages: "[系统警告]: 你已连续发送 {} 条消息，请等待用户回复后再继续发言，避免刷屏。"
-  timer_triggered: "[{}]: 计时器 {} 已触发。"
-  recall: "[{}]: 消息 {} ({}) 被撤回。"
+  timer_triggered: "计时器 {} 已触发。"
+  recall: "消息 {} ({}) 被撤回。"
   poke:
-    to_me: "[{}]: {} 戳了戳你。"
-    to_other: "[{}]: {} 戳了戳 {}。"
-  reaction: "[{}]: {} 回应了你的消息“{}”: {}"
+    to_me: "{} 戳了戳你。"
+    to_other: "{} 戳了戳 {}。"
+  reaction: "{} 回应了你的消息“{}”: {}"
   event_template: "[{}]: {}"
   note:
     format: "- {} (#{}，创建于 {})"

--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -239,14 +239,6 @@ class MessageProcessor:
             content = await self.session.text(
                 "prompt.event_template", datetime.now().strftime("%H:%M:%S"), event_prompt
             )
-            # 为事件添加附加信息
-            event_user_id = self.session.session_id
-            if self.session.get_session_type() == "group" and self.session.cached_messages:
-                for msg in reversed(self.session.cached_messages):
-                    if not msg["self"]:
-                        event_user_id = msg["user_id"]
-                        break
-            content += await self.generate_additional_prompt(content, event_user_id)
             await self.openai_messages.append_user_message(content)
             self.token_bucket.add(0.6)
 

--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -286,9 +286,7 @@ class MessageProcessor:
             asyncio.create_task(self.generate_reply(trigger_mode == "all", item[0] == "event"))
 
     async def handle_timer(self, description: str) -> None:
-        await self.session.add_event(
-            await self.session.text("prompt.timer_triggered", description), "all"
-        )
+        await self.session.add_event(await self.session.text("prompt.timer_triggered", description), "all")
 
     async def leave_for_a_while(self) -> None:
         await self.session.mute()
@@ -648,9 +646,7 @@ class MessageProcessor:
 
     async def handle_poke(self, operator_name: str, target_name: str, to_me: bool) -> None:
         if to_me:
-            await self.session.add_event(
-                await self.session.text("prompt.poke.to_me", operator_name), "all"
-            )
+            await self.session.add_event(await self.session.text("prompt.poke.to_me", operator_name), "all")
             # 注意：由于现在事件是异步处理的，blocked 标志不再需要在 poke 中设置
             # 事件会在 get_message 中被处理并直接生成回复
         else:

--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -239,6 +239,14 @@ class MessageProcessor:
             content = await self.session.text(
                 "prompt.event_template", datetime.now().strftime("%H:%M:%S"), event_prompt
             )
+            # 为事件添加附加信息
+            event_user_id = self.session.session_id
+            if self.session.get_session_type() == "group" and self.session.cached_messages:
+                for msg in reversed(self.session.cached_messages):
+                    if not msg["self"]:
+                        event_user_id = msg["user_id"]
+                        break
+            content += await self.generate_additional_prompt(content, event_user_id)
             await self.openai_messages.append_user_message(content)
             self.token_bucket.add(0.6)
 
@@ -279,7 +287,7 @@ class MessageProcessor:
 
     async def handle_timer(self, description: str) -> None:
         await self.session.add_event(
-            await self.session.text("prompt.timer_triggered", datetime.now().strftime("%H:%M:%S"), description), "all"
+            await self.session.text("prompt.timer_triggered", description), "all"
         )
 
     async def leave_for_a_while(self) -> None:
@@ -632,7 +640,6 @@ class MessageProcessor:
         await self.session.add_event(
             await self.session.text(
                 "prompt.recall",
-                datetime.now().strftime("%H:%M:%S"),
                 message_id,
                 message_content,
             ),
@@ -642,7 +649,7 @@ class MessageProcessor:
     async def handle_poke(self, operator_name: str, target_name: str, to_me: bool) -> None:
         if to_me:
             await self.session.add_event(
-                await self.session.text("prompt.poke.to_me", datetime.now().strftime("%H:%M:%S"), operator_name), "all"
+                await self.session.text("prompt.poke.to_me", operator_name), "all"
             )
             # 注意：由于现在事件是异步处理的，blocked 标志不再需要在 poke 中设置
             # 事件会在 get_message 中被处理并直接生成回复
@@ -650,7 +657,6 @@ class MessageProcessor:
             await self.session.add_event(
                 await self.session.text(
                     "prompt.poke.to_other",
-                    datetime.now().strftime("%H:%M:%S"),
                     operator_name,
                     target_name,
                 ),
@@ -661,7 +667,6 @@ class MessageProcessor:
         await self.session.add_event(
             await self.session.text(
                 "prompt.reaction",
-                datetime.now().strftime("%H:%M:%S"),
                 operator_name,
                 message_string,
                 QQ_EMOJI_MAP[emoji_id],


### PR DESCRIPTION
Fix #1113

修复事件模板时间重复问题：移除 timer_triggered、recall、poke、reaction 等模板中的时间前缀，统一由 event_template 添加时间，避免出现双重时间格式。