### PR TITLE
feat(chat): 合并转发超长消息自动总结

### DIFF
--- a/src/lang/en_us/chat.yaml
+++ b/src/lang/en_us/chat.yaml
@@ -996,6 +996,9 @@ parser:
     not_supported: '[合并转发：获取信息失败（不支持）]'
     failed: '[合并转发：获取信息失败（{}）]'
     forward: '[合并转发：{}]'
+    summary: '[合并转发（消息过多，已总结）：{}]'
+    summary_prompt: |
+      You are a chat log summarization assistant. Please provide a concise summary of the following forwarded chat messages, keeping key information and main topics.
   reply: '[回复: {}]'
   reply_with_sender: '[回复: {} (来自 {})]'
   reply_failed: '[回复: 获取信息失败]'

--- a/src/lang/zh_hans/chat.yaml
+++ b/src/lang/zh_hans/chat.yaml
@@ -1049,6 +1049,9 @@ parser:
     not_supported: '[合并转发：获取信息失败（不支持）]'
     failed: '[合并转发：获取信息失败（{}）]'
     forward: '[合并转发：{}]'
+    summary: '[合并转发（消息过多，已总结）：{}]'
+    summary_prompt: |
+      你是一位聊天记录总结助手。请对以下合并转发的聊天记录进行简洁的总结，保留关键信息和主要话题。
   reply: '[回复: {}]'
   reply_with_sender: '[回复: {} (来自 {})]'
   reply_failed: '[回复: 获取信息失败]'

--- a/src/lang/zh_tw/chat.yaml
+++ b/src/lang/zh_tw/chat.yaml
@@ -993,9 +993,12 @@ parser:
   image_without_desc: '[图片({})]'
   poke: '[戳一戳]'
   forward:
-    not_supported: '[合并转发：获取信息失败（不支持）]'
-    failed: '[合并转发：获取信息失败（{}）]'
-    forward: '[合并转发：{}]'
+    not_supported: '[合併轉發：獲取信息失敗（不支持）]'
+    failed: '[合併轉發：獲取信息失敗（{}）]'
+    forward: '[合併轉發：{}]'
+    summary: '[合併轉發（消息過多，已總結）：{}]'
+    summary_prompt: |
+      你是一位聊天記錄總結助手。請對以下合併轉發的聊天記錄進行簡潔的總結，保留關鍵信息和主要話題。
   reply: '[回复: {}]'
   reply_with_sender: '[回复: {} (来自 {})]'
   reply_failed: '[回复: 获取信息失败]'

--- a/src/plugins/nonebot_plugin_chat/config.py
+++ b/src/plugins/nonebot_plugin_chat/config.py
@@ -26,6 +26,8 @@ class Config(BaseModel):
     moonlark_api_base: str = "http://localhost:8080"  # Moonlark API 基础地址
     rua_reaction_config: RuaReactionConfig = RuaReactionConfig()
     judge_reaction_config: JudgeReactionConfig = JudgeReactionConfig()
+    # 合并转发消息自动总结阈值（字符数），超过此长度的转发消息将调用 AI 生成摘要
+    forward_summary_threshold: int = 2000
 
 
 config = get_plugin_config(Config)

--- a/src/plugins/nonebot_plugin_chat/utils/message.py
+++ b/src/plugins/nonebot_plugin_chat/utils/message.py
@@ -31,10 +31,10 @@ from nonebot.adapters.onebot.v11 import MessageSegment as OneBotV11Segment
 
 from nonebot_plugin_openai import fetch_message, generate_message
 
+from nonebot_plugin_chat.config import config
+
 from .image import generate_image_id, get_image_summary
 from .file import get_file_summary
-
-FORWARD_SUMMARY_THRESHOLD = 2000
 
 
 class MessageParser:
@@ -105,7 +105,7 @@ class MessageParser:
             message_list_str = await self.get_forawrd_message_list(ref_id)
         except ActionFailed as e:
             return await lang.text("parser.forward.failed", self.user_id, e)
-        if len(message_list_str) > FORWARD_SUMMARY_THRESHOLD:
+        if len(message_list_str) > config.forward_summary_threshold:
             try:
                 summary = await fetch_message(
                     [

--- a/src/plugins/nonebot_plugin_chat/utils/message.py
+++ b/src/plugins/nonebot_plugin_chat/utils/message.py
@@ -29,8 +29,12 @@ from nonebot.adapters.onebot.v11 import Message as OneBotV11Message
 from nonebot.adapters.onebot.v11 import MessageSegment as OneBotV11Segment
 
 
+from nonebot_plugin_openai import fetch_message, generate_message
+
 from .image import generate_image_id, get_image_summary
 from .file import get_file_summary
+
+FORWARD_SUMMARY_THRESHOLD = 2000
 
 
 class MessageParser:
@@ -101,6 +105,21 @@ class MessageParser:
             message_list_str = await self.get_forawrd_message_list(ref_id)
         except ActionFailed as e:
             return await lang.text("parser.forward.failed", self.user_id, e)
+        if len(message_list_str) > FORWARD_SUMMARY_THRESHOLD:
+            try:
+                summary = await fetch_message(
+                    [
+                        generate_message(
+                            await lang.text("parser.forward.summary_prompt", self.user_id),
+                            "system",
+                        ),
+                        generate_message(message_list_str, "user"),
+                    ],
+                    identify="Forward Message Summary",
+                )
+                return await lang.text("parser.forward.summary", self.user_id, summary)
+            except Exception:
+                logger.warning("Forward message summary failed, falling back to full list")
         return await lang.text("parser.forward.forward", self.user_id, message_list_str)
 
     async def get_forawrd_message_list(


### PR DESCRIPTION
## 改动说明

当合并转发的消息列表超过 2000 字时，自动调用 AI 生成摘要替代完整消息列表显示。若总结失败则回退显示完整列表。

### 改动内容

- ：添加  常量，在  中增加字数判断 + AI 总结逻辑
- ：添加  和  语言键
- ：同上（英文 prompt）
- ：同上（繁体中文），同时修正原有 forward 文案为繁体字

### 逻辑流程

