### PR TITLE
fix(ranking): remove negative margin from myrank in wide theme

### DIFF
--- a/src/templates/ranking.html.jinja
+++ b/src/templates/ranking.html.jinja
@@ -10,11 +10,6 @@
 </style>
 {% if me %}
 <style>
-    .myrank {
-        margin-top: -15px;
-        margin-bottom: -20px;
-    }
-
     .ranking {
         margin-bottom: -20px;
     }


### PR DESCRIPTION
## Description

Remove the negative margin-top and margin-bottom from `.myrank` style because in the wide theme, `.card-body` has 12px padding which makes the negative margin compress the card height, causing the blue background to only cover the text area.

## Before

In the wide theme, the blue background bar for 'my rank' was too short (only covered the text). The negative margin compressed the card to near-zero height.

## After

The 'my rank' card now has the same padding as other rank cards in both default and wide themes, making the blue background height consistent.

## Changes

- Removed negative margin from `.myrank` class (was `-15px` top and `-20px` bottom)
- Retained the `.ranking` class (`margin-bottom: -20px`) to remove extra space before the 'my rank' card