### PR TITLE
fix(chat): use logger.exception for gift drop error handling

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/matchers.py
+++ b/src/plugins/nonebot_plugin_chat/core/matchers.py
@@ -74,7 +74,7 @@ async def _(
     try:
         await handle_gift_drop(bot, event, user_id, session_id, session.is_napcat_bot())
     except Exception as e:
-        logger.debug(f"Gift drop check failed: {e}")
+        logger.exception(e)
 
 
 @on_message(priority=50, rule=private_message, block=False).handle()

--- a/src/plugins/nonebot_plugin_items/registry/registry.py
+++ b/src/plugins/nonebot_plugin_items/registry/registry.py
@@ -20,6 +20,11 @@ class ResourceLocation:
     def getPath(self) -> str:
         return self.path
 
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, ResourceLocation):
+            return self.namespace == other.namespace and self.path == other.path
+        return False
+
     def __hash__(self) -> int:
         return str(self).__hash__()
 


### PR DESCRIPTION
fix(items): implement __eq__ for ResourceLocation

- Update `nonebot_plugin_chat` to use `logger.exception` instead of `logger.debug` when `handle_gift_drop` fails to ensure full stack traces are captured.
- Implement `__eq__` in `ResourceLocation` within `nonebot_plugin_items` to allow proper equality comparison based on namespace and path.