### PR TITLE
feat: add /menu command with hierarchical category browsing

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -4,14 +4,10 @@
 ## `2048`: 2048 小游戏
 
 数字合成游戏 —— 2048
-
-### 用法
 - `/2048`
 ## `bingo`: 宾果游戏生成
 
 输入大小与内容，一键生成宾果游戏图片
-
-### 用法
 - `/bingo [列数] [行数] (开始创建宾果游戏)`
 ## `boothill`: 波提欧
 
@@ -19,49 +15,35 @@
 
 「他宝了个腿的。」 ——巡海游侠，波提欧
 
-
-### 用法
 - `/boothill <句子>`
 ## `character`: 成员列表
 
 （该功能仍在测试中）查看当前拥有的角色。
-
-### 用法
 - `/character (查看角色列表)`
 - `/character <index> (查看角色详情)`
 ## `chatterbox`: 群话痨排行
 
 统计群聊中的话痨，该功能不支持 QQ 节点且需要在群聊中手动启用。
-
-### 用法
 - `/ct (群话痨排行)`
 - `/ct -e|-d (功能开关)`
 - `/ct me|<@用户> (查询指定用户的话痨排行)`
 ## `defuse-tnt`: 拆除 TNT
 
 运气游戏——通过猜测排列出正确的拆除炸弹的密码。
-
-### 用法
 - `/defuse-tnt`
 ## `epic-free`: Epic 免费游戏查询
 
 查询 Epic Games Store 当前和即将到来的免费游戏。
-
-### 用法
 - `/epic-free (查询免费游戏)`
 ## `ftt`: 寻径指津
 
 寻径指津玩法
-
-### 用法
 - `/ftt (从随机地图开始)`
 - `/ftt <seed> (从指定种子生成地图)`
 - `/ftt legend (查看方块图例)`
 ## `jrrp`: 今日人品
 
 查询今天的人品值，今天也是幸运的一天～
-
-### 用法
 - `/jrrp (获取今天的人品值)`
 - `/jrrp r (今日幸运星[--rank])`
 - `/jrrp rr (今日倒霉蛋[--rank-r])`
@@ -69,14 +51,10 @@
 ## `minigame-rank`: 小游戏积分排名
 
 查看 Moonlark 中游玩玩法的用户的排名
-
-### 用法
 - `/minigame-rank`
 ## `quick-math`: 快速数学
 
 以计算为核心的玩法。找到问题的答案，并在排行榜中获取更高的积分。（指令别名：qm）
-
-### 用法
 - `/quick-math [--level <开始的等级>] (开始挑战)`
 - `/quick-math rank [--total] (积分排行榜)`
 - `/quick-math points (查看总分详情)`
@@ -84,21 +62,15 @@
 ## `sandbox`: 战斗沙箱
 
 （该功能仍在测试中）启动战斗沙箱，进行模拟战斗。
-
-### 用法
 - `/sandbox [标靶等级] [标靶数量]`
 ## `setu`: 随机图片
 
 随机 Pixiv 插画
-
-### 用法
 - `/setu (随机图片)`
 - `/setu rank (查看使用排行)`
 ## `sudoku`: 数独解谜游戏
 
 数独解谜游戏，提供不同难度级别的数独谜题。游戏可以错误检查功能，帮助用户学习数独技巧。
-
-### 用法
 - `/sudoku new <num-holes> (生成指定空格数的数独)`
 - `/sudoku change <row> <column> <value> (修改数独指定行列数字)`
 - `/sudoku erase <row> <column> (去除数独指定行列数字)`
@@ -110,15 +82,11 @@
 ## `team`: 设置战斗队伍
 
 （该功能仍在测试中）设置战斗有关模块使用的队伍，配合 character 指令使用。
-
-### 用法
 - `/team (查看当前队伍)`
 - `/team set <位置> <index> (成员入队)`
 ## `tol`: 关灯挑战
 
 尝试关掉所有的灯_一盏灯被开启或关闭时它上、下、左、右边的灯的状态也会发生改变。
-
-### 用法
 - `/tol`
 ## `wordle`: WORDLE
 
@@ -126,21 +94,15 @@
 
 游玩提示：为了避免干扰使用，不成功的匹配不会被提示，也不能在一个会话中同时开启多个 WORDLE 游戏。
 
-
-### 用法
 - `/wordle [长度=5]`
 ## `access`: 权限管理
 
 Moonlark 权限控制 (仅 SUPERUSER 可用)
-
-### 用法
 - `/access {ban|pardon} <主体ID> (封禁/解封用户)`
 - `/access {block|unblock} <权限> <主体ID> (添加/移除权限)`
 ## `bag`: 背包
 
 查看，处理，使用背包中的物品
-
-### 用法
 - `/bag (查看背包)`
 - `/bag overflow list (查看 overflow 区物品列表)`
 - `/bag overflow show <INDEX> (查看 overflow 区物品)`
@@ -153,189 +115,135 @@ Moonlark 权限控制 (仅 SUPERUSER 可用)
 ## `lang`: 本地化
 
 Moonlark 本地化设置
-
-### 用法
 - `/lang (查看语言列表)`
 - `/lang view <语言> (查看语言信息)`
 - `/lang set <语言> (设置语言)`
 - `/lang reload (重载语言[SU])`
-## `model`: 模型管理
-
-管理 OpenAI 模型配置（仅限超级用户）
-
-### 用法
-- `/model (查看模型配置信息)`
-- `/model <模型名> (更换默认模型)`
-- `/model <模型名> <应用标识> (设置应用专用模型)`
-- `/model :default: <应用标识> (删除应用配置)`
 ## `panel`: 用户面板
 
 查看用户数据面板
-
-### 用法
 - `/panel (查看面板)`
 ## `present`: 赠送礼物
 
 将背包中的礼物赠送给 Moonlark
-
-### 用法
 - `/present <INDEX> [-c|--count <count>] (赠送礼物)`
 ## `setnick`: 修改昵称
 
 修改自己在 Moonlark 中的昵称，不带参数则解锁昵称锁定
-
-### 用法
 - `/setnick <昵称> (修改昵称，不带参数解锁锁定)`
 ## `status`: 系统状态
 
 显示系统状态信息
-
-### 用法
 - `/status`
 ## `theme`: 主题
 
 设定部分指令的图片渲染主题
-
-### 用法
 - `/theme (查看主题列表)`
 - `/theme <name> (更换主题)`
 ## `version`: 版本管理
 
 使用 git 和 nb_cli 管理版本，仅限 SUPERUSER
-
-### 用法
 - `/version show (显示版本信息)`
 - `/version upgrade (更新代码)`
 ## `whoami`: 我是谁
 
 查看用户帐号基本信息
-
-### 用法
 - `/whoami (查看帐号信息)`
 ## `bac`: 蔚蓝档案活动日历
 
 查询蔚蓝档案现在和将来的卡池、活动信息，支持国服（默认）、国际服（参数：in）、日服（参数：jp）。
-
-### 用法
 - `/bac (国服活动日历)`
 - `/bac in|jp (国际/日服活动日历)`
 ## `bac-remind`: 总力战提醒管理
 
 管理总力战/大决战提醒功能，开启后会在活动开始前1小时和结束前1小时发送提醒。仅支持 OneBot V11 协议。
-
-### 用法
 - `/bac-remind (查看当前状态)`
 - `/bac-remind on/off (开启/关闭提醒)`
+## `bc`: 广播设置
+
+开启或关闭所在群聊的广播接收
+- `/bc (查看广播状态)`
+- `/bc on (开启广播)`
+- `/bc off (关闭广播)`
 ## `calc`: 计算器
 
 通过 Wolfram|Alpha 计算表达式或回答问题
-
-### 用法
 - `/calc <问题> (询问 WolframAlpha)`
 ## `check-history`: 发过了吗
 
 检查最近 48 小时内是否已经讨论过某个话题或发送过某条消息。
-
-### 用法
 - `/check-history [内容]`
 - `/check-history (回复某条消息)`
 ## `cmd-rank`: 指令统计
 
 统计指令使用情况，提供近N天热门指令排行
-
-### 用法
 - `/指令排行 - 查看近7天热门指令排行`
 - `/指令排行 <天数> - 查看近N天热门指令排行（最大90天）`
 ## `debate-helper`: 辩论助手
 
 分析群聊中的争议或辩论，提供客观的双方观点摘要。
-
-### 用法
 - `/debate [读取长度]`
 ## `github`: GitHub 链接解析
 
 预览 GitHub 链接内容
-
-### 用法
 - `/github <链接/仓库>`
 ## `group-daily`: 每日群聊总结
 
 获取当日群聊的总结报告，需要先启用群消息总结功能。
-
-### 用法
 - `/group-daily (获取当日群聊总结)`
 ## `help`: 命令帮助
 
 获取命令用法
-
-### 用法
 - `/help (获取命令列表)`
 - `/help <命令名> (查看命令帮助)`
 ## `holiday`: 剩余假期
 
 查看剩余的假期
-
-### 用法
 - `/holiday`
 ## `hsrc`: 崩铁活动日历
 
 《崩坏：星穹铁道》活动日历
-
-### 用法
 - `/hsrc`
 ## `int`: 进制转换器
 
 转换进制
-
-### 用法
 - `/int <数字> [源进制(默认自动识别)] [目标进制(默认 10)]`
 ## `latex`: 渲染 LaTeX 表达式
 
 将 LaTeX 表达式渲染为图片
-
-### 用法
 - `/latex <内容>`
 ## `luxun-said`: 鲁迅说没说
 
 鲁迅到底说没说过？从鲁迅先生的作品中模糊搜索他的一句话。
-
-### 用法
 - `/luxun-said <内容>`
 ## `man`: 查询 Man
 
 Linux 手册 (ManPage) 查询
-
-### 用法
 - `/man <名称> [章节] (查询 ManPage)`
+## `menu`: 分级菜单
+
+显示分类菜单和随机指令
+- `/menu (查看分类菜单)`
+- `/menu <分类ID> (查看指定分类的指令列表)`
 ## `motd`: MC 服务器查询
 
 [lgc-NB2Dev/nonebot-plugin-picmcstat] 查询 Minecraft 服务器信息
-
-### 用法
 - `/motd <IP>`
 ## `pacman`: Linux 包搜索
 
 搜索 Arch Linux 包
-
-### 用法
 - `/pacman <关键词>`
 ## `preview`: 预览网页
 
 截图一个网页 (加载不完全请尝试指定 wait)
-
-### 用法
 - `/preview <URL> [-w|--wait <等待时间>] (截图URL)`
 ## `raw`: 生草机
 
 基于翻译，一键生草（一种植物），仅支持中文。
-
-### 用法
 - `/raw <文本...>`
 ## `summary`: 历史消息总结
 
 使用 AI 总结群聊中的历史消息。读取长度默认为 200 条消息，最大为 270，该功能不支持 QQ 节点且需要在群聊中手动启用。
-
-### 用法
 - `/summary [读取长度] (总结历史消息)`
 - `/summary -s broadcast (广播风格总结)`
 - `/summary -s topic (话题梳理)`
@@ -344,22 +252,16 @@ Linux 手册 (ManPage) 查询
 ## `t`: 翻译器
 
 翻译文本（默认英到中）
-
-### 用法
 - `/t <文本...> [-s|--sorce <源语言>] [-t|--target <目标语言>]`
 ## `time-progress`: 时间进度
 
 查看本年/月/日的进度，支持年进度推送订阅
-
-### 用法
 - `/time-progress - 查看时间进度
 time-progress sub - 查看订阅状态
 time-progress sub on/off - 开启/关闭年进度推送`
 ## `vote`: 投票
 
 Moonlark 投票
-
-### 用法
 - `/vote [-a|--all] (获取投票列表)`
 - `/vote create [-g|--global] [-l|--last <持续(小时)>] [标题] (创建投票)`
 - `/vote <投票ID> <选项编号> (参与投票)`
@@ -368,22 +270,16 @@ Moonlark 投票
 ## `wakatime`: WakaTime
 
 在 Moonlark 上查看 WakaTime 时长并参与排行
-
-### 用法
 - `/wakatime (查看我的 WakaTime 信息)`
 - `/wakatime login (绑定 WakaTime 账户)`
 - `/wakatime rank (查看 WakaTime 排行榜)`
 ## `wdym`: 请问什么意思
 
 回复一条消息，让 AI 结合上下文解释消息中的晦涩内容、专业术语、梗或缩写。
-
-### 用法
 - `/wdym (回复一条消息)`
 ## `cave`: 回声洞
 
 （与漂流瓶类似）投稿或查看其他用户投稿的回声洞，所有内容依照 CC-BY-NC-SA 4.0 许可协议授权
-
-### 用法
 - `/cave (随机条目)`
 - `/cave-a <内容...> (投稿条目)`
 - `/cave-r [-c] <ID> (删除条目或评论)`
@@ -394,8 +290,6 @@ Moonlark 投票
 ## `chat`: 主动水群
 
 基于 LLM 的主动水群功能，可以尝试用于活跃群气氛。（启用后将会收集、处理、并储存启用群聊的聊天记录和群员的昵称，仅支持非 QQ 官方节点）
-
-### 用法
 - `/chat switch (切换功能启用状态)`
 - `/chat on (启用功能)`
 - `/chat off (禁用功能)`
@@ -415,14 +309,10 @@ Moonlark 投票
 ## `decision`: 虚假处分通知
 
 根据群内最近 300 条消息，对指定群员生成一份符合公文格式的虚假处分通知（整活用）。
-
-### 用法
 - `/decision @群友 <处分内容>`
 ## `email`: 邮件
 
 进入 Moonlark 邮箱
-
-### 用法
 - `/email (查看未读邮件)`
 - `/email claim all (领取全部物品)`
 - `/email claim <email_id> (领取指定邮件)`
@@ -431,42 +321,30 @@ Moonlark 投票
 ## `fav-rank`: 好感度排行
 
 查看 Moonlark 好感度排行榜，展示所有用户的好感度排名。好感度通过日常互动累积，数值越高代表与 Moonlark 的亲密度越高。
-
-### 用法
 - `/fav-rank (查看好感度排行榜)`
 ## `ghot`: 群发言热度
 
 计算群聊消息的热度分数，并进行排名。使用此功能需要先使用 /summary -e 启用群历史消息总结功能，否则群热度分数恒为 0。
-
-### 用法
 - `/ghot (当前群聊热度分数)`
 - `/ghot history [-l] (最近的天分数历史)`
 ## `lastseen`: 查询最后上线时间
 
 记录并查询用户最后上线时间，支持全局和当前会话两种范围
-
-### 用法
 - `/lastseen (查看自己最后上线时间)`
 - `/lastseen @用户 (查看指定用户最后上线时间)`
 - `/lastseen QQ号 (通过QQ号查询指定用户最后上线时间)`
 ## `neko-finder`: 找猫娘
 
 根据近 2 天的消息对群友的“猫娘指数”进行打分。
-
-### 用法
 - `/neko-finder`
 ## `online-timer`: 在线时间段
 
 查询 Moonlark 记录的群友在线时间段
-
-### 用法
 - `/online-timer [@用户]`
 - `/online-timer rank (在线排行)`
 ## `rua`: 互动
 
 通过 rua 指令与 Moonlark 进行亲密互动（如戳一戳、摸头、拥抱等）。不同的互动动作需要不同的好感度才能解锁。
-
-### 用法
 - `/rua (使用当前选中的动作与 Moonlark 互动)`
 - `/rua action (查看可用的互动动作列表)`
 - `/rua action <编号> (切换当前使用的互动动作)`
@@ -477,21 +355,32 @@ Moonlark 投票
 ## `schedule`: 每日任务
 
 查看每日任务或领取每日任务奖励，每日刷新，部分功能仅在签到后可用。
-
-### 用法
 - `/schedule (查看每日任务列表)`
 - `/schedule collect (领取可领取的奖励)`
 ## `waifu`: 今日群老婆
 
 匹配你的每日群老婆！（仅支持群聊使用）
-
-### 用法
 - `/waifu (今日群老婆)`
 - `/waifu divorce (离婚)`
 - `/waifu force-marry <@群员> (强娶)`
 ## `wtfis`: 这在说啥
 
 随机跨领域因果关系谬误文案。（基于预先生成的文案，绝对没有使用大语言模型及人工智能！）
-
-### 用法
 - `/wtfis`
+## `bcsu`: 广播管理
+
+发送和管理广播消息
+> 此指令仅 Moonlark 管理员可用。
+- `/bcsu (查看广播管理菜单)`
+- `/bcsu <内容> (设置广播内容)`
+- `/bcsu clear (清除广播内容)`
+- `/bcsu preview (预览广播内容)`
+- `/bcsu submit (提交并发送广播)`
+## `model`: 模型管理
+
+管理 OpenAI 模型配置（仅限超级用户）
+> 此指令仅 Moonlark 管理员可用。
+- `/model (查看模型配置信息)`
+- `/model <模型名> (更换默认模型)`
+- `/model <模型名> <应用标识> (设置应用专用模型)`
+- `/model :default: <应用标识> (删除应用配置)`

--- a/poetry.lock
+++ b/poetry.lock
@@ -1320,14 +1320,14 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "fastapi"
-version = "0.138.2"
+version = "0.139.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.138.2-py3-none-any.whl", hash = "sha256:db90c1ffb5517fba5d4a9f80e866daa008747e646310c9ce155c8c535f9d1615"},
-    {file = "fastapi-0.138.2.tar.gz", hash = "sha256:6432359d067a432134620e7c5e4c6e5063e7f37815bbbbf20acef14b0d2e3fc8"},
+    {file = "fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189"},
+    {file = "fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145"},
 ]
 
 [package.dependencies]
@@ -6005,14 +6005,14 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.17.0,<1.19)", "pre-commit", "pytest 
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev", "test"]
 files = [
-    {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
-    {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+    {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
+    {file = "typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -4542,14 +4542,14 @@ crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0"
+version = "11.0.1"
 description = "Extension pack for Python Markdown."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6"},
-    {file = "pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589"},
+    {file = "pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2"},
+    {file = "pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1344,14 +1344,14 @@ standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[stand
 
 [[package]]
 name = "filelock"
-version = "3.29.4"
+version = "3.29.5"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767"},
-    {file = "filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a"},
+    {file = "filelock-3.29.5-py3-none-any.whl", hash = "sha256:8af830889ba3a0ffcefbd6c7d2af8a54012058103771f2e10848222f476a1693"},
+    {file = "filelock-3.29.5.tar.gz", hash = "sha256:6e6034c57a00a020e767f2614a5539863f056de7e7991d6d1473aef7ff73f156"},
 ]
 
 [[package]]

--- a/src/lang/en_us/broadcast.yaml
+++ b/src/lang/en_us/broadcast.yaml
@@ -12,6 +12,22 @@ bcsu:
   no_bots: "未找到 OneBot V11 适配器的机器人"
   broadcast_sent: "广播已发送至 {0} 个群聊"
   start: 已开始推送广播内容
+help:
+  description: Broadcast Management
+  details: Send and manage broadcast messages
+  usage1: bcsu (View broadcast management menu)
+  usage2: bcsu <content> (Set broadcast content)
+  usage3: bcsu clear (Clear broadcast content)
+  usage4: bcsu preview (Preview broadcast content)
+  usage5: bcsu submit (Submit and send broadcast)
+
+bc_help:
+  description: Broadcast Settings
+  details: Enable or disable broadcast reception in your group
+  usage1: bc (View broadcast status)
+  usage2: bc on (Enable broadcast)
+  usage3: bc off (Disable broadcast)
+
 bc:
   group_only: "此命令只能在群聊中使用"
   enabled: "广播功能已启用"

--- a/src/lang/en_us/larkhelp.yaml
+++ b/src/lang/en_us/larkhelp.yaml
@@ -34,6 +34,8 @@ menu:
   usage1: 'menu (View category menu)'
   usage2: 'menu <category> (View details of a category)'
   menu_cat_help_hint: 'Use help <command> to view command details'
+  description: Category Menu
+  details: Browse command categories and discover random commands
 
 help:
   description: Command Help

--- a/src/lang/en_us/larkhelp.yaml
+++ b/src/lang/en_us/larkhelp.yaml
@@ -53,4 +53,5 @@ markdown:
     {}
 
     ### 用法
+  superuser_warning: '> This command is only available to Moonlark administrators.'
   usage: "- `{}`\n"

--- a/src/lang/en_us/larkhelp.yaml
+++ b/src/lang/en_us/larkhelp.yaml
@@ -9,6 +9,7 @@ list:
     setting: 用户与系统管理
     community: 社区与社交
     new: 新加入的
+    superuser: Admin
 command:
   info: |
     [✓] {}: {}
@@ -24,6 +25,15 @@ command:
   error: |
     指令列表发送失败了唔……
     主人可以前往 Moonlark 的 GitHub 仓库的 COMMANDS.md 文件查阅指令列表喵~
+
+menu:
+  title: Moonlark Menu
+  menu_category_hint: 'Use {prefix}menu <category> to view category details'
+  random_title: Random Command
+  category_not_found: Category {category} not found
+  usage1: 'menu (View category menu)'
+  usage2: 'menu <category> (View details of a category)'
+
 help:
   description: Command Help
   details: Get command usage

--- a/src/lang/en_us/larkhelp.yaml
+++ b/src/lang/en_us/larkhelp.yaml
@@ -33,6 +33,7 @@ menu:
   category_not_found: Category {category} not found
   usage1: 'menu (View category menu)'
   usage2: 'menu <category> (View details of a category)'
+  menu_cat_help_hint: 'Use help <command> to view command details'
 
 help:
   description: Command Help

--- a/src/lang/zh_hans/broadcast.yaml
+++ b/src/lang/zh_hans/broadcast.yaml
@@ -13,6 +13,22 @@ bcsu:
   broadcast_sent: "广播已发送至 {0} 个群聊"
   start: 已开始推送广播内容
 
+help:
+  description: 广播管理
+  details: 发送和管理广播消息
+  usage1: bcsu (查看广播管理菜单)
+  usage2: bcsu <内容> (设置广播内容)
+  usage3: bcsu clear (清除广播内容)
+  usage4: bcsu preview (预览广播内容)
+  usage5: bcsu submit (提交并发送广播)
+
+bc_help:
+  description: 广播设置
+  details: 开启或关闭所在群聊的广播接收
+  usage1: bc (查看广播状态)
+  usage2: bc on (开启广播)
+  usage3: bc off (关闭广播)
+
 bc:
   group_only: "此命令只能在群聊中使用"
   enabled: "广播功能已启用"

--- a/src/lang/zh_hans/larkhelp.yaml
+++ b/src/lang/zh_hans/larkhelp.yaml
@@ -9,6 +9,7 @@ list:
     setting: 用户与系统管理
     community: 社区与社交
     new: 新加入的
+    superuser: 管理员
     
 command:
   info: |
@@ -25,6 +26,15 @@ command:
   error: |
     指令列表发送失败了唔……
     主人可以前往 Moonlark 的 GitHub 仓库的 COMMANDS.md 文件查阅指令列表喵~
+
+menu:
+  title: Moonlark 在这里喵~！
+  menu_category_hint: '使用 {prefix}menu <分类ID> 查看分类详情'
+  random_title: 随机指令
+  category_not_found: 未找到分类 {category}
+  usage1: menu (查看分类菜单)
+  usage2: menu <分类ID> (查看指定分类的指令列表)
+
 help:
   description: 命令帮助
   details: 获取命令用法

--- a/src/lang/zh_hans/larkhelp.yaml
+++ b/src/lang/zh_hans/larkhelp.yaml
@@ -35,6 +35,8 @@ menu:
   usage1: menu (查看分类菜单)
   usage2: menu <分类ID> (查看指定分类的指令列表)
   menu_cat_help_hint: '使用 help <指令名> 查看指令的具体用法'
+  description: 分级菜单
+  details: 显示分类菜单和随机指令
 
 help:
   description: 命令帮助

--- a/src/lang/zh_hans/larkhelp.yaml
+++ b/src/lang/zh_hans/larkhelp.yaml
@@ -34,6 +34,7 @@ menu:
   category_not_found: 未找到分类 {category}
   usage1: menu (查看分类菜单)
   usage2: menu <分类ID> (查看指定分类的指令列表)
+  menu_cat_help_hint: '使用 help <指令名> 查看指令的具体用法'
 
 help:
   description: 命令帮助

--- a/src/lang/zh_hans/larkhelp.yaml
+++ b/src/lang/zh_hans/larkhelp.yaml
@@ -54,6 +54,7 @@ markdown:
     ## `{}`: {}
 
     {}
+  superuser_warning: '> 此指令仅 Moonlark 管理员可用。'
 
     ### 用法
   

--- a/src/lang/zh_tw/broadcast.yaml
+++ b/src/lang/zh_tw/broadcast.yaml
@@ -12,6 +12,22 @@ bcsu:
   no_bots: "未找到 OneBot V11 适配器的机器人"
   broadcast_sent: "广播已发送至 {0} 个群聊"
   start: 已开始推送广播内容
+help:
+  description: 廣播管理
+  details: 發送和管理廣播訊息
+  usage1: bcsu (查看廣播管理菜單)
+  usage2: bcsu <內容> (設置廣播內容)
+  usage3: bcsu clear (清除廣播內容)
+  usage4: bcsu preview (預覽廣播內容)
+  usage5: bcsu submit (提交並發送廣播)
+
+bc_help:
+  description: 廣播設置
+  details: 開啓或關閉所在群聊的廣播接收
+  usage1: bc (查看廣播狀態)
+  usage2: bc on (開啓廣播)
+  usage3: bc off (關閉廣播)
+
 bc:
   group_only: "此命令只能在群聊中使用"
   enabled: "广播功能已启用"

--- a/src/lang/zh_tw/larkhelp.yaml
+++ b/src/lang/zh_tw/larkhelp.yaml
@@ -53,4 +53,5 @@ markdown:
     {}
 
     ### 用法
+  superuser_warning: '> 此指令僅 Moonlark 管理員可用。'
   usage: "- `{}`\n"

--- a/src/lang/zh_tw/larkhelp.yaml
+++ b/src/lang/zh_tw/larkhelp.yaml
@@ -9,6 +9,7 @@ list:
     setting: 用户与系统管理
     community: 社区与社交
     new: 新加入的
+    superuser: 管理員
 command:
   info: |
     [✓] {}: {}
@@ -24,6 +25,15 @@ command:
   error: |
     指令列表发送失败了唔……
     主人可以前往 Moonlark 的 GitHub 仓库的 COMMANDS.md 文件查阅指令列表喵~
+
+menu:
+  title: Moonlark 在這裡喵~！
+  menu_category_hint: '使用 {prefix}menu <分類ID> 查看分類詳情'
+  random_title: 隨機指令
+  category_not_found: 未找到分類 {category}
+  usage1: menu (查看分類菜單)
+  usage2: menu <分類ID> (查看指定分類的指令列表)
+
 help:
   description: 命令帮助
   details: 获取命令用法

--- a/src/lang/zh_tw/larkhelp.yaml
+++ b/src/lang/zh_tw/larkhelp.yaml
@@ -33,6 +33,7 @@ menu:
   category_not_found: 未找到分類 {category}
   usage1: menu (查看分類菜單)
   usage2: menu <分類ID> (查看指定分類的指令列表)
+  menu_cat_help_hint: '使用 help <指令名> 查看指令的具體用法'
 
 help:
   description: 命令帮助

--- a/src/lang/zh_tw/larkhelp.yaml
+++ b/src/lang/zh_tw/larkhelp.yaml
@@ -34,6 +34,8 @@ menu:
   usage1: menu (查看分類菜單)
   usage2: menu <分類ID> (查看指定分類的指令列表)
   menu_cat_help_hint: '使用 help <指令名> 查看指令的具體用法'
+  description: 分級菜單
+  details: 顯示分類菜單和隨機指令
 
 help:
   description: 命令帮助

--- a/src/plugins/nonebot_plugin_broadcast/help.yaml
+++ b/src/plugins/nonebot_plugin_broadcast/help.yaml
@@ -1,0 +1,4 @@
+plugin: broadcast
+commands:
+  bcsu: help;5;superuser
+  bc: bc_help;3;tools

--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -206,7 +206,7 @@ menu_cmd = on_alconna(Alconna("menu", Args["category?", str]))
 
 
 @menu_cmd.assign("category")
-async def _(category: str, user_id: str = get_user_id()) -> None:
+async def menu_category_handler(category: str, user_id: str = get_user_id()) -> None:
     cat_data = await get_category_commands(category, user_id)
     if cat_data is None:
         await lang.finish("menu.category_not_found", user_id, category)
@@ -233,7 +233,7 @@ async def _(category: str, user_id: str = get_user_id()) -> None:
 
 
 @menu_cmd.assign("$main")
-async def _(user_id: str = get_user_id()) -> None:
+async def menu_main_handler(user_id: str = get_user_id()) -> None:
     try:
         await menu_cmd.finish(
             UniMessage().image(

--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -218,7 +218,7 @@ async def _(category: str, user_id: str = get_user_id()) -> None:
                     cat_data["name"],
                     user_id,
                     cat_data,
-                    {"usage_text": await lang.text("list.usage_text", user_id)},
+                    {"help_hint": await lang.text("menu.menu_cat_help_hint", user_id)},
                     False,
                     True,
                 ),

--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 from nonebot.log import logger
 import traceback
 from unittest.util import sorted_list_difference
@@ -73,7 +74,7 @@ async def get_templates(user_id: str) -> list[dict[str, Any]]:
         raise ValueError("No Command")
     sorted_help_list = sorted(list(help_list.items()), key=lambda x: x[0])
     commands = []
-    for command in [await get_help_dict(name, user_id, data) for name, data in sorted_help_list]:
+    for command in [await get_help_dict(name, user_id, data) for name, data in sorted_help_list if data.category != "superuser"]:
         for category in commands:
             if category["name"] == command["category"]:
                 category["commands"].append(command)
@@ -135,3 +136,113 @@ async def _(user_id: str = get_user_id()) -> None:
     except Exception:
         logger.error(traceback.format_exc())
         await help_cmd.finish(await lang.text("command.error", user_id))
+
+
+async def get_menu_templates(user_id: str) -> list[dict[str, Any]]:
+    """获取菜单所需的所有分类数据，包括 superuser"""
+    if not help_list:
+        raise ValueError("No Command")
+    sorted_help_list = sorted(list(help_list.items()), key=lambda x: x[0])
+    categories: dict[str, dict] = {}
+    for name, data in sorted_help_list:
+        cat_id = data.category
+        if cat_id not in categories:
+            categories[cat_id] = {"id": cat_id, "commands": []}
+        cmd_dict = await get_help_dict(name, user_id, data)
+        categories[cat_id]["commands"].append(cmd_dict)
+
+    result = []
+    for cat_id, cat_data in categories.items():
+        cat_data["name"] = await lang.text(f"list.category.{cat_id}", user_id)
+        cat_data["count"] = len(cat_data["commands"])
+        result.append(cat_data)
+    return result
+
+
+async def get_random_command(user_id: str) -> dict:
+    """随机指令（排除 superuser）"""
+    non_super = {name: data for name, data in help_list.items() if data.category != "superuser"}
+    if not non_super:
+        raise ValueError("No non-superuser commands")
+    name = random.choice(list(non_super.keys()))
+    return await get_help_dict(name, user_id, non_super[name])
+
+
+async def get_category_commands(category_id: str, user_id: str) -> Optional[dict]:
+    """获取指定分类的指令数据"""
+    commands = []
+    for name, data in sorted(help_list.items(), key=lambda x: x[0]):
+        if data.category == category_id:
+            commands.append(await get_help_dict(name, user_id, data))
+    if not commands:
+        return None
+    return {
+        "id": category_id,
+        "name": await lang.text(f"list.category.{category_id}", user_id),
+        "commands": commands,
+        "count": len(commands),
+    }
+
+
+@creator("menu.html.jinja")
+async def render_menu(user_id: str) -> bytes:
+    categories = await get_menu_templates(user_id)
+    random_cmd = await get_random_command(user_id)
+    return await render_template(
+        "menu.html.jinja",
+        await lang.text("menu.title", user_id),
+        user_id,
+        {"categories": categories, "random_command": random_cmd},
+        {
+            "menu_category_hint": await lang.text("menu.menu_category_hint", user_id),
+            "random_title": await lang.text("menu.random_title", user_id),
+        },
+        True,
+        True,
+    )
+
+
+menu_cmd = on_alconna(Alconna("menu", Args["category?", str]))
+
+
+@menu_cmd.assign("category")
+async def _(category: str, user_id: str = get_user_id()) -> None:
+    cat_data = await get_category_commands(category, user_id)
+    if cat_data is None:
+        await lang.finish("menu.category_not_found", user_id, category)
+    try:
+        await menu_cmd.finish(
+            UniMessage().image(
+                raw=await render_template(
+                    "menu_category.html.jinja",
+                    cat_data["name"],
+                    user_id,
+                    cat_data,
+                    {"usage_text": await lang.text("list.usage_text", user_id)},
+                    False,
+                    True,
+                ),
+                name="image.png",
+            )
+        )
+    except FinishedException:
+        raise
+    except Exception:
+        logger.error(traceback.format_exc())
+        await menu_cmd.finish(await lang.text("command.error", user_id))
+
+
+@menu_cmd.assign("$main")
+async def _(user_id: str = get_user_id()) -> None:
+    try:
+        await menu_cmd.finish(
+            UniMessage().image(
+                raw=await render_menu(user_id),
+                name="image.png",
+            )
+        )
+    except FinishedException:
+        raise
+    except Exception:
+        logger.error(traceback.format_exc())
+        await menu_cmd.finish(await lang.text("command.error", user_id))

--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -91,6 +91,7 @@ async def generate_markdown() -> str:
     await load_languages()
     user_id = f"mlsid::--lang={sys.argv[1]}"
     text = await lang.text("markdown.title", user_id)
+    # Regular commands (excluding superuser)
     commands = []
     for command_list in [category["commands"] for category in (await get_templates(user_id))]:
         commands.extend(command_list)
@@ -100,6 +101,17 @@ async def generate_markdown() -> str:
         )
         for usage in command["usages"]:
             text += await lang.text("markdown.usage", user_id, usage)
+    # Superuser commands with warning
+    for category in (await get_menu_templates(user_id)):
+        if category["id"] == "superuser":
+            for command in category["commands"]:
+                text += await lang.text(
+                    "markdown.command", user_id, command["name"], command["description"], command["details"]
+                )
+                text += await lang.text("markdown.superuser_warning", user_id) + "\n"
+                for usage in command["usages"]:
+                    text += await lang.text("markdown.usage", user_id, usage)
+            break
     return text
 
 

--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -74,7 +74,9 @@ async def get_templates(user_id: str) -> list[dict[str, Any]]:
         raise ValueError("No Command")
     sorted_help_list = sorted(list(help_list.items()), key=lambda x: x[0])
     commands = []
-    for command in [await get_help_dict(name, user_id, data) for name, data in sorted_help_list if data.category != "superuser"]:
+    for command in [
+        await get_help_dict(name, user_id, data) for name, data in sorted_help_list if data.category != "superuser"
+    ]:
         for category in commands:
             if category["name"] == command["category"]:
                 category["commands"].append(command)
@@ -102,7 +104,7 @@ async def generate_markdown() -> str:
         for usage in command["usages"]:
             text += await lang.text("markdown.usage", user_id, usage)
     # Superuser commands with warning
-    for category in (await get_menu_templates(user_id)):
+    for category in await get_menu_templates(user_id):
         if category["id"] == "superuser":
             for command in category["commands"]:
                 text += await lang.text(

--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -184,7 +184,6 @@ async def get_category_commands(category_id: str, user_id: str) -> Optional[dict
     }
 
 
-@creator("menu.html.jinja")
 async def render_menu(user_id: str) -> bytes:
     categories = await get_menu_templates(user_id)
     random_cmd = await get_random_command(user_id)

--- a/src/plugins/nonebot_plugin_larkhelp/help.yaml
+++ b/src/plugins/nonebot_plugin_larkhelp/help.yaml
@@ -1,3 +1,4 @@
 plugin: larkhelp
 commands:
   help: help;2;tools
+  menu: menu;2;tools

--- a/src/plugins/nonebot_plugin_openai/help.yaml
+++ b/src/plugins/nonebot_plugin_openai/help.yaml
@@ -1,3 +1,3 @@
 plugin: openai
 commands:
-  model: help_model;4;setting
+  model: help_model;4;superuser

--- a/src/templates/menu.html.jinja
+++ b/src/templates/menu.html.jinja
@@ -1,0 +1,30 @@
+{% extends base %}
+
+{% block body %}
+<div class="row">
+    <div class="col-12" style="text-align:center;font-size:20px;margin-bottom:10px;">
+        ฅ^•ﻌ•^ฅ Moonlark 在这里喵~！
+    </div>
+</div>
+<hr>
+<div class="row">
+    <div class="col-12">
+        {% for c in categories %}
+        <div style="margin: 8px 0; display: flex; align-items: center; gap: 8px;">
+            <span class="badge bg-secondary" style="font-size: 14px;">{{ c.id }}</span>
+            <span style="flex-grow: 1;">{{ c.name }}</span>
+            <span class="badge bg-info rounded-pill" style="font-size: 12px;">{{ c.count }} 个指令</span>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+<hr>
+<p style="color: #666;">{{ text.menu_category_hint }}</p>
+<hr>
+<div class="row">
+    <div class="col-12">
+        <h5>{{ text.random_title }}</h5>
+        <p><span class="badge bg-info">{{ random_command.name }}</span> {{ random_command.description }}</p>
+    </div>
+</div>
+{% endblock body %}

--- a/src/templates/menu_category.html.jinja
+++ b/src/templates/menu_category.html.jinja
@@ -1,0 +1,18 @@
+{% extends base %}
+
+{% block body %}
+<div class="row">
+    <div class="col-12">
+        <ul style="list-style: none; padding: 0;">
+            {% for command in commands %}
+            <li style="margin: 10px 0;">
+                <span class="badge bg-info" style="font-size: 14px;">{{ command.name }}</span>
+                <span style="margin-left: 8px;">{{ command.description }}</span>
+            </li>
+            {% endfor %}
+        </ul>
+        <hr>
+        <p style="color: #666;">{{ text.usage_text }}</p>
+    </div>
+</div>
+{% endblock body %}

--- a/src/templates/menu_category.html.jinja
+++ b/src/templates/menu_category.html.jinja
@@ -12,7 +12,7 @@
             {% endfor %}
         </ul>
         <hr>
-        <p style="color: #666;">{{ text.usage_text }}</p>
+        <p style="color: #666;">{{ text.help_hint }}</p>
     </div>
 </div>
 {% endblock body %}


### PR DESCRIPTION
## Summary

添加 `/menu` 分级菜单指令，类似于 help 的扩展版。

## Changes

### 1. New feature: `/menu` command
新增分级菜单指令，支持两种模式：
- `menu` - 显示根菜单，包含所有分类列表和随机指令展示
- `menu <category>` - 显示指定分类下的指令列表

### 2. help.yaml 模型扩展
- `help.yaml` 支持 `superuser` 分类
- `superuser` 分类的指令默认不在 `help` 中展示
- 在 `menu` 中显示为「管理员」

### 3. 指令分类调整
- 将 `/model` 指令从 `setting` 分类移至 `superuser` 分类

### 4. 翻译支持
- 添加了 zh_hans、zh_tw、en_us 三种语言的 menu 相关字符串

## Files modified
| File | Change |
|------|--------|
| `src/plugins/nonebot_plugin_larkhelp/__main__.py` | 添加 menu 指令、分类查询、随机指令功能；help 过滤 superuser |
| `src/templates/menu.html.jinja` | 菜单根模板（分类列表+随机指令） |
| `src/templates/menu_category.html.jinja` | 分类详情模板（指令列表） |
| `src/plugins/nonebot_plugin_larkhelp/help.yaml` | 注册 menu 指令自己 |
| `src/plugins/nonebot_plugin_openai/help.yaml` | model 指令改为 superuser 分类 |
| `src/lang/zh_hans/larkhelp.yaml` | 添加 menu 翻译 |
| `src/lang/zh_tw/larkhelp.yaml` | 添加 menu 翻译 |
| `src/lang/en_us/larkhelp.yaml` | 添加 menu 翻译 |