### PR TITLE
fix(command_stats): pass days as keyword arg to lang.text()

### DIFF
--- a/src/lang/en_us/command_stats.yaml
+++ b/src/lang/en_us/command_stats.yaml
@@ -5,11 +5,11 @@ help:
   usage2: "cmd-rank <days> - Show top commands in last N days (max 90)"
 
 ranking:
-  title: "📊 Top Commands in Last {days} Days"
-  no_data: "No command usage recorded in the last {days} days~"
+  title: "📊 Top Commands in Last {{days}} Days"
+  no_data: "No command usage recorded in the last {{days}} days~"
   total_count: "Total Usage"
   cmd_count: "Commands"
   user_count: "Active Users"
-  user_detail: "{count} users"
+  user_detail: "{{count}} users"
   count_unit: "times"
   days_error: "Days must be between 1 and 90~"

--- a/src/lang/zh_hans/command_stats.yaml
+++ b/src/lang/zh_hans/command_stats.yaml
@@ -5,11 +5,11 @@ help:
   usage2: "指令排行 <天数> - 查看近N天热门指令排行（最大90天）"
 
 ranking:
-  title: "📊 近{days}天热门指令排行"
-  no_data: "近{days}天暂无指令使用记录喵～"
+  title: "📊 近{{days}}天热门指令排行"
+  no_data: "近{{days}}天暂无指令使用记录喵～"
   total_count: "总使用次数"
   cmd_count: "指令种类"
   user_count: "活跃用户"
-  user_detail: "{count} 位用户使用"
+  user_detail: "{{count}} 位用户使用"
   count_unit: "次"
   days_error: "天数范围应在 1-90 之间喵～"

--- a/src/lang/zh_tw/command_stats.yaml
+++ b/src/lang/zh_tw/command_stats.yaml
@@ -5,11 +5,11 @@ help:
   usage2: "指令排行 <天數> - 查看近N天熱門指令排行（最大90天）"
 
 ranking:
-  title: "📊 近{days}天熱門指令排行"
-  no_data: "近{days}天暫無指令使用記錄喵～"
+  title: "📊 近{{days}}天熱門指令排行"
+  no_data: "近{{days}}天暫無指令使用記錄喵～"
   total_count: "總使用次數"
   cmd_count: "指令種類"
   user_count: "活躍用戶"
-  user_detail: "{count} 位用戶使用"
+  user_detail: "{{count}} 位用戶使用"
   count_unit: "次"
   days_error: "天數範圍應在 1-90 之間喵～"

--- a/src/plugins/nonebot_plugin_command_stats/__main__.py
+++ b/src/plugins/nonebot_plugin_command_stats/__main__.py
@@ -180,10 +180,10 @@ async def handle_cmd_rank(result: Arparma, user_id: str = get_user_id()):
     stats = await get_total_stats(days=days)
 
     if not ranking:
-        await cmd_rank.finish(await lang.text("ranking.no_data", user_id, days))
+        await cmd_rank.finish(await lang.text("ranking.no_data", user_id, days=days))
 
     # 渲染图片
-    title = await lang.text("ranking.title", user_id, days)
+    title = await lang.text("ranking.title", user_id, days=days)
     image = await render_template(
         "command_ranking.html.jinja",
         title,

--- a/src/templates/command_ranking.html.jinja
+++ b/src/templates/command_ranking.html.jinja
@@ -137,7 +137,7 @@
                 <span class="prefix">/</span>{{ item.command }}
             </div>
             <div class="rank-detail">
-                {{ text.user_detail | replace("{count}", item.user_count) }}
+                {{ text.user_detail | replace("{{count}}", item.user_count) }}
             </div>
         </div>
 


### PR DESCRIPTION
str.format() requires keyword args for {days} placeholder. Fix caller to pass days=days instead of positional arg. Revert lang files to original format.