### PR TITLE
feat(chat): pass specific current_time to diary generation

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -443,7 +443,14 @@ class MoonlarkMain:
             context = self._format_diary_context(entries)
 
             # 3. 第一次调用：生成日记正文
-            diary_messages = await get_messages("diary", context=context)
+            # 使用最后一次睡眠时间作为日记时间
+            diary_time = self.sleep_controller.sleep_begin_time
+            if diary_time:
+                diary_time_str = diary_time.strftime("%Y-%m-%d %H:%M:%S")
+            else:
+                diary_time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            
+            diary_messages = await get_messages("diary", context=context, current_time=diary_time_str)
             diary_text = await fetch_message(
                 diary_messages,
                 identify="MoonlarkMain - Generate Diary",

--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -449,7 +449,7 @@ class MoonlarkMain:
                 diary_time_str = diary_time.strftime("%Y-%m-%d %H:%M:%S")
             else:
                 diary_time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            
+
             diary_messages = await get_messages("diary", context=context, current_time=diary_time_str)
             diary_text = await fetch_message(
                 diary_messages,

--- a/src/plugins/nonebot_plugin_openai/utils/message.py
+++ b/src/plugins/nonebot_plugin_openai/utils/message.py
@@ -62,7 +62,9 @@ def generate_message(content: str | list, role: Literal["system", "user", "assis
 
 async def get_message_text(name: str, **kwargs) -> str:
     template = env.get_template(name)
-    kwargs["current_time"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    # 只在未提供 current_time 时才使用当前时间
+    if "current_time" not in kwargs:
+        kwargs["current_time"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     return await template.render_async(**kwargs)
 
 


### PR DESCRIPTION
Pass the sleep start time as the `current_time` when generating diary messages in `MoonlarkMain`. Update `get_message_text` to only default to the current system time if `current_time` is not explicitly provided in the arguments.