### PR TITLE
feat(ego): 恢复 change_sleep_status 睡眠决策链条

### DIFF
--- a/src/lang/en_us/chat.yaml
+++ b/src/lang/en_us/chat.yaml
@@ -741,6 +741,16 @@ tools_desc:
       **何时必须调用**：你被要求“去做某事”时调用，例如“去吃点东西”。不要用于机器人回复用户消息或获取外部知识。
     do: '想要做的事的名字，例如："吃午饭"、"玩一会游戏"'
     duration: '建议的持续时间（分钟），意识会话会参考这个值但不一定完全采纳。'
+  change_sleep_status:
+    desc: |
+      处理犯困提示，决定是否准备睡觉。
+      **何时必须调用**：当你收到犯困提示时，使用此工具来确认你是否准备睡觉。
+      - 选择 `ready`：确认准备去睡觉
+      - 选择 `delay`：延迟一段时间再考虑睡觉，可以指定延迟的分钟数和原因
+    deal_type: "决策类型：'ready' 表示准备睡觉，'delay' 表示延迟。"
+    delay_minutes: "延迟的分钟数（仅当 deal_type 为 'delay' 时有效），最大 30 分钟。"
+    reason: "延迟的原因（仅当 deal_type 为 'delay' 时可选）。"
+
   request_sleep:
     desc: |
       向你的"EGO"申请睡觉。
@@ -1260,17 +1270,24 @@ main_session:
     result_approved: "已批准睡觉申请，正在启动睡觉流程。"
     result_denied: "已拒绝睡觉申请。"
     error: "睡觉申请处理出错：{}"
+  sleep_decision:
+    ready_approved: "已确认准备睡觉，正在启动睡觉流程。"
+    delay_approved: "已延迟 {} 分钟再考虑睡觉。原因：{}"
+    no_reason: "未指定原因"
+    error: "睡眠决策处理出错：{}"
   latest_event:
     boredom_thresold: 你感到有些无聊，需要做一些事情来保持活力。
     task_finished: 你刚刚结束了一个任务（{request_text}），你可以继续观望群聊（`skip`）或决定下一步的行动。
     chat_request: 会话 {trigger_from} 请求进行 {request_text} 任务。你可以查看该会话最近的聊天记录获取详细的信息。
     ready_sleep: 你感觉有点困了，决定去睡觉。
 sleep:
-  drowsy_prompt: "[提示]: 你感到有些犯困了。你可以使用 `request_sleep` 工具申请去睡觉。"
+  drowsy_prompt: "[提示]: 你感到有些犯困了。请使用 `change_sleep_status` 工具来决定是否准备睡觉。"
 request_action:
   timeout: "动作申请超时，意识会话未在规定时间内做出决定。"
 request_sleep:
   timeout: "睡觉申请超时，意识会话未在规定时间内做出决定。"
+sleep_decision:
+  timeout: "睡眠决策超时，意识会话未在规定时间内做出决定。"
 recall_fetch_failed: "消息内容获取失败"
 message_truncate_check:
   system: |

--- a/src/lang/zh_hans/chat.yaml
+++ b/src/lang/zh_hans/chat.yaml
@@ -781,6 +781,16 @@ tools_desc:
     do: '想要做的事的名字，例如："吃午饭"、"玩一会游戏"'
     duration: '建议的持续时间（分钟），意识会话会参考这个值但不一定完全采纳。'
 
+  change_sleep_status:
+    desc: |
+      处理犯困提示，决定是否准备睡觉。
+      **何时必须调用**：当你收到犯困提示时，使用此工具来确认你是否准备睡觉。
+      - 选择 `ready`：确认准备去睡觉
+      - 选择 `delay`：延迟一段时间再考虑睡觉，可以指定延迟的分钟数和原因
+    deal_type: "决策类型：'ready' 表示准备睡觉，'delay' 表示延迟。"
+    delay_minutes: "延迟的分钟数（仅当 deal_type 为 'delay' 时有效），最大 30 分钟。"
+    reason: "延迟的原因（仅当 deal_type 为 'delay' 时可选）。"
+
   request_sleep:
     desc: |
       向你的"EGO"申请睡觉。
@@ -1313,19 +1323,27 @@ main_session:
     result_approved: "已批准睡觉申请，正在启动睡觉流程。"
     result_denied: "已拒绝睡觉申请。"
     error: "睡觉申请处理出错：{}"
+  sleep_decision:
+    ready_approved: "已确认准备睡觉，正在启动睡觉流程。"
+    delay_approved: "已延迟 {} 分钟再考虑睡觉。原因：{}"
+    no_reason: "未指定原因"
+    error: "睡眠决策处理出错：{}"
   latest_event:
     boredom_thresold: 你感到有些无聊，需要做一些事情来保持活力。
     task_finished: 你刚刚结束了一个任务（{request_text}），你可以继续观望群聊（`skip`）或决定下一步的行动。
     chat_request: 会话 {trigger_from} 请求进行 {request_text} 任务。你可以查看该会话最近的聊天记录获取详细的信息。
     ready_sleep: 你感觉有点困了，决定去睡觉。
 sleep:
-  drowsy_prompt: "[提示]: 你感到有些犯困了。你可以使用 `request_sleep` 工具申请去睡觉。"
+  drowsy_prompt: "[提示]: 你感到有些犯困了。请使用 `change_sleep_status` 工具来决定是否准备睡觉。"
 
 request_action:
   timeout: "动作申请超时，意识会话未在规定时间内做出决定。"
 
 request_sleep:
   timeout: "睡觉申请超时，意识会话未在规定时间内做出决定。"
+
+sleep_decision:
+  timeout: "睡眠决策超时，意识会话未在规定时间内做出决定。"
 
 recall_fetch_failed: "消息内容获取失败"
 

--- a/src/lang/zh_tw/chat.yaml
+++ b/src/lang/zh_tw/chat.yaml
@@ -741,10 +741,20 @@ tools_desc:
       **何时必须调用**：你被要求“去做某事”时调用，例如“去吃点东西”。不要用于机器人回复用户消息或获取外部知识。
     do: '想要做的事的名字，例如："吃午饭"、"玩一会游戏"'
     duration: '建议的持续时间（分钟），意识会话会参考这个值但不一定完全采纳。'
+  change_sleep_status:
+    desc: |
+      處理犯困提示，決定是否準備睡覺。
+      **何時必須調用**：當你收到犯困提示時，使用此工具來確認你是否準備睡覺。
+      - 選擇 `ready`：確認準備去睡覺
+      - 選擇 `delay`：延遲一段時間再考慮睡覺，可以指定延遲的分鐘數和原因
+    deal_type: "決策類型：'ready' 表示準備睡覺，'delay' 表示延遲。"
+    delay_minutes: "延遲的分鐘數（僅當 deal_type 為 'delay' 時有效），最大 30 分鐘。"
+    reason: "延遲的原因（僅當 deal_type 為 'delay' 時可選）。"
+
   request_sleep:
     desc: |
-      向你的"EGO"申请睡觉。
-      **何时必须调用**：当你收到犯困提示时，调用此工具申请去睡觉。
+      向你的"EGO"申請睡覺。
+      **何時必須調用**：當你收到犯困提示時，調用此工具申請去睡覺。
   query_history_message:
     desc: |
       查询其他会话的历史消息和即时记忆。
@@ -1257,20 +1267,27 @@ main_session:
       {}
 
       请决定是否批准。
-    result_approved: "已批准睡觉申请，正在启动睡觉流程。"
-    result_denied: "已拒绝睡觉申请。"
-    error: "睡觉申请处理出错：{}"
+    result_approved: "已批准睡覺申請，正在啟動睡覺流程。"
+    result_denied: "已拒絕睡覺申請。"
+    error: "睡覺申請處理出錯：{}"
+  sleep_decision:
+    ready_approved: "已確認準備睡覺，正在啟動睡覺流程。"
+    delay_approved: "已延遲 {} 分鐘再考慮睡覺。原因：{}"
+    no_reason: "未指定原因"
+    error: "睡眠決策處理出錯：{}"
   latest_event:
     boredom_thresold: 你感到有些无聊，需要做一些事情来保持活力。
     task_finished: 你刚刚结束了一个任务（{request_text}），你可以继续观望群聊（`skip`）或决定下一步的行动。
     chat_request: 会话 {trigger_from} 请求进行 {request_text} 任务。你可以查看该会话最近的聊天记录获取详细的信息。
     ready_sleep: 你感觉有点困了，决定去睡觉。
 sleep:
-  drowsy_prompt: "[提示]: 你感到有些犯困了。你可以使用 `request_sleep` 工具申请去睡觉。"
+  drowsy_prompt: "[提示]: 你感到有些犯困了。请使用 `change_sleep_status` 工具来决定是否准备睡觉。"
 request_action:
-  timeout: "动作申请超时，意识会话未在规定时间内做出决定。"
+  timeout: "動作申請超時，意識會話未在規定時間內做出決定。"
 request_sleep:
-  timeout: "睡觉申请超时，意识会话未在规定时间内做出决定。"
+  timeout: "睡覺申請超時，意識會話未在規定時間內做出決定。"
+sleep_decision:
+  timeout: "睡眠決策超時，意識會話未在規定時間內做出決定。"
 recall_fetch_failed: "消息内容获取失败"
 message_truncate_check:
   system: |

--- a/src/plugins/nonebot_plugin_chat/core/ego/main_session.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/main_session.py
@@ -94,8 +94,7 @@ class MainSession:
 
         if result == "sleep":
             return True  # 强制触发，request_think 中会强制选择 sleep
-        elif result == "drowsy":
-            return True  # 触发犯困提示
+        # drowsy 状态现在通过事件提示处理，不在这里触发
         return False
 
     async def generate_user_prompt(
@@ -316,7 +315,12 @@ class MainSession:
                 if drowsiness_result == "sleep":
                     await self.request_think("ready_sleep", None)
                 elif drowsiness_result == "drowsy":
-                    await self.request_think("boredom_thresold", None)
+                    # 向群聊会话发送犯困提示事件，让 LLM 调用 change_sleep_status 工具
+                    drowsy_prompt = await lang.text("sleep.drowsy_prompt", self.lang_str)
+                    for group in groups.values():
+                        if group.get_session_type() == "group":
+                            await group.add_event(drowsy_prompt, "probability")
+                            break
 
         await self.save_action_history()
 
@@ -548,6 +552,49 @@ class MainSession:
             logger.exception(e)
             if future and not future.done():
                 future.set_result(await lang.text("main_session.sleep_request.error", self.lang_str, str(e)))
+
+    async def submit_sleep_decision(
+        self,
+        session_id: str,
+        deal_type: Literal["ready", "delay"],
+        delay_minutes: Optional[int] = None,
+        reason: Optional[str] = None,
+        future: Optional[asyncio.Future] = None,
+    ) -> None:
+        """处理来自子会话的睡眠决策（change_sleep_status 工具调用）"""
+        try:
+            if deal_type == "ready":
+                # 准备睡觉
+                self.state = StateEnum.SLEEPING
+                sleep_minutes = 20
+                sleep_start = datetime.now()
+                sleep_end = sleep_start + timedelta(minutes=sleep_minutes)
+                self.state_until = sleep_end
+                self.action_history.append((sleep_start, RestAction(type="sleep", time=sleep_minutes), None))
+                await self.trigger_sleep()
+
+                if future and not future.done():
+                    future.set_result(
+                        await lang.text("main_session.sleep_decision.ready_approved", self.lang_str)
+                    )
+            else:
+                # 延迟睡觉
+                delay = min(delay_minutes or 5, 30)  # 默认5分钟，最大30分钟
+                self.state_until = datetime.now() + timedelta(minutes=delay)
+
+                if future and not future.done():
+                    future.set_result(
+                        await lang.text(
+                            "main_session.sleep_decision.delay_approved",
+                            self.lang_str,
+                            delay,
+                            reason or await lang.text("main_session.sleep_decision.no_reason", self.lang_str),
+                        )
+                    )
+        except Exception as e:
+            logger.exception(e)
+            if future and not future.done():
+                future.set_result(await lang.text("main_session.sleep_decision.error", self.lang_str, str(e)))
 
     async def wake_up(self, session: Optional["BaseSession"] = None) -> None:
         if self.state != StateEnum.SLEEPING:

--- a/src/plugins/nonebot_plugin_chat/core/ego/main_session.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/main_session.py
@@ -574,9 +574,7 @@ class MainSession:
                 await self.trigger_sleep()
 
                 if future and not future.done():
-                    future.set_result(
-                        await lang.text("main_session.sleep_decision.ready_approved", self.lang_str)
-                    )
+                    future.set_result(await lang.text("main_session.sleep_decision.ready_approved", self.lang_str))
             else:
                 # 延迟睡觉
                 delay = min(delay_minutes or 5, 30)  # 默认5分钟，最大30分钟

--- a/src/plugins/nonebot_plugin_chat/core/session/base.py
+++ b/src/plugins/nonebot_plugin_chat/core/session/base.py
@@ -320,6 +320,51 @@ class BaseSession(ABC):
         # 向会话发送事件，强制触发回复
         await self.post_event(event_prompt, "all")
 
+    async def change_sleep_status(
+        self, deal_type: Literal["ready", "delay"], delay_minutes: Optional[int] = None, reason: Optional[str] = None
+    ) -> str:
+        """
+        修改睡觉状态
+
+        Args:
+            deal_type: 决策类型，"ready"表示准备睡觉，"delay"表示延迟
+            delay_minutes: 延迟的分钟数（仅当deal_type为"delay"时有效）
+            reason: 延迟的原因（仅当deal_type为"delay"时有效）
+
+        Returns:
+            工具调用的结果（会等待main_session统一处理）
+        """
+        from ..ego import consciousness
+
+        # 验证参数
+        if deal_type == "delay":
+            if delay_minutes is None:
+                delay_minutes = 0
+            if delay_minutes > 30:
+                delay_minutes = 30
+            if delay_minutes < 0:
+                delay_minutes = 0
+
+        # 创建一个Future用于等待main_session的处理结果
+        # 这里使用异步等待挂起响应
+        result_future = asyncio.get_event_loop().create_future()
+
+        # 提交决策到main_session
+        await consciousness.submit_sleep_decision(
+            session_id=self.session_id,
+            deal_type=deal_type,
+            delay_minutes=delay_minutes,
+            reason=reason,
+            future=result_future,
+        )
+
+        # 等待main_session的处理结果
+        try:
+            result = await asyncio.wait_for(result_future, timeout=120)  # 最多等待2分钟
+            return result
+        except asyncio.TimeoutError:
+            return await self.text("sleep_decision.timeout")
+
     async def request_action(self, do: str, duration: Optional[int] = None) -> str:
         """
         向意识会话申请执行一个动作

--- a/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
@@ -100,6 +100,14 @@ class ToolManager:
         luck_value = await get_luck_value(user_id)
         return await self.text("tools_desc.calculate_luck_value.result", nickname, luck_value)
 
+    async def change_sleep_status(
+        self, deal_type: Literal["ready", "delay"], delay_minutes: Optional[int] = None, reason: Optional[str] = None
+    ) -> str:
+        """修改睡觉状态，委托给session处理"""
+        return await self.processor.session.change_sleep_status(
+            deal_type=deal_type, delay_minutes=delay_minutes, reason=reason
+        )
+
     async def request_action(self, do: str, duration: Optional[int] = None) -> str:
         """向意识会话申请执行一个动作"""
         return await self.processor.session.request_action(do=do, duration=duration)
@@ -479,6 +487,32 @@ class ToolManager:
                         "duration": FunctionParameter(
                             type="integer",
                             description=await self.text("tools_desc.request_action.duration"),
+                            required=False,
+                        ),
+                    },
+                )
+            )
+
+            # change_sleep_status
+            tools.append(
+                AsyncFunction(
+                    func=self.change_sleep_status,
+                    description=await self.text("tools_desc.change_sleep_status.desc"),
+                    parameters={
+                        "deal_type": FunctionParameterWithEnum(
+                            type="string",
+                            description=await self.text("tools_desc.change_sleep_status.deal_type"),
+                            required=True,
+                            enum={"ready", "delay"},
+                        ),
+                        "delay_minutes": FunctionParameter(
+                            type="integer",
+                            description=await self.text("tools_desc.change_sleep_status.delay_minutes"),
+                            required=False,
+                        ),
+                        "reason": FunctionParameter(
+                            type="string",
+                            description=await self.text("tools_desc.change_sleep_status.reason"),
                             required=False,
                         ),
                     },


### PR DESCRIPTION
## 变更概述

恢复从 `7ad2021` 被删除的睡眠决策链条，即 **sleep controller 决定犯困 → chat session 调用 `change_sleep_status` 工具确认 → main session 进行进一步操作**，但保留当前的犯困决定算法（SleepController 困倦值公式）。

## 变更内容

### 核心逻辑变更
- **`core/session/base.py`**: 恢复 `change_sleep_status` 方法，通过 `consciousness.submit_sleep_decision()` 提交决策到 main session
- **`core/ego/main_session.py`**: 
  - 新增 `submit_sleep_decision()` 方法，处理 `change_sleep_status` 工具调用
  - 修改 `process_timer()`: `drowsy` 状态现在通过事件提示 LLM 调用 `change_sleep_status` 工具（而非直接触发 `request_think("boredom_thresold")`）
  - 修改 `is_boredom()`: 仅 `sleep` 状态返回 `True`
- **`utils/tool_manager.py`**: 恢复 `change_sleep_status` 工具（`deal_type`: `ready`/`delay`，可选 `delay_minutes` 和 `reason`）

### 语言文件
- 更新 `drowsy_prompt`：提示使用 `change_sleep_status` 工具
- 添加 `change_sleep_status` 工具描述（zh_hans/en_us/zh_tw）
- 添加 `sleep_decision` 系列文本

## 睡眠决策流程

```
SleepController 检测 drowsy
    ↓
向群聊会话发送犯困事件提示
    ↓
LLM 调用 change_sleep_status 工具
    ↓
┌─ ready → main session 启动睡觉流程
└─ delay → main session 延迟 state_until
```