### PR TITLE
feat(last-seen): 支持显示上次下线时间

### DIFF
--- a/migrations/versions/0fbe94039ef4_add_previous_last_seen.py
+++ b/migrations/versions/0fbe94039ef4_add_previous_last_seen.py
@@ -1,0 +1,33 @@
+"""add previous_last_seen to LastSeenRecord
+
+迁移 ID: 0fbe94039ef4
+父迁移: a280bc2d
+创建时间: 2026-05-24 22:30:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0fbe94039ef4"
+down_revision: str | Sequence[str] | None = "ebd58910367a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade(name: str = "") -> None:
+    if name:
+        return
+    with op.batch_alter_table("nonebot_plugin_last_seen_lastseenrecord", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("previous_last_seen", sa.DateTime(), nullable=True))
+
+
+def downgrade(name: str = "") -> None:
+    if name:
+        return
+    with op.batch_alter_table("nonebot_plugin_last_seen_lastseenrecord", schema=None) as batch_op:
+        batch_op.drop_column("previous_last_seen")

--- a/src/plugins/nonebot_plugin_last_seen/__main__.py
+++ b/src/plugins/nonebot_plugin_last_seen/__main__.py
@@ -29,8 +29,9 @@ async def update_last_seen(user_id: str, session_id: str) -> None:
         current_time = datetime.now()
 
         if record:
-            # 更新现有记录，保存旧值
-            record.previous_last_seen = record.last_seen
+            # 更新现有记录，仅当时间差大于 5 分钟时才更新上次上线时间
+            if (current_time - record.last_seen).total_seconds() >= 300:
+                record.previous_last_seen = record.last_seen
             record.last_seen = current_time
         else:
             # 创建新记录

--- a/src/plugins/nonebot_plugin_last_seen/__main__.py
+++ b/src/plugins/nonebot_plugin_last_seen/__main__.py
@@ -29,7 +29,8 @@ async def update_last_seen(user_id: str, session_id: str) -> None:
         current_time = datetime.now()
 
         if record:
-            # 更新现有记录
+            # 更新现有记录，保存旧值
+            record.previous_last_seen = record.last_seen
             record.last_seen = current_time
         else:
             # 创建新记录
@@ -40,13 +41,25 @@ async def update_last_seen(user_id: str, session_id: str) -> None:
 
 
 async def get_last_seen(user_id: str, session_id: str) -> Optional[datetime]:
-    """获取用户的最后上线时间"""
+    """获取用户的最后上线时间
+
+    如果用户当前在线（5分钟内有消息），返回上一次下线时间。
+    否则返回最后上线时间。
+    """
     async with get_session() as session:
         result = await session.execute(
             select(LastSeenRecord).where(LastSeenRecord.user_id == user_id, LastSeenRecord.session_id == session_id)
         )
         record = result.scalar_one_or_none()
-        return record.last_seen if record else None
+        if not record:
+            return None
+
+        # 如果5分钟内有消息且有上一次记录，返回上一次下线时间
+        now = datetime.now()
+        if (now - record.last_seen).total_seconds() < 300 and record.previous_last_seen:
+            return record.previous_last_seen
+
+        return record.last_seen
 
 
 # Message handler to track last seen time

--- a/src/plugins/nonebot_plugin_last_seen/models.py
+++ b/src/plugins/nonebot_plugin_last_seen/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 from nonebot_plugin_orm import Model
 from sqlalchemy import String, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
@@ -15,5 +16,6 @@ class LastSeenRecord(Model):
     user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     session_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     last_seen: Mapped[datetime] = mapped_column(DateTime)
+    previous_last_seen: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, default=None)
 
     __table_args__ = {"extend_existing": True}


### PR DESCRIPTION
## 改动

当用户当前在线时，`/lastseen` 显示上一次下线时间而不是当前在线时间。

### 实现
- `models.py`: 新增 `previous_last_seen` 字段
- `update_last_seen`: 每次更新时将旧值存入 `previous_last_seen`
- `get_last_seen`: 如果 5 分内有消息且有历史记录，返回 `previous_last_seen`
- 新增数据库迁移