### PR TITLE
fix(ego): 修复 ActionDecider timer 在纯 tool_calls 场景下不注入的问题

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -136,10 +136,21 @@ class ActionDecider:
                 ),
             ],
             pre_function_call=self.pre_function_call,
+            on_tool_round_complete=self._on_tool_round,
             reasoning_effort="medium",
             tool_choice="required",
         )
         self.fetcher = fetcher
+
+    async def _on_tool_round(self) -> None:
+        """工具调用完成但模型未输出文本时的回调。
+
+        当 request() 不 yield（content 为空）时，loop() 拿不到控制权，
+        此回调在 insert_message_queue flush 之前执行，确保 timer 消息能注入上下文。
+        """
+        logger.info("[ActionDecider] 工具调用完成（无文本输出），等待 60 秒后注入 timer")
+        await asyncio.sleep(60)
+        await self.on_event("timer")
 
     async def loop(self) -> None:
         if self.lock.locked():

--- a/src/plugins/nonebot_plugin_openai/utils/chat.py
+++ b/src/plugins/nonebot_plugin_openai/utils/chat.py
@@ -75,9 +75,11 @@ class LLMRequestSession(Generic[T2]):
         timeout_strategy: Optional[TimeoutStrategy] = None,
         reasoning_effort: Optional[ReasoningEffort] = None,
         response_format: Optional[type[T2]] = None,
+        on_tool_round_complete: Optional[Callable[[], Awaitable[None]]] = None,
     ) -> None:
         self.messages: Messages = messages
         self.identify = identify
+        self.on_tool_round_complete = on_tool_round_complete
         self.func_list = generate_function_list(func_index)
         self.func_index = func_index
         self.tool_choice = kwargs.pop("tool_choice", "auto")
@@ -95,6 +97,7 @@ class LLMRequestSession(Generic[T2]):
         self.timeout_per_request = timeout
         self.timeout_strategy = timeout_strategy
         self.insert_message_queue = []
+        self._content_yielded = False
 
     def set_custom_trace_id(self, trace_id: str) -> None:
         self.trace_id = trace_id
@@ -166,7 +169,9 @@ class LLMRequestSession(Generic[T2]):
             return
         logger.debug(f"{response=}")
         self.messages.append(response.message)
+        self._content_yielded = False
         if response.message.content:
+            self._content_yielded = True
             if self.response_format and hasattr(response.message, "parsed"):
                 yield response.message.parsed  # type: ignore
             else:
@@ -175,6 +180,8 @@ class LLMRequestSession(Generic[T2]):
             for request in response.message.tool_calls:
                 if isinstance(request, ChatCompletionMessageFunctionToolCall):
                     await self.call_function(request.id, request.function.name, json.loads(request.function.arguments))
+            if not self._content_yielded and self.on_tool_round_complete:
+                await self.on_tool_round_complete()
         elif not self.insert_message_queue:
             self.stop = True
         self.messages.extend(self.insert_message_queue)
@@ -228,6 +235,7 @@ class MessageFetcher(Generic[T2]):
         timeout_strategy: Optional[TimeoutStrategy] = None,
         reasoning_effort: Optional[ReasoningEffort] = None,
         response_format: Optional[type[T2]] = None,
+        on_tool_round_complete: Optional[Callable[[], Awaitable[None]]] = None,
         **kwargs,
     ) -> None:
         logger.debug(f"{identify=}")
@@ -250,6 +258,7 @@ class MessageFetcher(Generic[T2]):
             timeout_strategy,
             reasoning_effort,
             response_format,
+            on_tool_round_complete,
         )
 
     @classmethod
@@ -268,6 +277,7 @@ class MessageFetcher(Generic[T2]):
         timeout_strategy: Optional[TimeoutStrategy] = None,
         reasoning_effort: Optional[ReasoningEffort] = None,
         response_format: Optional[type[T2]] = None,
+        on_tool_round_complete: Optional[Callable[[], Awaitable[None]]] = None,
         **kwargs,
     ) -> "MessageFetcher":
         """异步创建 MessageFetcher 实例，正确处理模型配置获取"""
@@ -292,6 +302,7 @@ class MessageFetcher(Generic[T2]):
             timeout_strategy,
             reasoning_effort,
             response_format,
+            on_tool_round_complete,
             **kwargs,
         )
 


### PR DESCRIPTION
## 问题

`LLMRequestSession.request()` 只在 `response.message.content` 非空时 yield。当 `tool_choice="required"` + reasoning 模型返回纯 tool_calls（`content: null`）时，`request()` 不 yield，`loop()` 永远拿不到控制权，导致：

1. `sleep(60)` 不生效 — 工具调用间无间隔
2. `on_event("timer")` 不执行 — timer 消息不注入上下文
3. ActionDecider 上下文中无 `[user] timer`（仅第一个请求有，后续全无）
4. 潜在无限循环 — 模型持续返回 tool_calls 时 stream 不会停

## 修复

在 `LLMRequestSession` / `MessageFetcher` 上新增 `on_tool_round_complete` 可选回调。

- 当 `request()` 执行完一轮 tool call 且**没有** yield content 时，调用此回调
- 回调在 `insert_message_queue.flush` **之前**执行，允许注入消息到下一次 API 请求
- `ActionDecider.setup()` 注册回调：`sleep(60)` → `on_event("timer")`
- `loop()` 中原有的 timer 逻辑保留（处理有 content 的情况）

两条路径互补：
- **有 content** → `request()` yield → `loop()` 拿到控制权 → `loop()` 插入 timer ✓
- **无 content** → `request()` 不 yield → 回调触发 → 注入 timer ✓

## 改动文件

- `src/plugins/nonebot_plugin_openai/utils/chat.py` — 新增 `on_tool_round_complete` 参数
- `src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py` — 注册回调