### PR TITLE
fix(template): correct GitHub body conditional rendering

### DIFF
--- a/src/templates/github.html.jinja
+++ b/src/templates/github.html.jinja
@@ -184,7 +184,7 @@
 <div class="markdown-body">
 {% if data.body %}
 {{ data.body }}
-{% else if %}
+{% else %}
 {{ text.pull.no_body }}
 {% endif %}
 </div>


### PR DESCRIPTION
Use Jinja's standard `else` branch for rendering the no-body fallback when GitHub issue or pull request data does not include a body.