### PR TITLE
feat(sign): 重设计签到卡片模板

### DIFF
--- a/src/lang/zh_hans/sign.yaml
+++ b/src/lang/zh_hans/sign.yaml
@@ -4,7 +4,7 @@ image:
   rank: 排名
   title: 签到成功！
   signdays_text: '{} 天'
-  rank_text: 第 {}
+  rank_text: '{}'
   vim: VimCoin
   exp: 经验
   uid: 'UID: {}'

--- a/src/plugins/nonebot_plugin_sign/__init__.py
+++ b/src/plugins/nonebot_plugin_sign/__init__.py
@@ -21,5 +21,6 @@ require("nonebot_plugin_render")
 require("nonebot_plugin_bag")
 require("nonebot_plugin_items")
 require("nonebot_plugin_chat")
+require("nonebot_plugin_larksetu")
 
 from .__main__ import is_user_signed

--- a/src/plugins/nonebot_plugin_sign/__main__.py
+++ b/src/plugins/nonebot_plugin_sign/__main__.py
@@ -16,6 +16,7 @@ from nonebot_plugin_chat.utils.gift_drop import get_gift_drop_manager
 from nonebot_plugin_email.utils.unread import get_unread_email_count
 from nonebot_plugin_items.registry.registry import ResourceLocation
 from nonebot_plugin_items.utils.get import get_item
+from nonebot_plugin_larksetu import get_image
 from nonebot_plugin_larkuser import get_user
 from nonebot_plugin_larkuser.user.base import MoonlarkUser
 from nonebot_plugin_larkuser.utils.matcher import patch_matcher
@@ -221,6 +222,7 @@ async def _(matcher: Matcher, user_id: str = get_user_id()) -> None:
             if (date.today() - data.last_sign).days < 1:
                 await lang.finish("sign.signed", user_id)
             templates = {
+                "date": date.today().strftime("%d"),
                 "signdays": {
                     "text": await lang.text("image.signdays", user_id),
                     "value": await lang.text("image.signdays_text", user_id, await get_sign_days(data, user)),
@@ -254,8 +256,18 @@ async def _(matcher: Matcher, user_id: str = get_user_id()) -> None:
                     templates["hitokoto"] = f"{gift_text}"
             data.last_sign = date.today()
             await session.commit()
+            # 获取 setu 图片作为背景
+            bg_kwargs = {}
+            try:
+                setu_img = await get_image()
+                b64 = base64.b64encode(setu_img["image"]).decode()
+                ext = setu_img["data"].ext
+                mime = "image/png" if ext == "png" else "image/jpeg"
+                bg_kwargs["background_url"] = f"data:{mime};base64,{b64}"
+            except Exception as e:
+                logger.warning(f"获取 setu 背景图失败，使用默认背景: {e}")
             image = await render_template(
-                "sign.html.jinja", await lang.text("image.title", user_id), user_id, templates
+                "sign.html.jinja", await lang.text("image.title", user_id), user_id, templates, **bg_kwargs,
             )
             msg = UniMessage().image(raw=image)
             _user_locks.pop(user_id, None)

--- a/src/plugins/nonebot_plugin_sign/__main__.py
+++ b/src/plugins/nonebot_plugin_sign/__main__.py
@@ -267,7 +267,11 @@ async def _(matcher: Matcher, user_id: str = get_user_id()) -> None:
             except Exception as e:
                 logger.warning(f"获取 setu 背景图失败，使用默认背景: {e}")
             image = await render_template(
-                "sign.html.jinja", await lang.text("image.title", user_id), user_id, templates, **bg_kwargs,
+                "sign.html.jinja",
+                await lang.text("image.title", user_id),
+                user_id,
+                templates,
+                **bg_kwargs,
             )
             msg = UniMessage().image(raw=image)
             _user_locks.pop(user_id, None)

--- a/src/templates/sign.html.jinja
+++ b/src/templates/sign.html.jinja
@@ -1,52 +1,224 @@
 {% extends base %}
 
 {% block body %}
-{% if not avatar %}
-<p>
-    <span class="h2">{{ nickname }}</span>
-    {{ uid }}
-</p>
-{% endif %}
-<div class="row">
-    {% if avatar %}
-    <div class="col-4">
-        <img src="data:image;base64,{{ avatar }}" class="rounded-circle" width="100%">
-        <p class="small"></p>
-        <div style="text-align: center;">
-            <span class="h3">{{ nickname }}</span>
-            <br>
-            {{ uid }}
+<style>
+    .sign-card {
+        background: rgba(255, 255, 255, 0.92);
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    }
+
+    .sign-header-img {
+        width: 100%;
+        height: 200px;
+        object-fit: cover;
+        display: block;
+    }
+
+    .sign-divider {
+        display: flex;
+        align-items: center;
+        padding: 12px 20px;
+        background: rgba(255, 255, 255, 0.95);
+        border-bottom: 1px solid #e0e0e0;
+    }
+
+    .sign-avatar {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        object-fit: cover;
+        border: 2px solid #fff;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+        flex-shrink: 0;
+    }
+
+    .sign-title-bar {
+        flex: 1;
+        margin-left: 14px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        /* 亚克力效果 */
+        background: rgba(255, 255, 255, 0.6);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border-radius: 8px;
+        padding: 8px 14px;
+    }
+
+    .sign-title-left {
+        font-size: 20px;
+        font-weight: 700;
+        color: #222;
+    }
+
+    .sign-title-right {
+        font-size: 28px;
+        font-weight: 700;
+        color: #999;
+    }
+
+    .sign-body {
+        padding: 16px 20px;
+    }
+
+    .sign-hitokoto {
+        font-size: 13px;
+        color: #999;
+        margin-bottom: 16px;
+        line-height: 1.6;
+    }
+
+    .sign-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 14px;
+    }
+
+    .sign-table td {
+        padding: 6px 4px;
+        font-size: 14px;
+        color: #333;
+        vertical-align: middle;
+    }
+
+    .sign-table .col-label {
+        font-weight: 600;
+        width: 70px;
+    }
+
+    .sign-table .col-old {
+        color: #888;
+        text-align: right;
+        width: 80px;
+    }
+
+    .sign-table .col-arrow {
+        text-align: center;
+        color: #aaa;
+        width: 30px;
+    }
+
+    .sign-table .col-new {
+        font-weight: 600;
+        text-align: right;
+        width: 80px;
+    }
+
+    .sign-table .col-diff {
+        color: #4caf50;
+        font-weight: 600;
+        text-align: right;
+        width: 80px;
+    }
+
+    .sign-sep {
+        border: none;
+        border-top: 1px solid #e0e0e0;
+        margin: 10px 0;
+    }
+
+    .sign-footer-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 4px 0 8px 0;
+    }
+
+    .sign-rank {
+        font-size: 15px;
+        font-weight: 600;
+        color: #333;
+    }
+
+    .sign-fortune-badge {
+        display: inline-block;
+        padding: 4px 14px;
+        border-radius: 20px;
+        font-size: 14px;
+        font-weight: 600;
+        color: #fff;
+    }
+
+    .fortune-warning { background: #f0a020; }
+    .fortune-success { background: #4caf50; }
+    .fortune-teal    { background: #26a69a; }
+    .fortune-secondary { background: #9e9e9e; }
+    .fortune-orange  { background: #ff9800; }
+    .fortune-danger  { background: #f44336; }
+    .fortune-dark    { background: #c62828; }
+</style>
+
+<div class="sign-card">
+    {# 头图 #}
+    <img src="{{ background_url }}" class="sign-header-img" alt="header" />
+
+    {# 头图与正文之间的分割线：头像 + 标题行 #}
+    <div class="sign-divider">
+        {% if avatar %}
+        <img src="data:image;base64,{{ avatar }}" class="sign-avatar" alt="avatar" />
+        {% endif %}
+        <div class="sign-title-bar">
+            <span class="sign-title-left">签到成功</span>
+            <span class="sign-title-right">{{ date }}</span>
         </div>
     </div>
-    <div class="col-4">
-        {% else %}
-        <div class="col">
-            {%endif%}
-            <h3>{{ exp.text }}</h3>
-            <p>{{ exp.origin }} -> {{ exp.now }} (<strong class="text-success">+{{ exp.add }}</strong>)</p>
-            <h3>{{ vim.text }}</h3>
-            <p>{{ vim.origin }} -> {{ vim.now }} (<strong class="text-success">+{{ vim.add }}</strong>)</p>
-            <h3>{{ fav.text }}</h3>
-            <p>{{ fav.origin }} -> {{ fav.now }} (<strong class="text-success">+{{ fav.add }}</strong>)</p>
-        </div>
-        {% if avatar %}
-        <div class="col-4">
-            {% else %}
-            <div class="col">
-                {% endif %}
-                <h3>{{ signdays.text }}</h3>
-                <p>{{ signdays.value }}</p>
-                <h3>{{ rank.text }}</h3>
-                <p>{{ rank.value }}</p>
-                <h3>{{ fortune.text }}</h3>
-                <p>{{ fortune.value }}</p>
-            </div>
-        </div>
-        <div style="text-align: center;">
-            {{ hitokoto }}
-        </div>
 
+    {# 正文 #}
+    <div class="sign-body">
+        {# 一言 #}
+        <div class="sign-hitokoto">{{ hitokoto }}</div>
+
+        {# 数据变动表格 #}
+        <table class="sign-table">
+            <tr>
+                <td class="col-label">{{ vim.text }}</td>
+                <td class="col-old">{{ vim.origin }}</td>
+                <td class="col-arrow">-></td>
+                <td class="col-new">{{ vim.now }}</td>
+                <td class="col-diff">(+{{ vim.add }})</td>
+            </tr>
+            <tr>
+                <td class="col-label">{{ exp.text }}</td>
+                <td class="col-old">{{ exp.origin }}</td>
+                <td class="col-arrow">-></td>
+                <td class="col-new">{{ exp.now }}</td>
+                <td class="col-diff">(+{{ exp.add }})</td>
+            </tr>
+            <tr>
+                <td class="col-label">{{ fav.text }}</td>
+                <td class="col-old">{{ fav.origin }}</td>
+                <td class="col-arrow">-></td>
+                <td class="col-new">{{ fav.now }}</td>
+                <td class="col-diff">(+{{ fav.add }})</td>
+            </tr>
+        </table>
+
+        {# 分割线 #}
+        <hr class="sign-sep" />
+
+        {# 排名与运势 #}
+        <div class="sign-footer-row">
+            <span class="sign-rank">{{ rank.text }}：{{ rank.value }}</span>
+            {% set fortune_text = fortune.value %}
+            {% if fortune_text == '大吉' %}
+                <span class="sign-fortune-badge fortune-warning">{{ fortune.text }}：{{ fortune_text }}</span>
+            {% elif fortune_text == '吉' %}
+                <span class="sign-fortune-badge fortune-success">{{ fortune.text }}：{{ fortune_text }}</span>
+            {% elif fortune_text == '小吉' %}
+                <span class="sign-fortune-badge fortune-teal">{{ fortune.text }}：{{ fortune_text }}</span>
+            {% elif fortune_text == '末吉' %}
+                <span class="sign-fortune-badge fortune-secondary">{{ fortune.text }}：{{ fortune_text }}</span>
+            {% elif fortune_text == '凶' %}
+                <span class="sign-fortune-badge fortune-orange">{{ fortune.text }}：{{ fortune_text }}</span>
+            {% elif fortune_text == '大凶' %}
+                <span class="sign-fortune-badge fortune-danger">{{ fortune.text }}：{{ fortune_text }}</span>
+            {% else %}
+                <span class="sign-fortune-badge fortune-secondary">{{ fortune.text }}：{{ fortune_text }}</span>
+            {% endif %}
+        </div>
     </div>
 </div>
-
 {% endblock body %}


### PR DESCRIPTION
## 改动内容

### 模板重写 (`sign.html.jinja`)
- 全新布局：头图 → 头像+标题栏 → 一言 → 数据表 → 排名/运势
- 头图使用 setu 插件图片作为背景（fallback 到默认随机图）
- 标题栏亚克力效果，左侧「签到成功」，右侧灰色日期（DD 格式）
- 数据变动：无边框表格展示 VimCoin / 经验 / 好感度
- 运势 Badge：六个等级各有专属颜色（大吉=金、吉=绿、小吉=青、末吉=灰、凶=橙、大凶=红）

### 插件改动 (`__main__.py`)
- 新增 `date` 变量传入模板
- 签到时调用 `get_image()` 获取 setu 图片，编码为 base64 data URI 作为 `background_url`
- 获取失败时 fallback 到默认背景，不影响签到流程

### 依赖 (`__init__.py`)
- 新增 `require("nonebot_plugin_larksetu")`

### 语言文件 (`sign.yaml`)
- `rank_text` 从 `第 {}` 改为 `{}`，适配新布局的「排名：X」格式

## 审查备注
- `nickname` / `uid` / `signdays` 在新模板中未展示（用户需求中未提及），数据仍在生成
- `fortune-dark` CSS 类已定义但当前未使用（预留扩展）
