### PR TITLE
feat(jrrp): implement June luck bias and beyond perfect luck state

### DIFF
--- a/src/lang/en_us/jrrp.yaml
+++ b/src/lang/en_us/jrrp.yaml
@@ -1,5 +1,6 @@
 message:
   __template__: '你今天的人品值是: {{}}{}'
+  beyond_perfect: '！！突破天際！！！'
   perfect_luck: '！100！100！！！'
   almost_perfect: '！可惜不是 100'
   great_day: '，是不错的一天呢！'
@@ -33,6 +34,7 @@ group_event_prompt: |
 reroll:
   max_reached: 你今天已经重算过 {} 次了，明天再来吧～
   perfect_luck: 你今天的人品值已经是 100 了，不需要再重算啦～
+  beyond_perfect: 你今天的人品值已经突破 100 了，不需要再重算啦～
   insufficient_vimcoin: 你的 VimCoin 不足哦，需要 {} vi，但你只有 {} vi。
   success: |
     今日已重算: {}/{} 次

--- a/src/lang/zh_hans/jrrp.yaml
+++ b/src/lang/zh_hans/jrrp.yaml
@@ -1,5 +1,6 @@
 message:
   __template__: '你今天的人品值是: {{}}{}'
+  beyond_perfect: '！！突破天际！！！'
   perfect_luck: ！100！100！！！
   almost_perfect: ！可惜不是 100
   great_day: ，是不错的一天呢！
@@ -33,6 +34,7 @@ group_event_prompt: |
 reroll:
   max_reached: 你今天已经重算过 {} 次了，明天再来吧～
   perfect_luck: 你今天的人品值已经是 100 了，不需要再重算啦～
+  beyond_perfect: 你今天的人品值已经突破 100 了，不需要再重算啦～
   insufficient_vimcoin: 你的 VimCoin 不足哦，需要 {} vi，但你只有 {} vi。
   success: |
     今日已重算: {}/{} 次

--- a/src/lang/zh_tw/jrrp.yaml
+++ b/src/lang/zh_tw/jrrp.yaml
@@ -1,5 +1,6 @@
 message:
   __template__: '你今天的人品值是: {{}}{}'
+  beyond_perfect: '！！突破天際！！！'
   perfect_luck: '！100！100！！！'
   almost_perfect: '！可惜不是 100'
   great_day: '，是不错的一天呢！'
@@ -33,6 +34,7 @@ group_event_prompt: |
 reroll:
   max_reached: 你今天已经重算过 {} 次了，明天再来吧～
   perfect_luck: 你今天的人品值已经是 100 了，不需要再重算啦～
+  beyond_perfect: 你今天的人品值已经突破 100 了，不需要再重算啦～
   insufficient_vimcoin: 你的 VimCoin 不足哦，需要 {} vi，但你只有 {} vi。
   success: |
     今日已重算: {}/{} 次

--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -54,7 +54,9 @@ class ActionDecider:
 
     async def create_fetcher(self) -> MessageFetcher:
         messages = [
-            await get_message("system", "moonlark_main/system.md.jinja", friends=await self.moonlark_main.get_friends()),
+            await get_message(
+                "system", "moonlark_main/system.md.jinja", friends=await self.moonlark_main.get_friends()
+            ),
             await self.generate_message(
                 ("online\n\n" "## 今日已进行的动作\n" f"{await self.moonlark_main._get_today_actions_text()}")
             ),

--- a/src/plugins/nonebot_plugin_jrrp/__main__.py
+++ b/src/plugins/nonebot_plugin_jrrp/__main__.py
@@ -61,7 +61,9 @@ async def _(bot: Bot, event: Event, user_id: str = get_user_id(), group_id: str 
     # 重新计算人品值
     result = await reroll_luck_value(user_id, MAX_REROLL_COUNT)
     if result is None:
-        if current_luck == 100:
+        if current_luck > 100:
+            await lang.finish("reroll.beyond_perfect", user_id, at_sender=True)
+        elif current_luck == 100:
             await lang.finish("reroll.perfect_luck", user_id, at_sender=True)
         else:
             await lang.finish("reroll.max_reached", user_id, MAX_REROLL_COUNT, at_sender=True)

--- a/src/plugins/nonebot_plugin_jrrp/types.py
+++ b/src/plugins/nonebot_plugin_jrrp/types.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class LuckType(Enum):
+    BEYOND_PERFECT = 0  # >100
     PERFECT_LUCK = 1  # 100
     ALMOST_PERFECT = 2  # 99
     GREAT_DAY = 3  # 85-98

--- a/src/plugins/nonebot_plugin_jrrp/utils.py
+++ b/src/plugins/nonebot_plugin_jrrp/utils.py
@@ -4,6 +4,8 @@ from .types import LuckType
 
 
 def get_luck_type(luck_value: int) -> LuckType:
+    if luck_value > 100:
+        return LuckType.BEYOND_PERFECT
     if luck_value == 100:
         return LuckType.PERFECT_LUCK
     elif luck_value == 99:

--- a/src/plugins/nonebot_plugin_larkutils/jrrp.py
+++ b/src/plugins/nonebot_plugin_larkutils/jrrp.py
@@ -14,14 +14,20 @@ class LuckValue(Model):
     reroll_count: Mapped[int] = mapped_column(default=0)
 
 
+def _get_june_bias() -> int:
+    today = date.today()
+    return 50 if today.month == 6 and 1 <= today.day <= 15 else 0
+
+
 async def get_luck_value(user_id: str) -> int:
+    bias = _get_june_bias()
     async with get_session() as session:
         value = await session.get(LuckValue, {"user_id": user_id})
         if value is not None and value.generate_date == date.today():
             return value.luck_value
         value = LuckValue(
             user_id=user_id,
-            luck_value=(luck_value := struct.unpack("<I", os.urandom(4))[0] % 101),
+            luck_value=(luck_value := struct.unpack("<I", os.urandom(4))[0] % 101 + bias),
             generate_date=date.today(),
             reroll_count=0,
         )
@@ -32,11 +38,12 @@ async def get_luck_value(user_id: str) -> int:
 
 async def get_luck_value_with_reroll_count(user_id: str) -> Tuple[int, int]:
     """获取用户今日人品值和已重算次数"""
+    bias = _get_june_bias()
     async with get_session() as session:
         value = await session.get(LuckValue, {"user_id": user_id})
         if value is not None and value.generate_date == date.today():
             return value.luck_value, value.reroll_count
-        luck_value = struct.unpack("<I", os.urandom(4))[0] % 101
+        luck_value = struct.unpack("<I", os.urandom(4))[0] % 101 + bias
         value = LuckValue(
             user_id=user_id,
             luck_value=luck_value,
@@ -56,19 +63,22 @@ async def reroll_luck_value(user_id: str, max_reroll_count: int) -> Optional[Tup
         user_id: 用户 ID
         max_reroll_count: 最大重算次数
 
-    返回: (新的人品值, 已重算次数) 或 None（如果已达到重算上限或人品值为100）
+    返回: (新的人品值, 已重算次数) 或 None（如果已达到重算上限或人品值为最大值）
 
     reroll 规则:
-        - 人品值为 0: 50% 留在 0，50% 随机 reroll
-        - 人品值为 1-99: 50% reroll 到更高值，50% reroll 到更低值
-        - 人品值为 100: 禁止 reroll
+        - 人品值为 0（仅无偏移时）: 50% 留在 0，50% 随机 reroll
+        - 人品值在正常范围内: 50% reroll 到更高值，50% reroll 到更低值
+        - 人品值达到最大值: 禁止 reroll
     """
+    bias = _get_june_bias()
+    max_luck = 100 + bias
+
     async with get_session() as session:
         value = await session.get(LuckValue, {"user_id": user_id})
 
         # 如果没有记录或不是今天的记录，先创建今日记录
         if value is None or value.generate_date != date.today():
-            new_luck_value = struct.unpack("<I", os.urandom(4))[0] % 101
+            new_luck_value = struct.unpack("<I", os.urandom(4))[0] % 101 + bias
             value = LuckValue(
                 user_id=user_id,
                 luck_value=new_luck_value,
@@ -83,30 +93,31 @@ async def reroll_luck_value(user_id: str, max_reroll_count: int) -> Optional[Tup
         if value.reroll_count >= max_reroll_count:
             return None
 
-        # 人品值为 100 时禁止 reroll
-        if value.luck_value == 100:
+        # 人品值达到最大值时禁止 reroll
+        if value.luck_value >= max_luck:
             return None
 
         current_luck = value.luck_value
 
         # 根据当前人品值应用不同的 reroll 规则
-        if current_luck == 0:
+        if current_luck == 0 and bias == 0:
             # 50% 留在 0，50% 随机 reroll
             if struct.unpack("<I", os.urandom(4))[0] % 2 == 0:
                 new_luck_value = 0
             else:
-                new_luck_value = struct.unpack("<I", os.urandom(4))[0] % 101
-        elif 1 <= current_luck <= 99:
+                new_luck_value = struct.unpack("<I", os.urandom(4))[0] % 101 + bias
+        else:
             # 50% reroll 到更高值，50% reroll 到更低值
             if struct.unpack("<I", os.urandom(4))[0] % 2 == 0:
-                # reroll 到更高值 (current_luck+1 到 100)
-                new_luck_value = current_luck + 1 + (struct.unpack("<I", os.urandom(4))[0] % (100 - current_luck))
+                # reroll 到更高值 (current_luck+1 到 max_luck)
+                new_luck_value = current_luck + 1 + (struct.unpack("<I", os.urandom(4))[0] % (max_luck - current_luck))
             else:
-                # reroll 到更低值 (0 到 current_luck-1)
-                if current_luck > 1:
-                    new_luck_value = struct.unpack("<I", os.urandom(4))[0] % current_luck
+                # reroll 到更低值 (bias 到 current_luck-1)
+                range_size = current_luck - bias
+                if range_size > 1:
+                    new_luck_value = bias + struct.unpack("<I", os.urandom(4))[0] % range_size
                 else:
-                    new_luck_value = 0
+                    new_luck_value = bias
 
         value.luck_value = new_luck_value
         value.reroll_count += 1

--- a/src/plugins/nonebot_plugin_sign/__main__.py
+++ b/src/plugins/nonebot_plugin_sign/__main__.py
@@ -55,7 +55,7 @@ class SignClaimData(TypedDict):
 
 async def get_luck(user_id: str) -> str:
     value = await get_luck_value(user_id)
-    if 80 < value <= 100:
+    if 80 < value:
         return "a"
     elif 60 < value <= 80:
         return "b"


### PR DESCRIPTION
Introduce a special luck bias for the first half of June, allowing luck values to exceed 100. This includes new localization strings, a new `LuckType` for values above 100, and updated reroll logic to handle the increased maximum value.

- Add `BEYOND_PERFECT` luck type and corresponding localization strings
- Implement `_get_june_bias` to add +50 luck during June 1st-15th
- Update reroll logic to allow rerolling when luck is 100 if bias is active
- Adjust `nonebot_plugin_sign` to handle luck values > 100