### PR TITLE
fix: cave node 消息迭代使用错误变量导致 TypeError

### DIFF
--- a/src/plugins/nonebot_plugin_larkcave/commands/post.py
+++ b/src/plugins/nonebot_plugin_larkcave/commands/post.py
@@ -75,7 +75,7 @@ async def _(
         await lang.finish("node.check_failed_1", user_id)
     for msg in node_messages:
         message = OB11Message()
-        for segment in node_messages["message"]:
+        for segment in msg["message"]:
             segment = OB11Segment(**segment)
             message.append(segment)
         uni_msg = UniMessage.generate_without_reply(message=message)


### PR DESCRIPTION
fix: cave node 消息迭代使用错误变量导致 TypeError。node_messages 是消息列表，循环变量应为 msg，误用 node_messages 导致 TypeError。