### PR TITLE
refactor(chat): 移除 self_action_ctrl 中多余的 identity_prompt 注入

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/ego/self_action_ctrl.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/self_action_ctrl.py
@@ -20,7 +20,6 @@ from nonebot_plugin_openai.utils.message import generate_message
 
 from ...lang import lang
 from ...models import SelfActionDurationResponse, TaskClassificationResponse
-from ...utils.prompt import get_prompt_text
 from ...utils.tool_manager import ToolManager
 
 if TYPE_CHECKING:
@@ -131,10 +130,9 @@ class SelfActionController:
             self._task = None
 
     async def get_task_duration(self, activity: str) -> int:
-        identity_prompt = await get_prompt_text("identity")
         response = await fetch_json(
             [
-                generate_message(await lang.text("self_action.duration.system", self.lang, identity_prompt), "system"),
+                generate_message(await lang.text("self_action.duration.system", self.lang), "system"),
                 generate_message(await lang.text("self_action.duration.user", self.lang, activity), "user"),
             ],
             SelfActionDurationResponse,
@@ -143,11 +141,10 @@ class SelfActionController:
         return response.duration_minutes
 
     async def get_task_type(self, activity: str) -> ActionType:
-        identity_prompt = await get_prompt_text("identity")
         response = await fetch_json(
             [
                 generate_message(
-                    await lang.text("moonlark_main.task_classification.prompt", self.lang, identity_prompt),
+                    await lang.text("moonlark_main.task_classification.prompt", self.lang),
                     "system",
                 ),
                 generate_message(


### PR DESCRIPTION
## 改动内容

#1180 合并时误将 `identity_prompt`（角色身份 prompt）注入到 `get_task_duration()` 和 `get_task_type()` 的 `lang.text()` 调用中，但 YAML 模板没有对应的 `{0}` 占位符，导致该参数被静默忽略。

这里提到的 `identity` 实际上是 `nonebot_plugin_openai` 插件中 `fetch_json` 的 **`identify` 参数**（应用识别名，用于日志追踪），而非角色身份 prompt。`identify` 参数已在 #1180 中正确添加。

### 移除内容

- 删除 `get_task_duration()` 和 `get_task_type()` 中的 `identity_prompt = await get_prompt_text("identity")`
- 删除 `lang.text()` 调用中多余的 `identity_prompt` 参数
- 删除不再使用的 `from ...utils.prompt import get_prompt_text` 导入
