### PR TITLE
feat(diary): 日记存入 DiaryPost 独立表

### DIFF
--- a/migrations/versions/b4c5d6e7f8a9_add_diarypost_table.py
+++ b/migrations/versions/b4c5d6e7f8a9_add_diarypost_table.py
@@ -1,0 +1,69 @@
+"""add_diarypost table and migrate diary data from note
+
+迁移 ID: b4c5d6e7f8a9
+父迁移: a3f8c2d1e5b7
+创建时间: 2026-06-08 15:20:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b4c5d6e7f8a9"
+down_revision: str | Sequence[str] | None = "a3f8c2d1e5b7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+DIARYPOST_TABLE = "nonebot_plugin_chat_diarypost"
+NOTE_TABLE = "nonebot_plugin_chat_note"
+DIARY_CONTEXT_ID = "moonlark_diary"
+
+
+def upgrade(name: str = "") -> None:
+    if name:
+        return
+
+    # 1. 创建 DiaryPost 表
+    op.create_table(
+        DIARYPOST_TABLE,
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("title", sa.String(256), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("keywords", sa.String(256), server_default="", nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("expire_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table(DIARYPOST_TABLE, schema=None) as batch_op:
+        batch_op.create_index(f"ix_{DIARYPOST_TABLE}_created_at", ["created_at"])
+
+    # 2. 将 note 表中 context_id='moonlark_diary' 的数据迁移到 diarypost
+    #    title 从 keywords 中取（日期 + "日记"），expire_time 映射到 expire_at
+    op.execute(f"""
+        INSERT INTO {DIARYPOST_TABLE} (title, content, keywords, created_at, expire_at)
+        SELECT
+            COALESCE(keywords, '') AS title,
+            content,
+            COALESCE(keywords, ''),
+            datetime(created_time, 'unixepoch', 'localtime'),
+            expire_time
+        FROM {NOTE_TABLE}
+        WHERE context_id = '{DIARY_CONTEXT_ID}'
+    """)
+
+    # 3. 删除已迁移的 note 记录
+    op.execute(f"DELETE FROM {NOTE_TABLE} WHERE context_id = '{DIARY_CONTEXT_ID}'")
+
+
+def downgrade(name: str = "") -> None:
+    if name:
+        return
+    with op.batch_alter_table(DIARYPOST_TABLE, schema=None) as batch_op:
+        batch_op.drop_index(f"ix_{DIARYPOST_TABLE}_created_at")
+
+    op.drop_table(DIARYPOST_TABLE)

--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -21,6 +21,7 @@ from ...lang import lang
 from ...models import (
     ActionDecisionResponse,
     DiaryEntry,
+    DiaryPost,
     DiaryProcessResponse,
     MainSessionActionHistory,
     PrivateChatSession,
@@ -430,7 +431,7 @@ class MoonlarkMain:
     # ========================================================================
 
     async def generate_diary(self) -> None:
-        """每日凌晨 2 点生成日记并写入笔记"""
+        """每日凌晨 2 点生成日记并写入 DiaryPost 表"""
         try:
             # 1. 读取近 24h 的日记条目
             entries = await self._fetch_diary_entries(hours=24)
@@ -462,16 +463,23 @@ class MoonlarkMain:
                 reasoning_effort="low",
             )
 
-            # 6. 写入笔记
-            from ...utils.note_manager import NoteManager
+            # 5. 计算过期时间
+            from datetime import timedelta
 
-            note_manager = NoteManager("moonlark_diary")
-            await note_manager.create_note(
-                content=diary_text,
-                keywords=processed.keywords,
-                expire_hours=processed.expire_hours,
-            )
-            logger.info(f"[Diary] 日记已生成并存入笔记: {processed.keywords}")
+            expire_at = datetime.now() + timedelta(hours=processed.expire_hours)
+
+            # 6. 写入 DiaryPost 表
+            title = date.today().strftime("%Y-%m-%d") + " 日记"
+            async with get_session() as session:
+                diary_post = DiaryPost(
+                    title=title,
+                    content=diary_text,
+                    keywords=processed.keywords,
+                    expire_at=expire_at,
+                )
+                session.add(diary_post)
+                await session.commit()
+            logger.info(f"[Diary] 日记已生成并存入 DiaryPost: {processed.keywords}")
 
             # 7. 清理已使用的日记条目
             await self._cleanup_diary_entries(before=entries[-1].created_at)

--- a/src/plugins/nonebot_plugin_chat/models.py
+++ b/src/plugins/nonebot_plugin_chat/models.py
@@ -268,6 +268,17 @@ class DiaryEntry(Model):
     content: Mapped[str] = mapped_column(Text())
 
 
+class DiaryPost(Model):
+    """生成的日记存储表，由每日凌晨任务自动生成"""
+
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(256))
+    content: Mapped[str] = mapped_column(Text())
+    keywords: Mapped[str] = mapped_column(String(256), default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime(), server_default=func.now(), index=True)
+    expire_at: Mapped[Optional[datetime]] = mapped_column(DateTime(), nullable=True)
+
+
 class DiaryProcessResponse(BaseModel):
     """日记处理 LLM 返回格式（关键词 + 过期时间）"""
 


### PR DESCRIPTION
## 改动

- **新增 `DiaryPost` 模型**：独立的日记存储表，包含 `title / content / keywords / created_at / expire_at`
- **修改 `generate_diary()`**：不再写入 `Note` 表（`NoteManager("moonlark_diary")`），改为直接写入 `DiaryPost`
- **数据迁移**：建表后自动将 `note` 表中 `context_id = 'moonlark_diary'` 的记录导入 `diarypost`，并清理旧数据