### PR TITLE
feat: 为 chat 会话添加 query_gift 工具

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1320,14 +1320,14 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.137.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620"},
-    {file = "fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab"},
+    {file = "fastapi-0.137.0-py3-none-any.whl", hash = "sha256:6dcbde8d464f92117c1accb9e42720f8e423fa9b86cb563b1f5862f785a06498"},
+    {file = "fastapi-0.137.0.tar.gz", hash = "sha256:d0565d551f65a803ecff245390840867186f456ef98971f750724eed16e1541c"},
 ]
 
 [package.dependencies]
@@ -1344,14 +1344,14 @@ standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[stand
 
 [[package]]
 name = "filelock"
-version = "3.29.3"
+version = "3.29.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "filelock-3.29.3-py3-none-any.whl", hash = "sha256:e58333029cc9b925f39aad59b1d8f0a1ad836af4e60d7217f4a4dba87461261d"},
-    {file = "filelock-3.29.3.tar.gz", hash = "sha256:7fc1b3f39cf172fd8203812043c57b8a65aef9969f38b6704f628b881f761a84"},
+    {file = "filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767"},
+    {file = "filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a"},
 ]
 
 [[package]]
@@ -4645,14 +4645,14 @@ wheel = "*"
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev", "test"]
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"},
+    {file = "pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c"},
 ]
 
 [package.dependencies]
@@ -6213,14 +6213,14 @@ test = ["aiohttp (>=3.10.5)", "flake8 (>=6.1,<7.0)", "mypy (>=0.800)", "psutil",
 
 [[package]]
 name = "virtualenv"
-version = "21.4.3"
+version = "21.5.0"
 description = "Virtual Python Environment builder"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.4.3-py3-none-any.whl", hash = "sha256:75f4127d4067397c64f38579ce918fec6bf9ca2cd4f48685e82952cc3c035840"},
-    {file = "virtualenv-21.4.3.tar.gz", hash = "sha256:938ff0fd3f4e0f0d3a025f67a3d2f25e3c3aabbcd5857ea6170619138d72d141"},
+    {file = "virtualenv-21.5.0-py3-none-any.whl", hash = "sha256:8f7c38605023688c89789f566959006af6d61c99eeeb9e58342eb780c5761e5e"},
+    {file = "virtualenv-21.5.0.tar.gz", hash = "sha256:98847aadf5e2037e0e4d2e19528eb3aca6f23906422e59a510bff231a6d32fce"},
 ]
 
 [package.dependencies]

--- a/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
@@ -122,32 +122,31 @@ class ToolManager:
         """
         if self.processor is None:
             raise RuntimeError("processor is None")
-        
+
         # 获取用户列表 {nickname: user_id}
         users = await self.processor.session.get_users()
         if not (user_id := users.get(target_nickname)):
             return f"找不到用户「{target_nickname}」"
-        
+
         # 获取用户背包物品
         try:
             items = await get_bag_items(user_id)
         except Exception as e:
             return f"查询背包失败: {e}"
-        
+
         # 过滤出 GiftItem 并按名称合并数量
         gift_counts = {}
         for item in items:
             if isinstance(item.stack.item, GiftItem):
                 name = await item.stack.getName()
                 gift_counts[name] = gift_counts.get(name, 0) + item.stack.count
-        
+
         if not gift_counts:
             return f"用户「{target_nickname}」背包中没有可送给 Moonlark 的礼物"
-        
+
         # 格式化输出
         lines = [f"{name}：{count}" for name, count in sorted(gift_counts.items(), key=lambda x: -x[1])]
         return "\n".join(lines)
-
 
     async def change_sleep_status(
         self, deal_type: Literal["ready", "delay"], delay_minutes: Optional[int] = None, reason: Optional[str] = None

--- a/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
@@ -23,6 +23,9 @@ from ..lang import lang
 from nonebot_plugin_openai.types import AsyncFunction, FunctionParameter, FunctionParameterWithEnum
 from nonebot.adapters.onebot.v11 import Bot as OB11Bot
 from nonebot_plugin_larkutils.jrrp import get_luck_value
+from nonebot_plugin_bag.utils.item import get_bag_items
+from nonebot_plugin_items.base.gift import GiftItem
+
 from .tools import (
     browse_webpage,
     web_search,
@@ -107,6 +110,44 @@ class ToolManager:
             return await self.text("tools_desc.calculate_luck_value.user_not_found", nickname)
         luck_value = await get_luck_value(user_id)
         return await self.text("tools_desc.calculate_luck_value.result", nickname, luck_value)
+
+    async def query_gift(self, target_nickname: str) -> str:
+        """查询用户背包中可赠送给 Moonlark 的礼物及其数量
+
+        Args:
+            target_nickname: 要查询的用户的昵称
+
+        Returns:
+            格式化的礼物列表
+        """
+        if self.processor is None:
+            raise RuntimeError("processor is None")
+        
+        # 获取用户列表 {nickname: user_id}
+        users = await self.processor.session.get_users()
+        if not (user_id := users.get(target_nickname)):
+            return f"找不到用户「{target_nickname}」"
+        
+        # 获取用户背包物品
+        try:
+            items = await get_bag_items(user_id)
+        except Exception as e:
+            return f"查询背包失败: {e}"
+        
+        # 过滤出 GiftItem 并按名称合并数量
+        gift_counts = {}
+        for item in items:
+            if isinstance(item.stack.item, GiftItem):
+                name = await item.stack.getName()
+                gift_counts[name] = gift_counts.get(name, 0) + item.stack.count
+        
+        if not gift_counts:
+            return f"用户「{target_nickname}」背包中没有可送给 Moonlark 的礼物"
+        
+        # 格式化输出
+        lines = [f"{name}：{count}" for name, count in sorted(gift_counts.items(), key=lambda x: -x[1])]
+        return "\n".join(lines)
+
 
     async def change_sleep_status(
         self, deal_type: Literal["ready", "delay"], delay_minutes: Optional[int] = None, reason: Optional[str] = None
@@ -201,6 +242,9 @@ class ToolManager:
 
             # calculate_luck_value
             tools.append(self.calculate_luck_value)
+
+            # query_gift
+            tools.append(self.query_gift)
 
             # request_action
             tools.append(self.request_action)

--- a/src/prompt/__tools__/query_gift.yaml
+++ b/src/prompt/__tools__/query_gift.yaml
@@ -1,0 +1,9 @@
+description: |
+  查询指定用户背包中所有可以赠送给 Moonlark 的礼物及其数量。
+  返回每个礼物的名称和数量（合并相同礼物后）。
+  如果用户没有注册或没有礼物，会返回提示信息。
+parameters:
+  - name: target_nickname
+    description: "要查询礼物的用户的昵称。"
+    type: string
+    required: true


### PR DESCRIPTION
## 改动内容

为 AI 聊天会话添加 `query_gift` 工具，Moonlark 可以用它查询用户背包中可赠送的礼物数量。

### 新增文件
- `src/prompt/__tools__/query_gift.yaml` — 工具定义（描述 + 参数）

### 修改文件
- `src/plugins/nonebot_plugin_chat/utils/tool_manager.py` — 添加 `query_gift` 方法并注册到工具列表

### 使用场景
Moonlark 可以先用此工具查询用户的礼物数量，然后向用户讨要礼物。

### 返回格式示例
```
小鱼干：5
猫罐头：0
猫铃铛：2
```

### 错误处理
- 找不到用户 → 返回提示信息
- 背包查询失败 → 返回错误信息
- 没有礼物 → 返回空结果提示