### PR TITLE
fix: trigger instant memory generation during message processing

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -450,6 +450,10 @@ class MessageProcessor:
                     self.session.accumulated_text_length += len(cleaned)
                 logger.debug(f"Accumulated text length: {self.session.accumulated_text_length}")
 
+            # 消息入队后异步检查是否需要生成即时记忆
+            if not self.blocked:
+                asyncio.create_task(self._maybe_generate_instant_memory())
+
     def get_message_content_list(self) -> list[str]:
         l = []
         for msg in self.openai_messages.messages:
@@ -652,6 +656,29 @@ class MessageProcessor:
 
         if manager.should_generate():
             await manager.generate()
+
+    async def _maybe_generate_instant_memory(self) -> None:
+        """在消息处理流程中条件触发即时记忆生成。
+
+        复用 InstantMemoryManager 的缓存和锁机制，
+        避免与 generate_instant_memory() 重复处理消息。
+        """
+        manager = self.session.instant_memory_manager
+
+        messages = [
+            f"[{msg['send_time'].strftime('%H:%M:%S')}][{msg['nickname']}]({msg['message_id']}): {msg['content']}"
+            for msg in self.session.get_message_for_instant_memory()
+        ]
+
+        if not messages:
+            # 没有新消息，直接尝试用已有缓存触发
+            await manager.maybe_generate(min_messages=5, cooldown_seconds=600)
+            return
+
+        manager.add_messages_to_cache(messages)
+        manager.cursor = len(self.session.cached_messages)
+
+        await manager.maybe_generate(min_messages=5, cooldown_seconds=600)
 
     async def check_message_truncated(self) -> bool:
         chat_history = await self.session.get_cached_messages_string(length=10, include_self_message=False)

--- a/src/plugins/nonebot_plugin_chat/utils/instant_mem.py
+++ b/src/plugins/nonebot_plugin_chat/utils/instant_mem.py
@@ -219,10 +219,7 @@ class InstantMemoryManager:
         if len(self.message_cache) < min_messages:
             return []
 
-        if (
-            self.last_generate_time is not None
-            and (now - self.last_generate_time).total_seconds() < cooldown_seconds
-        ):
+        if self.last_generate_time is not None and (now - self.last_generate_time).total_seconds() < cooldown_seconds:
             return []
 
         return await self.generate()

--- a/src/plugins/nonebot_plugin_chat/utils/instant_mem.py
+++ b/src/plugins/nonebot_plugin_chat/utils/instant_mem.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Generator, TypedDict
+from typing import Generator, Optional, TypedDict
 
 from nonebot_plugin_openai.utils.chat import fetch_message
 from nonebot_plugin_openai.utils.message import generate_message
@@ -133,6 +133,7 @@ class InstantMemoryManager:
         self.message_cache: list[str] = []
         self.cursor: int = 0
         self._generate_lock = asyncio.Lock()
+        self.last_generate_time: Optional[datetime] = None
 
     def add_messages_to_cache(self, messages: list[str]) -> None:
         self.message_cache.extend(messages)
@@ -183,6 +184,7 @@ class InstantMemoryManager:
                     new_memories.append(memory)
 
                 instant_memories.extend(new_memories)
+                self.last_generate_time = datetime.now()
                 logger.info(f"[InstantMemory:{self.session_id}] 生成了 {len(new_memories)} 条即时记忆")
 
                 await _deduplicate(self.lang_str)
@@ -192,3 +194,35 @@ class InstantMemoryManager:
             except Exception as e:
                 logger.exception(f"[InstantMemory:{self.session_id}] 生成即时记忆失败: {e}")
                 return []
+
+    async def maybe_generate(
+        self,
+        min_messages: int = 5,
+        cooldown_seconds: int = 600,
+    ) -> list[InstantMemory]:
+        """条件触发即时记忆生成。
+
+        在消息处理流程中调用，避免每次消息都触发 LLM 调用。
+
+        Args:
+            min_messages: 缓存中最少消息数才触发生成
+            cooldown_seconds: 距上次生成的最短间隔（秒）
+
+        Returns:
+            生成的新记忆列表，未触发时返回空列表
+        """
+        now = datetime.now()
+
+        if self._generate_lock.locked():
+            return []
+
+        if len(self.message_cache) < min_messages:
+            return []
+
+        if (
+            self.last_generate_time is not None
+            and (now - self.last_generate_time).total_seconds() < cooldown_seconds
+        ):
+            return []
+
+        return await self.generate()


### PR DESCRIPTION
## 问题

即时记忆（Instant Memory）的生成只在主会话空闲时触发（`request_think` / `trigger_sleep`），导致群聊活跃期间记忆不更新。主会话做决策时拿到的即时记忆是过时的。

## 改动

### `instant_mem.py`
- `InstantMemoryManager` 新增 `last_generate_time` 字段，跟踪上次生成时间
- 新增 `maybe_generate(min_messages, cooldown_seconds)` 方法：
  - 缓存消息数 >= min_messages（默认 5）才触发
  - 距上次生成间隔 >= cooldown_seconds（默认 600s）才触发
  - 满足条件后调用已有的 `generate()` 方法

### `processor.py`
- 新增 `_maybe_generate_instant_memory()` 方法，复用缓存和游标机制
- 在 `process_messages()` 末尾通过 `asyncio.create_task` 异步调用，不阻塞消息处理

## 效果

- 低活跃群：5 条消息 + 10 分钟间隔即可生成记忆
- 高活跃群：10 分钟冷却避免频繁 LLM 调用
- 与原有 `generate_instant_memory()` 共享缓存和锁，不会重复生成
