### PR TITLE
fix(chat): ignore output parse failure on tool call rounds

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5474,24 +5474,24 @@ unleash = ["UnleashClient (>=6.0.1)"]
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 description = "Most extensible Python build backend with support for C/C++ extension modules"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb"},
-    {file = "setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9"},
+    {file = "setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3"},
+    {file = "setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
 core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
+enabler = ["pytest-enabler (>=3.4)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [[package]]
 name = "six"

--- a/src/plugins/nonebot_plugin_chat/core/message.py
+++ b/src/plugins/nonebot_plugin_chat/core/message.py
@@ -360,6 +360,7 @@ class MessageQueue:
 
         self.fetcher = await self._create_fetcher()
         retry_count = 0
+        analysis = None  # 跟踪是否已成功解析 JSON
         try:
             async for message in self.fetcher.fetch_message_stream():
                 if retry_count > 5:
@@ -369,6 +370,13 @@ class MessageQueue:
                 try:
                     analysis = type_validate_json(ModelResponse, strip_json_codeblock(message))
                 except Exception as e:
+                    # 如果当前轮次含有工具调用，忽略输出解析失败提示
+                    last_msg = self.fetcher.session.messages[-1] if self.fetcher.session.messages else None
+                    if last_msg and getattr(last_msg, "tool_calls", None):
+                        continue
+                    # 如果已成功解析过 JSON，忽略同一调用后续轮次的解析失败
+                    if analysis is not None:
+                        continue
                     self.fetcher.session.insert_message(
                         generate_message(await self.processor.session.text("fetcher.parse_failed", str(e)), "user")
                     )

--- a/src/plugins/nonebot_plugin_chat/core/message.py
+++ b/src/plugins/nonebot_plugin_chat/core/message.py
@@ -65,7 +65,6 @@ class MessageQueue:
         fetcher.session.set_custom_trace_id(self.trace_id)
         return fetcher
 
-
     async def reset_chat_history(self) -> list[OpenAIMessage]:
         messages = copy.deepcopy(self.messages)
         if self.fetcher is not None:

--- a/src/plugins/nonebot_plugin_wdym/matcher.py
+++ b/src/plugins/nonebot_plugin_wdym/matcher.py
@@ -92,7 +92,9 @@ async def _get_replied_message_hash(
         if group_msg is not None:
             raw_text = group_msg.message
         else:
-            raw_text = await parse_message_to_string(UniMessage.generate_without_reply(message=msg, bot=bot), event, bot, state, lang_str)
+            raw_text = await parse_message_to_string(
+                UniMessage.generate_without_reply(message=msg, bot=bot), event, bot, state, lang_str
+            )
         return message_hash, raw_text
     except Exception as e:
         logger.exception(f"Failed to get replied message hash: {e}")
@@ -168,7 +170,9 @@ async def get_replied_raw(
 
 
 async def get_context_str(
-    state: T_State, session: async_scoped_session, group_id: str = get_group_id(),
+    state: T_State,
+    session: async_scoped_session,
+    group_id: str = get_group_id(),
 ) -> Optional[str]:
     replied_hash = state.get("replied_hash")
     context_messages: list[GroupMessage] = []


### PR DESCRIPTION
## 问题

在 `_fetch_reply` 中，每次 `fetch_message_stream()` 的输出都会被尝试解析为 `ModelResponse` JSON。但在以下场景中会错误地插入 `parse_failed` 提示：

1. **模型输出思考内容 + 工具调用**：模型在输出最终 JSON 前可能先输出思考文本，且同一轮次包含 `tool_calls`，此时思考文本本就不应被当作 `ModelResponse` 解析
2. **多轮 LLM 调用**：`_fetch_reply` 的一个完整执行周期内可能包含多次 LLM 请求（例如先工具调用再生成回复），后续轮次的输出如果解析失败，但前一轮已成功解析过 JSON，说明错误是多余的

## 修改

在 `_fetch_reply` 的 `except` 块中增加两个跳过条件：

1. 检查 `messages[-1].tool_calls`：如果当前 LLM 响应拥有工具调用，则该轮次输出的内容不必符合 `ModelResponse` 格式，直接跳过解析失败处理
2. 检查 `analysis is not None`：如果同一 `_fetch_reply` 调用中已经成功解析过一次 JSON，则后续轮次即使解析失败也无需插入错误提示

## 测试建议

- 触发模型使用工具的场景，确认不会插入提示字让模型重试
- 确保正常场景下（模型直接输出 JSON）的解析失败提示仍能正常工作