### PR TITLE
fix: correct function name in query_history import

### DIFF
--- a/src/plugins/nonebot_plugin_chat/utils/tools/__init__.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tools/__init__.py
@@ -28,4 +28,4 @@ from .vm import (
     is_vm_configured,
 )
 from .bilibili import describe_bilibili_video, resolve_b23_url
-from .query_history import query_history_message
+from .query_history import fetch_history_messages


### PR DESCRIPTION
## 问题
在 `nonebot_plugin_chat/utils/tools/__init__.py` 中，第31行尝试导入 `query_history_message`，但 `query_history.py` 中定义的函数是 `fetch_history_messages`。

## 修复
将导入名从 `query_history_message` 改为 `fetch_history_messages`，与 `query_history.py` 中的实际函数定义保持一致。

## 错误信息
```
from .query_history import query_history_message
ImportError: cannot import name 'query_history_message'
```