### PR TITLE
feat(chat): 在事件模板中添加 additional_info

### DIFF
--- a/src/lang/en_us/chat.yaml
+++ b/src/lang/en_us/chat.yaml
@@ -331,7 +331,18 @@ prompt:
     to_me: "{} 戳了戳你。"
     to_other: "{} 戳了戳 {}。"
   reaction: "{} 回应了你的消息“{}”: {}"
-  event_template: "[{}]: {}"
+  event_template: |
+    [{}]: {}
+
+    {}
+  event_additional_info: |
+    <additional_info>
+    Current Token: {}
+    {}
+    Recent activities:
+    {}
+    </additional_info>
+  event_additional_info.no_activity: "None"
   note:
     format: "- {} (#{}，创建于 {})"
     none: "暂无"

--- a/src/lang/zh_hans/chat.yaml
+++ b/src/lang/zh_hans/chat.yaml
@@ -339,7 +339,18 @@ prompt:
     to_me: "{} 戳了戳你。"
     to_other: "{} 戳了戳 {}。"
   reaction: "{} 回应了你的消息“{}”: {}"
-  event_template: "[{}]: {}"
+  event_template: |
+    [{}]: {}
+
+    {}
+  event_additional_info: |
+    <additional_info>
+    当前 Token: {}
+    {}
+    最近做的事:
+    {}
+    </additional_info>
+  event_additional_info.no_activity: "暂无"
   note:
     format: "- {} (#{}，创建于 {})"
     none: "暂无"

--- a/src/lang/zh_tw/chat.yaml
+++ b/src/lang/zh_tw/chat.yaml
@@ -331,7 +331,18 @@ prompt:
     to_me: "{} 戳了戳你。"
     to_other: "{} 戳了戳 {}。"
   reaction: "{} 回应了你的消息“{}”: {}"
-  event_template: "[{}]: {}"
+  event_template: |
+    [{}]: {}
+
+    {}
+  event_additional_info: |
+    <additional_info>
+    當前 Token: {}
+    {}
+    最近做的事:
+    {}
+    </additional_info>
+  event_additional_info.no_activity: "暫無"
   note:
     format: "- {} (#{}，创建于 {})"
     none: "暂无"

--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -236,8 +236,9 @@ class MessageProcessor:
         if item[0] == "event":
             # 处理事件类型队列项
             event_prompt, trigger_mode = item[1]  # type: ignore
+            additional_info = await self.generate_event_additional_info()
             content = await self.session.text(
-                "prompt.event_template", datetime.now().strftime("%H:%M:%S"), event_prompt
+                "prompt.event_template", datetime.now().strftime("%H:%M:%S"), event_prompt, additional_info
             )
             await self.openai_messages.append_user_message(content)
             self.token_bucket.add(0.6)
@@ -579,6 +580,35 @@ class MessageProcessor:
                 if line in str(message):
                     return True
         return False
+
+    async def generate_event_additional_info(self) -> str:
+        """生成事件的 additional_info，包含 token、当前状态和正在做的事"""
+        from .ego import consciousness
+
+        status_manager = get_status_manager()
+        mood, mood_reason = status_manager.get_status()
+        mood_text = await self.session.text(f"status.mood.{mood.value}")
+
+        state = await self.session.text(
+            "prompt_group.state",
+            mood_text,
+            status_manager.get_mood_retention(),
+            mood_reason,
+        )
+
+        # 获取正在做的事（查重）
+        recent_activities = "\n".join(
+            await self.filter_info_lines(
+                (await consciousness.get_recent_actions_text(self.session.lang_str)).splitlines()
+            )
+        )
+
+        return await self.session.text(
+            "prompt.event_additional_info",
+            round(self.token_bucket.get(), 2),
+            state,
+            recent_activities or await self.session.text("prompt.event_additional_info.no_activity"),
+        )
 
     async def generate_system_prompt(self) -> OpenAIMessage:
         fav_rule = await get_prompt_text("favorability")


### PR DESCRIPTION
## 变更概述

在事件模板中添加 `<additional_info>` 标签，让 LLM 在处理事件时也能获取当前状态信息。

## 变更内容

### processor.py
- 新增 `generate_event_additional_info()` 方法，生成事件的附加信息
- 修改事件处理逻辑，将 additional_info 传递给事件模板

### 语言文件（zh_hans/en_us/zh_tw）
- 修改 `event_template`：从 `[{}]: {}` 改为多行格式，包含 additional_info
- 新增 `event_additional_info` 模板：包含 Token、状态、最近做的事
- 新增 `event_additional_info.no_activity`：无活动时的占位文本

## 事件模板示例

```
[14:30:25]: 你感到有些犯困了。

<additional_info>
当前 Token: 5.2
当前状态：
心情：疲惫 (情感强度: 0.8; 原因: 连续对话)

最近做的事:
- [2026-05-21 14:00:00] 和群友聊天
</additional_info>
```

## 查重机制

"最近做的事" 部分会通过 `filter_info_lines` 进行查重，避免重复展示已经展示过的内容。