### PR TITLE
feat: cave 投稿成功后向 chat 插件发送事件

### DIFF
--- a/src/lang/en_us/larkcave.yaml
+++ b/src/lang/en_us/larkcave.yaml
@@ -12,6 +12,7 @@ add:
   image_empty: An error occurred while fetching the image in the message, please try again later
   posted: 'Echo cave ({}) submitted successfully'
   checking: 正在检查投稿内容，请稍候……
+  event_prompt: "{} 投稿了一条回声洞（#{}）：{}"
 cave:
   noresult: |
     获取回声洞时出现错误: 所含图片失效

--- a/src/lang/zh_hans/larkcave.yaml
+++ b/src/lang/zh_hans/larkcave.yaml
@@ -12,6 +12,7 @@ add:
   image_empty: 获取消息中的图片时发生错误，请稍后重试
   posted: '回声洞 ({}) 投稿成功'
   checking: 正在检查投稿内容，请稍候……
+  event_prompt: "{} 投稿了一条回声洞（#{}）：{}"
 cave:
   noresult: |
     获取回声洞时出现错误: 所含图片失效

--- a/src/lang/zh_tw/larkcave.yaml
+++ b/src/lang/zh_tw/larkcave.yaml
@@ -12,6 +12,7 @@ add:
   image_empty: 获取消息中的图片时发生错误，请稍后重试
   posted: '回声洞 ({}) 投稿成功'
   checking: 正在检查投稿内容，请稍候……
+  event_prompt: "{} 投稿了一条回声洞（#{}）：{}"
 cave:
   noresult: |
     获取回声洞时出现错误: 所含图片失效

--- a/src/plugins/nonebot_plugin_larkcave/commands/post.py
+++ b/src/plugins/nonebot_plugin_larkcave/commands/post.py
@@ -30,7 +30,13 @@ from nonebot_plugin_larkcave.utils.post import post_cave
 
 @cave.assign("add.content")
 async def _(
-    session: async_scoped_session, event: Event, bot: Bot, state: T_State, result: Arparma, user_id: str = get_user_id(), group_id: str = get_group_id()
+    session: async_scoped_session,
+    event: Event,
+    bot: Bot,
+    state: T_State,
+    result: Arparma,
+    user_id: str = get_user_id(),
+    group_id: str = get_group_id(),
 ) -> None:
     try:
         content = cast(list[Image | Text], list(result.subcommands["add"].args["content"]))

--- a/src/plugins/nonebot_plugin_larkcave/commands/post.py
+++ b/src/plugins/nonebot_plugin_larkcave/commands/post.py
@@ -23,21 +23,21 @@ from nonebot.typing import T_State
 from nonebot_plugin_orm import async_scoped_session
 
 from nonebot_plugin_larkcave.__main__ import cave
-from nonebot_plugin_larkutils import get_user_id
+from nonebot_plugin_larkutils import get_user_id, get_group_id
 from nonebot_plugin_larkcave.lang import lang
 from nonebot_plugin_larkcave.utils.post import post_cave
 
 
 @cave.assign("add.content")
 async def _(
-    session: async_scoped_session, event: Event, bot: Bot, state: T_State, result: Arparma, user_id: str = get_user_id()
+    session: async_scoped_session, event: Event, bot: Bot, state: T_State, result: Arparma, user_id: str = get_user_id(), group_id: str = get_group_id()
 ) -> None:
     try:
         content = cast(list[Image | Text], list(result.subcommands["add"].args["content"]))
     except KeyError:
         await lang.finish("add.empty", user_id)
         return
-    await post_cave(content, user_id, event, bot, state, session)
+    await post_cave(content, user_id, event, bot, state, session, group_id=group_id)
 
 
 from nonebot.adapters.onebot.v11 import Bot as OB11Bot
@@ -53,6 +53,7 @@ async def _(
     bot: Bot,
     state: T_State,
     user_id: str = get_user_id(),
+    group_id: str = get_group_id(),
 ) -> None:
     content = []
     if node_msg.id is None or not isinstance(bot, OB11Bot):
@@ -77,4 +78,4 @@ async def _(
         content.append(uni_msg)
         content.append(Text("\n"))
     content.pop(-1)
-    await post_cave(content, user_id, event, bot, state, session)
+    await post_cave(content, user_id, event, bot, state, session, group_id=group_id)

--- a/src/plugins/nonebot_plugin_larkcave/utils/post.py
+++ b/src/plugins/nonebot_plugin_larkcave/utils/post.py
@@ -45,7 +45,13 @@ async def get_cave_id(session: async_scoped_session) -> int:
 
 
 async def post_cave(
-    content: list[Image | Text], user_id: str, event: Event, bot: Bot, state: T_State, session: async_scoped_session
+    content: list[Image | Text],
+    user_id: str,
+    event: Event,
+    bot: Bot,
+    state: T_State,
+    session: async_scoped_session,
+    group_id: str | None = None,
 ) -> NoReturn:
     await lang.send("add.checking", user_id)
     try:
@@ -78,4 +84,21 @@ async def post_cave(
         )
         session.add(CaveData(id=cave_id, author=user_id, time=datetime.now(), content=parsed_content))
         await session.commit()
+
+    # 投稿成功后，向 chat 插件发送事件
+    if group_id:
+        try:
+            from nonebot_plugin_chat.core.session import post_group_event
+            from nonebot_plugin_chat.utils.message import parse_message_to_string
+            from nonebot_plugin_larkuser import get_nickname
+
+            uni_message = UniMessage(content)
+            content_str = await parse_message_to_string(uni_message, event, bot, state, user_id)
+            nickname = await get_nickname(user_id, bot, event)
+            event_prompt = await lang.text("add.event_prompt", user_id, nickname, cave_id, content_str)
+            await post_group_event(group_id, event_prompt, "probability")
+        except Exception as e:
+            from nonebot import logger
+            logger.warning(f"Failed to post cave event to chat: {e}")
+
     await lang.finish("add.posted", user_id, cave_id, reply_message=True)

--- a/src/plugins/nonebot_plugin_larkcave/utils/post.py
+++ b/src/plugins/nonebot_plugin_larkcave/utils/post.py
@@ -19,10 +19,14 @@ import asyncio
 from datetime import datetime
 from typing import NoReturn, cast
 
+from nonebot import logger
 from nonebot.adapters import Bot
 from nonebot.internal.adapter import Event
 from nonebot.typing import T_State
 from nonebot_plugin_alconna import Image, Text, UniMessage, image_fetch
+from nonebot_plugin_chat.core.session import post_group_event
+from nonebot_plugin_chat.utils.message import parse_message_to_string
+from nonebot_plugin_larkuser import get_nickname
 
 from nonebot_plugin_orm import async_scoped_session
 from sqlalchemy import select, func
@@ -88,18 +92,12 @@ async def post_cave(
     # 投稿成功后，向 chat 插件发送事件
     if group_id:
         try:
-            from nonebot_plugin_chat.core.session import post_group_event
-            from nonebot_plugin_chat.utils.message import parse_message_to_string
-            from nonebot_plugin_larkuser import get_nickname
-
             uni_message = UniMessage(content)
             content_str = await parse_message_to_string(uni_message, event, bot, state, user_id)
             nickname = await get_nickname(user_id, bot, event)
             event_prompt = await lang.text("add.event_prompt", user_id, nickname, cave_id, content_str)
             await post_group_event(group_id, event_prompt, "probability")
         except Exception as e:
-            from nonebot import logger
-
             logger.warning(f"Failed to post cave event to chat: {e}")
 
     await lang.finish("add.posted", user_id, cave_id, reply_message=True)

--- a/src/plugins/nonebot_plugin_larkcave/utils/post.py
+++ b/src/plugins/nonebot_plugin_larkcave/utils/post.py
@@ -99,6 +99,7 @@ async def post_cave(
             await post_group_event(group_id, event_prompt, "probability")
         except Exception as e:
             from nonebot import logger
+
             logger.warning(f"Failed to post cave event to chat: {e}")
 
     await lang.finish("add.posted", user_id, cave_id, reply_message=True)


### PR DESCRIPTION
在 larkcave 插件投稿成功后，使用 post_group_event 向 chat 插件发送事件，使 Moonlark 能够感知 cave 投稿并决定是否增加好感度。

修改内容：
-  添加  参数
- 使用  解析 UniMessage 内容（包括图片描述，不用占位符）
- 投稿成功后通过  触发 probability 模式事件
- 三个语言文件添加  文本