### PR TITLE
fix(command_stats): use single braces for str.format() substitution

### DIFF
--- a/src/lang/en_us/command_stats.yaml
+++ b/src/lang/en_us/command_stats.yaml
@@ -5,11 +5,11 @@ help:
   usage2: "cmd-rank <days> - Show top commands in last N days (max 90)"
 
 ranking:
-  title: "📊 Top Commands in Last {{days}} Days"
-  no_data: "No command usage recorded in the last {{days}} days~"
+  title: "📊 Top Commands in Last {days} Days"
+  no_data: "No command usage recorded in the last {days} days~"
   total_count: "Total Usage"
   cmd_count: "Commands"
   user_count: "Active Users"
-  user_detail: "{{count}} users"
+  user_detail: "{count} users"
   count_unit: "times"
   days_error: "Days must be between 1 and 90~"

--- a/src/lang/zh_hans/command_stats.yaml
+++ b/src/lang/zh_hans/command_stats.yaml
@@ -5,11 +5,11 @@ help:
   usage2: "指令排行 <天数> - 查看近N天热门指令排行（最大90天）"
 
 ranking:
-  title: "📊 近{{days}}天热门指令排行"
-  no_data: "近{{days}}天暂无指令使用记录喵～"
+  title: "📊 近{days}天热门指令排行"
+  no_data: "近{days}天暂无指令使用记录喵～"
   total_count: "总使用次数"
   cmd_count: "指令种类"
   user_count: "活跃用户"
-  user_detail: "{{count}} 位用户使用"
+  user_detail: "{count} 位用户使用"
   count_unit: "次"
   days_error: "天数范围应在 1-90 之间喵～"

--- a/src/lang/zh_tw/command_stats.yaml
+++ b/src/lang/zh_tw/command_stats.yaml
@@ -5,11 +5,11 @@ help:
   usage2: "指令排行 <天數> - 查看近N天熱門指令排行（最大90天）"
 
 ranking:
-  title: "📊 近{{days}}天熱門指令排行"
-  no_data: "近{{days}}天暫無指令使用記錄喵～"
+  title: "📊 近{days}天熱門指令排行"
+  no_data: "近{days}天暫無指令使用記錄喵～"
   total_count: "總使用次數"
   cmd_count: "指令種類"
   user_count: "活躍用戶"
-  user_detail: "{{count}} 位用戶使用"
+  user_detail: "{count} 位用戶使用"
   count_unit: "次"
   days_error: "天數範圍應在 1-90 之間喵～"


### PR DESCRIPTION
Python str.format() treats {{ as escaped literal brace. {{days}} becomes {days} literal, not replaced with value. Use {days} for proper variable substitution.