### PR TITLE
chore: switch picmcstat from git dependency to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,8 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.11, <4.0"
-nonebot-plugin-picmcstat = {git = "https://github.com/Moonlark-Dev/nonebot-plugin-picmcstat.git"}
-mcstatus = ">=11.1.1, <13"  # TODO: picmcstat 兼容 v13 后移除
+nonebot-plugin-picmcstat = ">=0.8.1,<0.9.0"
+mcstatus = ">=12.0.5, <13"  # picmcstat 0.8.1 需要 mcstatus>=12.0.5
 nonebot-plugin-picstatus = ">=2.1.3, <3.0.0"
 nonebot-plugin-sentry = ">=2.0.0, <3.0.0"
 


### PR DESCRIPTION
将 nonebot-plugin-picmcstat 从 Moonlark-Dev 的 Git 依赖更换为 PyPI 上的上游版本。

### 变更内容
- `nonebot-plugin-picmcstat`: `{git = "..."}` → `>=0.8.1,<0.9.0`
- `mcstatus`: `>=11.1.1` → `>=12.0.5`（picmcstat 0.8.1 所需）

### 原因
使用 PyPI 上的上游版本而非 Moonlark-Dev fork，便于后续更新维护。