### PR TITLE
fix(chat): 修复私聊戳一戳和 ActionDecider 的两个 bug

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -146,7 +146,7 @@ class ActionDecider:
             return
         async with self.lock:
             try:
-                if not hasattr(self, "fetcher"):
+                if getattr(self, "fetcher", None) is None:
                     await self.setup()
                 async for message in self.fetcher.fetch_message_stream():
                     # 检查 sleep 工具是否已被触发（工具调用过程中设置 sleep_mode=True）
@@ -208,7 +208,7 @@ class ActionDecider:
         if self.loop_task is not None:
             self.loop_task.cancel()
             self.loop_task = None
-        # 清除 fetcher，使下次 loop() 调用时通过 hasattr 检测重新 setup
+        # 清除 fetcher，使下次 loop() 调用时通过 getattr 检测重新 setup
         self.fetcher = None
 
 

--- a/src/plugins/nonebot_plugin_chat/core/matchers.py
+++ b/src/plugins/nonebot_plugin_chat/core/matchers.py
@@ -127,7 +127,10 @@ async def _(
     moonlark_group_id: str = get_group_id(),
     user_id: str = get_user_id(),
 ) -> None:
-    session = await create_group_session(moonlark_group_id, get_target(event), bot)
+    if event.group_id is not None:
+        session = await create_group_session(moonlark_group_id, get_target(event), bot)
+    else:
+        session = await create_private_session(user_id, get_target(event), bot)
     nickname = await get_nickname(user_id, bot, event)
     await session.handle_poke(event, nickname)
 


### PR DESCRIPTION
## 修复内容

### Bug 1: 私聊戳一戳错误创建 GroupSession

**`core/matchers.py`**

PokeNotifyEvent handler 没有过滤私聊场景，导致私聊戳一戳时创建了 `GroupSession` 而非 `PrivateSession`。
根据 nonebot-adapter-onebot v2.4.6 的模型定义，`PokeNotifyEvent.group_id` 在私聊时为 `None`，用 `event.group_id is not None` 来分流。

### Bug 2: ActionDecider 中 `hasattr` 不处理 `fetcher` 为 None

**`core/ego/moonlark_main.py`**

`reset()` 设置 `self.fetcher = None` 后，`loop()` 中的 `if not hasattr(self, "fetcher")` 仍返回 `True`（hasattr 在 attribute 值为 None 时也返回 True），导致不会重新 setup。改为 `if getattr(self, "fetcher", None) is None`。