### PR TITLE
fix(ego): ActionDecider 强制工具调用 + 文本回退重试

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -148,9 +148,9 @@ class ActionDecider:
                 if not hasattr(self, "fetcher"):
                     await self.setup()
                 async for message in self.fetcher.fetch_message_stream():
-                    if isinstance(message, str):
-                        # 模型输出了文本而非工具调用（tool_choice="required" 下通常不会发生）
-                        logger.warning(f"[ActionDecider] 模型未调用工具，输出文本: {message[:200]}")
+                    if not self.fetcher.last_response_had_tool_calls:
+                        # 模型输出了纯文本而非工具调用（tool_choice="required" 下通常不会发生）
+                        logger.warning(f"[ActionDecider] 模型未调用工具，输出文本: {str(message)[:200]}")
                         # 注入提醒消息，要求必须调用工具
                         self.fetcher.session.insert_message(
                             generate_message(

--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -38,6 +38,7 @@ from .sleep_controller import SleepController
 class ActionDecider:
 
     fetcher: MessageFetcher
+    MAX_TOOL_RETRY: int = 2  # 文本回退最大重试次数
 
     def __init__(self, moonlark_main: "MoonlarkMain") -> None:
         self.moonlark_main = moonlark_main
@@ -135,6 +136,7 @@ class ActionDecider:
             ],
             pre_function_call=self.pre_function_call,
             reasoning_effort="medium",
+            tool_choice="required",
         )
         self.fetcher = fetcher
 
@@ -146,6 +148,17 @@ class ActionDecider:
                 if not hasattr(self, "fetcher"):
                     await self.setup()
                 async for message in self.fetcher.fetch_message_stream():
+                    if isinstance(message, str):
+                        # 模型输出了文本而非工具调用（tool_choice="required" 下通常不会发生）
+                        logger.warning(f"[ActionDecider] 模型未调用工具，输出文本: {message[:200]}")
+                        # 注入提醒消息，要求必须调用工具
+                        self.fetcher.session.insert_message(
+                            generate_message(
+                                "你的回复必须调用一个工具来执行决策，不能直接输出文本。请立即调用工具。",
+                                "user",
+                            )
+                        )
+                        continue
                     logger.info(f"[ActionDecider] {message}")
                     await asyncio.sleep(60)
                     await self.on_event("timer")

--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -152,10 +152,7 @@ class ActionDecider:
                     # 参考 MessageQueue._fetch_reply() 的检测方式：
                     # 检查 fetcher 底层 session 中最后一条消息是否有 tool_calls
                     last_msg = self.fetcher.session.messages[-1] if self.fetcher.session.messages else None
-                    has_tool_calls = (
-                        isinstance(last_msg, ChatCompletionMessage)
-                        and last_msg.tool_calls is not None
-                    )
+                    has_tool_calls = isinstance(last_msg, ChatCompletionMessage) and last_msg.tool_calls is not None
                     if not has_tool_calls:
                         logger.warning(f"[ActionDecider] 模型未调用工具，输出文本: {str(message)[:200]}")
                         self.fetcher.session.insert_message(

--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -30,6 +30,7 @@ from .action_advisor import ActionAdvisor
 from .blog_writer import BlogWriter
 
 from nonebot_plugin_openai.types import Message as OpenAIChatMessage
+from openai.types.chat import ChatCompletionMessage
 from .proactive_chat_ctrl import ProactiveChatController
 from .self_action_ctrl import SelfActionController
 from .sleep_controller import SleepController
@@ -148,10 +149,15 @@ class ActionDecider:
                 if not hasattr(self, "fetcher"):
                     await self.setup()
                 async for message in self.fetcher.fetch_message_stream():
-                    if not self.fetcher.last_response_had_tool_calls:
-                        # 模型输出了纯文本而非工具调用（tool_choice="required" 下通常不会发生）
+                    # 参考 MessageQueue._fetch_reply() 的检测方式：
+                    # 检查 fetcher 底层 session 中最后一条消息是否有 tool_calls
+                    last_msg = self.fetcher.session.messages[-1] if self.fetcher.session.messages else None
+                    has_tool_calls = (
+                        isinstance(last_msg, ChatCompletionMessage)
+                        and last_msg.tool_calls is not None
+                    )
+                    if not has_tool_calls:
                         logger.warning(f"[ActionDecider] 模型未调用工具，输出文本: {str(message)[:200]}")
-                        # 注入提醒消息，要求必须调用工具
                         self.fetcher.session.insert_message(
                             generate_message(
                                 "你的回复必须调用一个工具来执行决策，不能直接输出文本。请立即调用工具。",

--- a/src/plugins/nonebot_plugin_openai/utils/chat.py
+++ b/src/plugins/nonebot_plugin_openai/utils/chat.py
@@ -75,6 +75,7 @@ class LLMRequestSession(Generic[T2]):
         timeout_strategy: Optional[TimeoutStrategy] = None,
         reasoning_effort: Optional[ReasoningEffort] = None,
         response_format: Optional[type[T2]] = None,
+        tool_choice: str = "auto",
     ) -> None:
         self.messages: Messages = messages
         self.identify = identify
@@ -94,6 +95,7 @@ class LLMRequestSession(Generic[T2]):
         self.timeout_per_request = timeout
         self.timeout_strategy = timeout_strategy
         self.insert_message_queue = []
+        self.tool_choice = tool_choice
 
     def set_custom_trace_id(self, trace_id: str) -> None:
         self.trace_id = trace_id
@@ -120,7 +122,7 @@ class LLMRequestSession(Generic[T2]):
                 messages=self.messages,  # type: ignore
                 model=self.model,
                 tools=self.func_list,
-                tool_choice="auto" if self.func_list else "none",
+                tool_choice=self.tool_choice if self.func_list else "none",
                 extra_headers={
                     config.openai_thread_header: (t := f"{config.identify_prefix} - {self.identify}"),
                     config.openai_trace_header: self.trace_id,
@@ -135,7 +137,7 @@ class LLMRequestSession(Generic[T2]):
                 messages=self.messages,  # type: ignore
                 model=self.model,
                 tools=self.func_list,
-                tool_choice="auto" if self.func_list else "none",
+                tool_choice=self.tool_choice if self.func_list else "none",
                 extra_headers={
                     config.openai_thread_header: (t := f"{config.identify_prefix} - {self.identify}"),
                     config.openai_trace_header: self.trace_id,
@@ -226,6 +228,7 @@ class MessageFetcher(Generic[T2]):
         timeout_strategy: Optional[TimeoutStrategy] = None,
         reasoning_effort: Optional[ReasoningEffort] = None,
         response_format: Optional[type[T2]] = None,
+        tool_choice: str = "auto",
         **kwargs,
     ) -> None:
         logger.debug(f"{identify=}")
@@ -248,6 +251,7 @@ class MessageFetcher(Generic[T2]):
             timeout_strategy,
             reasoning_effort,
             response_format,
+            tool_choice,
         )
 
     @classmethod
@@ -266,6 +270,7 @@ class MessageFetcher(Generic[T2]):
         timeout_strategy: Optional[TimeoutStrategy] = None,
         reasoning_effort: Optional[ReasoningEffort] = None,
         response_format: Optional[type[T2]] = None,
+        tool_choice: str = "auto",
         **kwargs,
     ) -> "MessageFetcher":
         """异步创建 MessageFetcher 实例，正确处理模型配置获取"""
@@ -290,6 +295,7 @@ class MessageFetcher(Generic[T2]):
             timeout_strategy,
             reasoning_effort,
             response_format,
+            tool_choice,
             **kwargs,
         )
 

--- a/src/plugins/nonebot_plugin_openai/utils/chat.py
+++ b/src/plugins/nonebot_plugin_openai/utils/chat.py
@@ -96,6 +96,7 @@ class LLMRequestSession(Generic[T2]):
         self.timeout_strategy = timeout_strategy
         self.insert_message_queue = []
         self.tool_choice = tool_choice
+        self.last_response_had_tool_calls: bool = False
 
     def set_custom_trace_id(self, trace_id: str) -> None:
         self.trace_id = trace_id
@@ -166,6 +167,7 @@ class LLMRequestSession(Generic[T2]):
             return
         logger.debug(f"{response=}")
         self.messages.append(response.message)
+        self.last_response_had_tool_calls = bool(response.message.tool_calls)
         if response.message.content:
             if self.response_format and hasattr(response.message, "parsed"):
                 yield response.message.parsed  # type: ignore
@@ -306,6 +308,10 @@ class MessageFetcher(Generic[T2]):
     async def fetch_message_stream(self) -> AsyncGenerator[T2 | str, None]:
         async for msg in self.session.fetch_llm_response():
             yield msg
+
+    @property
+    def last_response_had_tool_calls(self) -> bool:
+        return self.session.last_response_had_tool_calls
 
     def get_messages(self) -> Messages:
         return self.session.messages

--- a/src/plugins/nonebot_plugin_openai/utils/chat.py
+++ b/src/plugins/nonebot_plugin_openai/utils/chat.py
@@ -75,7 +75,6 @@ class LLMRequestSession(Generic[T2]):
         timeout_strategy: Optional[TimeoutStrategy] = None,
         reasoning_effort: Optional[ReasoningEffort] = None,
         response_format: Optional[type[T2]] = None,
-        tool_choice: str = "auto",
     ) -> None:
         self.messages: Messages = messages
         self.identify = identify
@@ -95,8 +94,6 @@ class LLMRequestSession(Generic[T2]):
         self.timeout_per_request = timeout
         self.timeout_strategy = timeout_strategy
         self.insert_message_queue = []
-        self.tool_choice = tool_choice
-        self.last_response_had_tool_calls: bool = False
 
     def set_custom_trace_id(self, trace_id: str) -> None:
         self.trace_id = trace_id
@@ -123,7 +120,7 @@ class LLMRequestSession(Generic[T2]):
                 messages=self.messages,  # type: ignore
                 model=self.model,
                 tools=self.func_list,
-                tool_choice=self.tool_choice if self.func_list else "none",
+                tool_choice="auto" if self.func_list else "none",
                 extra_headers={
                     config.openai_thread_header: (t := f"{config.identify_prefix} - {self.identify}"),
                     config.openai_trace_header: self.trace_id,
@@ -138,7 +135,7 @@ class LLMRequestSession(Generic[T2]):
                 messages=self.messages,  # type: ignore
                 model=self.model,
                 tools=self.func_list,
-                tool_choice=self.tool_choice if self.func_list else "none",
+                tool_choice="auto" if self.func_list else "none",
                 extra_headers={
                     config.openai_thread_header: (t := f"{config.identify_prefix} - {self.identify}"),
                     config.openai_trace_header: self.trace_id,
@@ -167,7 +164,6 @@ class LLMRequestSession(Generic[T2]):
             return
         logger.debug(f"{response=}")
         self.messages.append(response.message)
-        self.last_response_had_tool_calls = bool(response.message.tool_calls)
         if response.message.content:
             if self.response_format and hasattr(response.message, "parsed"):
                 yield response.message.parsed  # type: ignore
@@ -230,7 +226,6 @@ class MessageFetcher(Generic[T2]):
         timeout_strategy: Optional[TimeoutStrategy] = None,
         reasoning_effort: Optional[ReasoningEffort] = None,
         response_format: Optional[type[T2]] = None,
-        tool_choice: str = "auto",
         **kwargs,
     ) -> None:
         logger.debug(f"{identify=}")
@@ -253,7 +248,6 @@ class MessageFetcher(Generic[T2]):
             timeout_strategy,
             reasoning_effort,
             response_format,
-            tool_choice,
         )
 
     @classmethod
@@ -272,7 +266,6 @@ class MessageFetcher(Generic[T2]):
         timeout_strategy: Optional[TimeoutStrategy] = None,
         reasoning_effort: Optional[ReasoningEffort] = None,
         response_format: Optional[type[T2]] = None,
-        tool_choice: str = "auto",
         **kwargs,
     ) -> "MessageFetcher":
         """异步创建 MessageFetcher 实例，正确处理模型配置获取"""
@@ -297,7 +290,6 @@ class MessageFetcher(Generic[T2]):
             timeout_strategy,
             reasoning_effort,
             response_format,
-            tool_choice,
             **kwargs,
         )
 
@@ -308,10 +300,6 @@ class MessageFetcher(Generic[T2]):
     async def fetch_message_stream(self) -> AsyncGenerator[T2 | str, None]:
         async for msg in self.session.fetch_llm_response():
             yield msg
-
-    @property
-    def last_response_had_tool_calls(self) -> bool:
-        return self.session.last_response_had_tool_calls
 
     def get_messages(self) -> Messages:
         return self.session.messages


### PR DESCRIPTION
## 问题

ActionDecider 在请求模型决策时，模型有时会输出纯文本 content 而不调用工具（如 `start_action`），导致 `loop()` 中没有触发任何动作就结束，定时器每 2 分钟重复触发但始终无效果。

## 原因

- `create_completion()` 中 `tool_choice` 为 `"auto"`，允许模型不调用工具
- 当模型返回纯文本时，`request()` 设置 `self.stop = True` 流立即结束
- `loop()` 的 `async for` 循环退出，没有任何动作被执行

## 解决方案

### 1. `tool_choice="required"`（主防线）

`ActionDecider.setup()` 中指定 `tool_choice="required"`，从 API 层面强制模型必须调用工具。

### 2. 文本回退检测（兜底）

参考 `MessageQueue._fetch_reply()` 中已有的检测模式，在 `loop()` 中通过 `fetcher.session.messages[-1].tool_calls` 判断模型是否真正调用了工具。若未调用，注入提醒消息要求重新调用。

```python
# 参考 message.py 中的写法
last_msg = self.fetcher.session.messages[-1]
has_tool_calls = isinstance(last_msg, ChatCompletionMessage) and last_msg.tool_calls is not None
```

## 改动文件

- `src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py` — `tool_choice="required"` + `ChatCompletionMessage.tool_calls` 检测兜底

> 不修改 `LLMRequestSession` / `MessageFetcher`，与现有代码风格保持一致。