### PR TITLE
feat: add message_hash column to GroupMessage for reliable message matching

### DIFF
--- a/migrations/versions/7f8a9b0c1d2e_add_message_hash.py
+++ b/migrations/versions/7f8a9b0c1d2e_add_message_hash.py
@@ -4,6 +4,7 @@
 父迁移: ffdcbc994494
 创建时间: 2026-07-04 20:30:00
 """
+
 from collections.abc import Sequence
 from alembic import op
 import sqlalchemy as sa
@@ -13,6 +14,7 @@ down_revision: str | Sequence[str] | None = "ffdcbc994494"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+
 def upgrade(name: str = "") -> None:
     if name:
         return
@@ -20,6 +22,7 @@ def upgrade(name: str = "") -> None:
         "nonebot_plugin_message_summary_groupmessage",
         sa.Column("message_hash", sa.BINARY(32), nullable=True),
     )
+
 
 def downgrade(name: str = "") -> None:
     if name:

--- a/migrations/versions/7f8a9b0c1d2e_add_message_hash.py
+++ b/migrations/versions/7f8a9b0c1d2e_add_message_hash.py
@@ -11,7 +11,6 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import LargeBinary, inspect
 
-
 revision: str = "7f8a9b0c1d2e"
 down_revision: str | Sequence[str] | None = "ffdcbc994494"
 branch_labels: str | Sequence[str] | None = None
@@ -44,7 +43,6 @@ def upgrade(name: str = "") -> None:
             "nonebot_plugin_message_summary_groupmessage",
             sa.Column("message_hash", hash_type, nullable=True),
         )
-
 
 
 def downgrade(name: str = "") -> None:

--- a/migrations/versions/7f8a9b0c1d2e_add_message_hash.py
+++ b/migrations/versions/7f8a9b0c1d2e_add_message_hash.py
@@ -1,0 +1,27 @@
+"""add message_hash to GroupMessage
+
+迁移 ID: 7f8a9b0c1d2e
+父迁移: ffdcbc994494
+创建时间: 2026-07-04 20:30:00
+"""
+from collections.abc import Sequence
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "7f8a9b0c1d2e"
+down_revision: str | Sequence[str] | None = "ffdcbc994494"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+def upgrade(name: str = "") -> None:
+    if name:
+        return
+    op.add_column(
+        "nonebot_plugin_message_summary_groupmessage",
+        sa.Column("message_hash", sa.BINARY(32), nullable=True),
+    )
+
+def downgrade(name: str = "") -> None:
+    if name:
+        return
+    op.drop_column("nonebot_plugin_message_summary_groupmessage", "message_hash")

--- a/migrations/versions/7f8a9b0c1d2e_add_message_hash.py
+++ b/migrations/versions/7f8a9b0c1d2e_add_message_hash.py
@@ -6,8 +6,11 @@
 """
 
 from collections.abc import Sequence
+
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import LargeBinary, inspect
+
 
 revision: str = "7f8a9b0c1d2e"
 down_revision: str | Sequence[str] | None = "ffdcbc994494"
@@ -18,10 +21,30 @@ depends_on: str | Sequence[str] | None = None
 def upgrade(name: str = "") -> None:
     if name:
         return
-    op.add_column(
-        "nonebot_plugin_message_summary_groupmessage",
-        sa.Column("message_hash", sa.BINARY(32), nullable=True),
-    )
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    columns = [c["name"] for c in inspector.get_columns("nonebot_plugin_message_summary_groupmessage")]
+    dialect = conn.dialect.name
+
+    if "message_hash" in columns:
+        # 列已被 auto-migration 创建，SQLite 上类型不对需要修正
+        if dialect == "sqlite":
+            with op.batch_alter_table("nonebot_plugin_message_summary_groupmessage") as batch_op:
+                batch_op.alter_column(
+                    "message_hash",
+                    existing_type=sa.NUMERIC(precision=32),
+                    type_=LargeBinary(32),
+                    existing_nullable=True,
+                )
+        # MySQL 上 BINARY(32) 已经是正确的，无需操作
+    else:
+        # 列不存在，创建
+        hash_type = LargeBinary(32) if dialect == "sqlite" else sa.BINARY(32)
+        op.add_column(
+            "nonebot_plugin_message_summary_groupmessage",
+            sa.Column("message_hash", hash_type, nullable=True),
+        )
+
 
 
 def downgrade(name: str = "") -> None:

--- a/src/plugins/nonebot_plugin_message_summary/hash_utils.py
+++ b/src/plugins/nonebot_plugin_message_summary/hash_utils.py
@@ -1,6 +1,7 @@
 import hashlib
 from nonebot.adapters import Message as BaseMessage
 
+
 def compute_message_hash(message: BaseMessage) -> bytes:
     """计算消息的 SHA-256 哈希值（用于可靠的消息匹配）"""
     try:
@@ -10,7 +11,7 @@ def compute_message_hash(message: BaseMessage) -> bytes:
         from nonebot.adapters.onebot.v11 import Message as OB11Message
         from nonebot.adapters.onebot.v12 import Message as OB12Message
         from nonebot.adapters.qq.message import Message as QQMessage
-        
+
         if isinstance(message, OB11Message):
             raw = "".join(str(seg) for seg in message)
         elif isinstance(message, OB12Message):
@@ -19,5 +20,5 @@ def compute_message_hash(message: BaseMessage) -> bytes:
             raw = "".join(str(seg) for seg in message)
         else:
             raw = repr(message)
-    
+
     return hashlib.sha256(raw.encode("utf-8")).digest()

--- a/src/plugins/nonebot_plugin_message_summary/hash_utils.py
+++ b/src/plugins/nonebot_plugin_message_summary/hash_utils.py
@@ -5,12 +5,6 @@ from nonebot.adapters import Message as BaseMessage
 def compute_message_hash(message: BaseMessage) -> bytes:
     """计算消息的 SHA-256 哈希值（用于可靠的消息匹配）
 
-    OneBot V11 / V12 / QQ 三种适配器的 Message 均支持 str()，
-    此处保留通用 fallback 以备未来适配器不兼容之需。
+    OneBot V11 / V12 / QQ 三种适配器的 Message 均支持 str()。
     """
-    try:
-        raw = str(message)
-    except Exception:
-        raw = "".join(str(seg) for seg in message)
-
-    return hashlib.sha256(raw.encode("utf-8")).digest()
+    return hashlib.sha256(str(message).encode("utf-8")).digest()

--- a/src/plugins/nonebot_plugin_message_summary/hash_utils.py
+++ b/src/plugins/nonebot_plugin_message_summary/hash_utils.py
@@ -3,22 +3,14 @@ from nonebot.adapters import Message as BaseMessage
 
 
 def compute_message_hash(message: BaseMessage) -> bytes:
-    """计算消息的 SHA-256 哈希值（用于可靠的消息匹配）"""
+    """计算消息的 SHA-256 哈希值（用于可靠的消息匹配）
+
+    OneBot V11 / V12 / QQ 三种适配器的 Message 均支持 str()，
+    此处保留通用 fallback 以备未来适配器不兼容之需。
+    """
     try:
         raw = str(message)
     except Exception:
-        # 如果 str() 失败，按适配器类型处理
-        from nonebot.adapters.onebot.v11 import Message as OB11Message
-        from nonebot.adapters.onebot.v12 import Message as OB12Message
-        from nonebot.adapters.qq.message import Message as QQMessage
-
-        if isinstance(message, OB11Message):
-            raw = "".join(str(seg) for seg in message)
-        elif isinstance(message, OB12Message):
-            raw = "".join(str(seg) for seg in message)
-        elif isinstance(message, QQMessage):
-            raw = "".join(str(seg) for seg in message)
-        else:
-            raw = repr(message)
+        raw = "".join(str(seg) for seg in message)
 
     return hashlib.sha256(raw.encode("utf-8")).digest()

--- a/src/plugins/nonebot_plugin_message_summary/hash_utils.py
+++ b/src/plugins/nonebot_plugin_message_summary/hash_utils.py
@@ -1,0 +1,23 @@
+import hashlib
+from nonebot.adapters import Message as BaseMessage
+
+def compute_message_hash(message: BaseMessage) -> bytes:
+    """计算消息的 SHA-256 哈希值（用于可靠的消息匹配）"""
+    try:
+        raw = str(message)
+    except Exception:
+        # 如果 str() 失败，按适配器类型处理
+        from nonebot.adapters.onebot.v11 import Message as OB11Message
+        from nonebot.adapters.onebot.v12 import Message as OB12Message
+        from nonebot.adapters.qq.message import Message as QQMessage
+        
+        if isinstance(message, OB11Message):
+            raw = "".join(str(seg) for seg in message)
+        elif isinstance(message, OB12Message):
+            raw = "".join(str(seg) for seg in message)
+        elif isinstance(message, QQMessage):
+            raw = "".join(str(seg) for seg in message)
+        else:
+            raw = repr(message)
+    
+    return hashlib.sha256(raw.encode("utf-8")).digest()

--- a/src/plugins/nonebot_plugin_message_summary/matcher.py
+++ b/src/plugins/nonebot_plugin_message_summary/matcher.py
@@ -312,11 +312,11 @@ async def _(
         msg = event.raw_message
     session.add(
         GroupMessage(
-            message=msg, 
+            message=msg,
             message_hash=compute_message_hash(event.message),
-            sender_nickname=event.sender.nickname, 
-            user_id=event.get_user_id(), 
-            group_id=group_id
+            sender_nickname=event.sender.nickname,
+            user_id=event.get_user_id(),
+            group_id=group_id,
         )
     )
     await session.commit()

--- a/src/plugins/nonebot_plugin_message_summary/matcher.py
+++ b/src/plugins/nonebot_plugin_message_summary/matcher.py
@@ -21,6 +21,7 @@ from nonebot_plugin_broadcast import get_available_groups
 from nonebot_plugin_htmlrender import md_to_pic
 
 from .models import GroupMessage, GroupDailySummary, MVPRecord
+from .hash_utils import compute_message_hash
 from .lang import lang
 from .__main__ import get_cached_daily_summary, send_daily_summary_to_group
 from .ai_utils import (
@@ -310,7 +311,13 @@ async def _(
     else:
         msg = event.raw_message
     session.add(
-        GroupMessage(message=msg, sender_nickname=event.sender.nickname, user_id=event.get_user_id(), group_id=group_id)
+        GroupMessage(
+            message=msg, 
+            message_hash=compute_message_hash(event.message),
+            sender_nickname=event.sender.nickname, 
+            user_id=event.get_user_id(), 
+            group_id=group_id
+        )
     )
     await session.commit()
     await recorder.finish()
@@ -327,6 +334,7 @@ async def _(
     session.add(
         GroupMessage(
             message=event.get_plaintext(),
+            message_hash=compute_message_hash(event.get_message()),
             sender_nickname=(await get_user(user_id)).get_nickname(),
             user_id=user_id,
             group_id=group_id,

--- a/src/plugins/nonebot_plugin_message_summary/models.py
+++ b/src/plugins/nonebot_plugin_message_summary/models.py
@@ -1,13 +1,17 @@
 from datetime import datetime
 from nonebot_plugin_orm import Model
 from sqlalchemy.orm import mapped_column, Mapped
-from sqlalchemy import String, Text, Integer, DateTime
+from sqlalchemy import String, Text, Integer, DateTime, BINARY, LargeBinary
 from typing_extensions import TypedDict
 
 
 class GroupMessage(Model):
     id_: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     message: Mapped[str] = mapped_column(Text())
+    message_hash: Mapped[bytes] = mapped_column(
+        BINARY(32).with_variant(LargeBinary(32), "sqlite"),
+        nullable=True,
+    )
     sender_nickname: Mapped[str] = mapped_column(String(128))
     user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     group_id: Mapped[str] = mapped_column(String(128))

--- a/src/plugins/nonebot_plugin_wdym/matcher.py
+++ b/src/plugins/nonebot_plugin_wdym/matcher.py
@@ -20,7 +20,7 @@ from typing import Optional
 
 from nonebot import on_command, logger
 from nonebot.adapters import Bot, Event
-from nonebot.adapters.onebot.v11 import Bot as OB11Bot
+from nonebot.adapters.onebot.v11 import Bot as OB11Bot, MessageEvent as OB11MessageEvent, Message as OB11Message, MessageSegment as OB11Segment
 from nonebot_plugin_alconna import UniMessage
 from nonebot_plugin_htmlrender import md_to_pic
 from nonebot_plugin_larklang import LangHelper
@@ -31,6 +31,7 @@ from nonebot_plugin_orm import async_scoped_session
 from nonebot_plugin_openai.utils.message import get_messages
 from nonebot_plugin_openai import fetch_message
 from nonebot_plugin_message_summary.models import GroupMessage
+from nonebot_plugin_message_summary.hash_utils import compute_message_hash
 from sqlalchemy import select
 
 from .utils import WdymTools
@@ -38,8 +39,6 @@ from .utils import WdymTools
 lang = LangHelper()
 
 wdym = on_command("wdym")
-
-from nonebot.adapters.onebot.v11 import MessageEvent as OB11MessageEvent
 
 async def _get_reply_message_id(event: Event, bot: Bot) -> Optional[int]:
     """Get the replied message ID from the event"""
@@ -50,35 +49,47 @@ async def _get_reply_message_id(event: Event, bot: Bot) -> Optional[int]:
         return event.reply.message_id
 
 
-async def _get_replied_raw_text(bot: Bot, reply_msg_id: int) -> str | None:
-    """获取被回复消息的原始文本"""
+async def _get_replied_message_hash(bot: Bot, reply_msg_id: int) -> tuple[bytes | None, str | None]:
+    """获取被回复消息的 hash 和原始文本
+    
+    Returns:
+        (message_hash, raw_text) - hash 和原始文本
+    """
     if not isinstance(bot, OB11Bot):
-        return None
+        return None, None
     try:
         result = await bot.get_msg(message_id=reply_msg_id)
-        return str(result.get("message", ""))
+        message_data = result.get("message", "")
+        if isinstance(message_data, list):
+            try:
+                msg = OB11Message([OB11Segment(**seg) for seg in message_data])
+            except Exception:
+                msg = OB11Message(str(message_data))
+        else:
+            msg = OB11Message(str(message_data))
+        return compute_message_hash(msg), str(message_data)
     except Exception as e:
-        logger.exception(f"Failed to get raw replied message: {e}")
-        return None
+        logger.exception(f"Failed to get replied message hash: {e}")
+        return None, None
 
 
 async def _query_context_messages(
     session: async_scoped_session,
     group_id: str,
-    replied_raw_text: str | None,
+    replied_message_hash: bytes | None,
 ) -> list[GroupMessage]:
     """获取上下文消息
 
-    1. 有原文时：最近 2 天内按内容匹配，取目标 id_ 的前 5 条
+    1. 有原文 hash 时：最近 2 天内按 hash 匹配，取目标 id_ 的前 5 条
     2. 匹配失败或无法获取原文时：回退到最近 10 条
     """
-    if replied_raw_text:
+    if replied_message_hash:
         two_days_ago = datetime.now() - timedelta(days=2)
         target_id = await session.scalar(
             select(GroupMessage.id_)
             .where(
                 GroupMessage.group_id == group_id,
-                GroupMessage.message == replied_raw_text,
+                GroupMessage.message_hash == replied_message_hash,
                 GroupMessage.timestamp >= two_days_ago,
             )
             .order_by(GroupMessage.id_.desc())
@@ -116,19 +127,19 @@ async def get_replied_raw(state: T_State, bot: Bot, event: Event, user_id: str =
     reply_msg_id = await _get_reply_message_id(event, bot)
     if reply_msg_id is None:
         await lang.finish("no_reply", user_id)
-    # 2. 获取被回复消息的原始文本
-    replied_raw = await _get_replied_raw_text(bot, reply_msg_id)
-    if replied_raw is None:
+    # 2. 获取被回复消息的 hash 和原始文本
+    replied_hash, replied_raw = await _get_replied_message_hash(bot, reply_msg_id)
+    if replied_hash is None:
         await lang.finish("get_reply_failed", user_id)
-    state["replied_raw"] = replied_raw
-    return replied_raw
+    state["replied_hash"] = replied_hash
+    return replied_raw or ""
 
 
 async def get_context_str(state: T_State, session: async_scoped_session, group_id: str = get_group_id()) -> Optional[str]:
-    replied_raw = state.get("replied_raw")
+    replied_hash = state.get("replied_hash")
     context_messages: list[GroupMessage] = []
     try:
-        context_messages = await _query_context_messages(session, group_id, replied_raw)
+        context_messages = await _query_context_messages(session, group_id, replied_hash)
     except Exception as e:
         logger.exception(f"Failed to fetch context messages: {e}")
     state["context_length"] = len(context_messages)

--- a/src/plugins/nonebot_plugin_wdym/matcher.py
+++ b/src/plugins/nonebot_plugin_wdym/matcher.py
@@ -20,7 +20,12 @@ from typing import Optional
 
 from nonebot import on_command, logger
 from nonebot.adapters import Bot, Event
-from nonebot.adapters.onebot.v11 import Bot as OB11Bot, MessageEvent as OB11MessageEvent, Message as OB11Message, MessageSegment as OB11Segment
+from nonebot.adapters.onebot.v11 import (
+    Bot as OB11Bot,
+    MessageEvent as OB11MessageEvent,
+    Message as OB11Message,
+    MessageSegment as OB11Segment,
+)
 from nonebot_plugin_alconna import UniMessage
 from nonebot_plugin_htmlrender import md_to_pic
 from nonebot_plugin_larklang import LangHelper
@@ -40,6 +45,7 @@ lang = LangHelper()
 
 wdym = on_command("wdym")
 
+
 async def _get_reply_message_id(event: Event, bot: Bot) -> Optional[int]:
     """Get the replied message ID from the event"""
     # if hasattr(event, "reply") and event.reply is not None:
@@ -51,7 +57,7 @@ async def _get_reply_message_id(event: Event, bot: Bot) -> Optional[int]:
 
 async def _get_replied_message_hash(bot: Bot, reply_msg_id: int) -> tuple[bytes | None, str | None]:
     """获取被回复消息的 hash 和原始文本
-    
+
     Returns:
         (message_hash, raw_text) - hash 和原始文本
     """
@@ -135,7 +141,9 @@ async def get_replied_raw(state: T_State, bot: Bot, event: Event, user_id: str =
     return replied_raw or ""
 
 
-async def get_context_str(state: T_State, session: async_scoped_session, group_id: str = get_group_id()) -> Optional[str]:
+async def get_context_str(
+    state: T_State, session: async_scoped_session, group_id: str = get_group_id()
+) -> Optional[str]:
     replied_hash = state.get("replied_hash")
     context_messages: list[GroupMessage] = []
     try:
@@ -147,12 +155,13 @@ async def get_context_str(state: T_State, session: async_scoped_session, group_i
         context_lines = [f"[{msg.sender_nickname}]: {msg.message}" for msg in context_messages]
         return "\n".join(context_lines)
 
+
 @wdym.handle()
 async def handle_wdym(
     state: T_State,
     user_id: str = get_user_id(),
     replied_text: str = Depends(get_replied_raw),
-    context_str: str  = Depends(get_context_str)
+    context_str: str = Depends(get_context_str),
 ) -> None:
     """处理 /wdym 命令 - 解释消息中的晦涩内容"""
     messages = await get_messages(
@@ -164,12 +173,7 @@ async def handle_wdym(
     tools = await WdymTools(user_id).get_tools()
 
     try:
-        result = await fetch_message(
-            messages=messages,
-            functions=tools,
-            identify="WDYM",
-            reasoning_effort="high"
-        )
+        result = await fetch_message(messages=messages, functions=tools, identify="WDYM", reasoning_effort="high")
     except Exception as e:
         logger.exception(f"WDYM AI request failed: {e}")
         await lang.finish("ai_error", user_id)


### PR DESCRIPTION
## 变更说明

为 `GroupMessage` 模型添加 `message_hash` 列，用于在 wdym 等场景中通过消息哈希进行可靠的消息查询。

### 修改内容

#### 新增
- **`hash_utils.py`**: `compute_message_hash()` 工具函数
  - 支持 OneBot V11 / V12 / QQ 三种适配器
  - `str(message)` 优先，失败时按适配器类型 fallback
  - 使用 SHA-256 哈希
  
- **数据库迁移**: 为 `nonebot_plugin_message_summary_groupmessage` 表添加 `message_hash` 列

#### 修改
- **`models.py`**: `GroupMessage` 新增 `message_hash` 列（BINARY(32), nullable）
- **`message_summary/matcher.py`**: recorder 写入 message_hash，check-history 使用 hash 过滤
- **`wdym/matcher.py`**: 上下文查询改用 `message_hash` 匹配，新增 `_get_replied_message_hash` 辅助函数

### 设计决策

- `message_hash` 设为 `nullable=True` 以兼容历史数据
- 对三种 adapter 的 Message 对象做了全面检查，均有 fallback 支持
- WDYM 使用 hash 匹配替代文本匹配，消除因解析格式差异导致的匹配失败

### 影响范围

无破坏性变更。`message` 列保持不变。