### PR TITLE
fix(sign): 显示掉落礼物名称而非物品 ID

### DIFF
--- a/src/plugins/nonebot_plugin_sign/__main__.py
+++ b/src/plugins/nonebot_plugin_sign/__main__.py
@@ -186,7 +186,7 @@ async def is_user_signed(user_id: str) -> bool:
         return (date.today() - data.last_sign).days < 1
 
 
-async def try_sign_gift_drop(user_id: str) -> Optional[str]:
+async def try_sign_gift_drop(user_id: str) -> Optional[tuple[str, str]]:
     gift_id = get_gift_drop_manager().select_gift()
     namespace, path = gift_id.split(":", 1)
     location = ResourceLocation(namespace, path)
@@ -205,8 +205,9 @@ async def try_sign_gift_drop(user_id: str) -> Optional[str]:
 
     stack = await get_item(location, user_id, count=1)
     await give_item(user_id, stack)
+    item_name = await stack.getName()
     logger.info(f"Sign gift drop: user={user_id}, gift={gift_id}")
-    return gift_id
+    return gift_id, item_name
 
 
 @sign.handle()
@@ -246,9 +247,10 @@ async def _(matcher: Matcher, user_id: str = get_user_id()) -> None:
                 "value": await lang.text("image.rank_text", user_id, rank_count + 1),
             }
             if rank_count == 0:
-                gift_id = await try_sign_gift_drop(user_id)
-                if gift_id:
-                    gift_text = await lang.text("image.gift", user_id, gift_id.split(":", 1)[1])
+                gift_drop = await try_sign_gift_drop(user_id)
+                if gift_drop:
+                    _, item_name = gift_drop
+                    gift_text = await lang.text("image.gift", user_id, item_name)
                     templates["hitokoto"] = f"{gift_text}"
             data.last_sign = date.today()
             await session.commit()


### PR DESCRIPTION
## 问题

签到掉落礼物时，说明中展示的是物品 ID（如 `dried_fish`）而非本地化显示名称。

## 改动

### `__main__.py`
- `try_sign_gift_drop` 返回类型从 `Optional[str]` 改为 `Optional[tuple[str, str]]`
- 掉落成功后通过 `stack.getName()` 获取本地化物品名称，返回 `(gift_id, item_name)` 元组
- 签到 handler 中使用 `item_name` 替代 `gift_id.split(":", 1)[1]`
