### PR TITLE
feat(setu): 导出 get_image 接口供其他插件调用

### DIFF
--- a/src/plugins/nonebot_plugin_larksetu/__init__.py
+++ b/src/plugins/nonebot_plugin_larksetu/__init__.py
@@ -19,6 +19,7 @@ require("nonebot_plugin_larklang")
 require("nonebot_plugin_localstore")
 require("nonebot_plugin_alconna")
 
+from .cache import get_image
 from . import __main__
 
 nonebot.load_plugin("nonebot_plugin_larksetu.plugins.nonebot_plugin_seturank")


### PR DESCRIPTION
## 改动

`__init__.py` 导出 `get_image` 函数。

## 接口说明

`cache.get_image()` 已实现完整流程：
1. 从缓存中取出一张图片
2. 从缓存列表中删除该图片并删除缓存文件
3. 触发 `update_cache()` 补充缓存

## 其他插件调用方式

```python
from nonebot_plugin_larksetu import get_image

image = await get_image()  # -> ImageWithData ({data: ImageData, image: bytes})
```