### PR TITLE
fix(command_stats): allow empty matcher type for AlconnaMatchers

### DIFF
--- a/src/plugins/nonebot_plugin_command_stats/__main__.py
+++ b/src/plugins/nonebot_plugin_command_stats/__main__.py
@@ -45,7 +45,8 @@ RANK_COMMAND_NAMES = {"指令排行", "cmd-rank", "命令排行", "热门指令"
 @run_preprocessor
 async def record_command_usage(matcher: Matcher, state: T_State, event: Event) -> None:
     """自动记录所有指令使用到数据库"""
-    if matcher.type != "message":
+    # AlconnaMatcher 的 type 可能为空字符串，只排除明确非 message 的类型
+    if matcher.type and matcher.type != "message":
         return
 
     # 识别指令名（参考 status_report 的逻辑）


### PR DESCRIPTION
AlconnaMatcher has type='' instead of 'message', causing the preprocessor to skip all recording. Change check to only exclude non-empty non-message types.