### PR TITLE
feat(bots): 支持 QQ 官方 bot 群聊消息路由与群绑定

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -28,3 +28,12 @@ WAKATIME_APP_ID=
 WAKATIME_APP_SECRET=
 TRANSLATE_DEEPLX_URL=
 METASO_API_KEY=
+
+# bots 插件配置
+# bot 代码名到 QQ 号的映射，用于 API 查询
+BOTS_LIST='{"main": "123456789", "secondary": "987654321"}'
+# QQ 官方 bot 的 app_id 到 QQ 号的映射，用于识别自收自发消息
+# 格式: {"app_id": "qq_number"}
+BOTS_APPID_MAP='{"102xxxxxx": "3889000000"}'
+# 群绑定验证码过期时间（秒）
+BOTS_BIND_GROUP_TIMEOUT=300

--- a/src/plugins/nonebot_plugin_bots/__init__.py
+++ b/src/plugins/nonebot_plugin_bots/__init__.py
@@ -12,5 +12,5 @@ __plugin_meta__ = PluginMetadata(
 
 require("nonebot_plugin_apscheduler")
 
-from . import __main__, matchers
+from . import __main__, matchers, bind
 from .__main__ import get_group_bot

--- a/src/plugins/nonebot_plugin_bots/__main__.py
+++ b/src/plugins/nonebot_plugin_bots/__main__.py
@@ -15,7 +15,8 @@ from typing import Optional, cast
 from nonebot_plugin_larkutils import get_group_id, get_user_id
 from .config import config
 from .types import BotStatus, OnlineBotStatus
-from .models import UserBotPrivateChatSettings
+from .models import UserBotPrivateChatSettings, GroupBind
+from .bind import try_process_bind_code
 
 from nonebot import get_bots
 from nonebot_plugin_orm import get_session
@@ -100,6 +101,113 @@ def assign_session(session_id: str, bot_id: str) -> None:
     logger.info(f"已将会话 {session_id} 分配给 {bot_id}")
 
 
+def _is_self_bot_message(user_id: str) -> bool:
+    """检查消息发送者是否属于 Moonlark 自身的 bot（包括 QQ 官方 bot）"""
+    # 检查是否为同一个 NoneBot 实例下的其他 bot
+    if user_id in get_bots():
+        return True
+    # 检查 QQ 官方 bot 的 app_id 映射（app_id 可能不在 get_bots() 中）
+    if user_id in config.bots_appid_map:
+        return True
+    # 反向查找：user_id 是否在 appid_map 的 value 中（对应 bot 的 QQ 号）
+    if user_id in config.bots_appid_map.values():
+        return True
+    return False
+
+
+async def _lookup_bind_by_ob11_group(session_id: str) -> Optional[GroupBind]:
+    """通过 OB11 的 session_id 查找 GroupBind"""
+    from sqlalchemy import select
+    # OB11 session_id 格式: onebot_v11_{qq_group_number}
+    try:
+        parts = session_id.rsplit("_", 1)
+        if len(parts) == 2 and parts[0].startswith("onebot"):
+            group_qq = parts[1]
+            async with get_session() as db_session:
+                result = await db_session.execute(
+                    select(GroupBind).where(GroupBind.group_qq_number == group_qq)
+                )
+                return result.scalar_one_or_none()
+    except Exception:
+        pass
+    return None
+
+
+async def _lookup_bind_by_qqbot_group(session_id: str) -> Optional[GroupBind]:
+    """通过 QQBot 的 session_id 查找 GroupBind"""
+    from sqlalchemy import select
+    try:
+        # QQBot session_id 格式: qq_{group_openid}
+        if session_id.startswith("qq_"):
+            group_oid = session_id[3:]
+            async with get_session() as db_session:
+                result = await db_session.execute(
+                    select(GroupBind).where(GroupBind.group_openid == group_oid)
+                )
+                return result.scalar_one_or_none()
+    except Exception:
+        pass
+    return None
+
+
+async def _get_bound_group(session_id: str) -> Optional[GroupBind]:
+    """获取已绑定的群记录，用于判断是否为共享群"""
+    bind = await _lookup_bind_by_ob11_group(session_id)
+    if bind is not None:
+        return bind
+    return await _lookup_bind_by_qqbot_group(session_id)
+
+
+def _is_qqbot_at_mentioned_in_ob11(event: Event) -> bool:
+    """在 OB11 事件中检查 QQ 官方 bot 是否被 @
+    
+    通过 bots_appid_map 的值（QQ 号）和 bots_list 的值来匹配 @ 目标。
+    """
+    # 获取所有已知的 QQ bot 的 QQ 号
+    known_qqbot_qq_numbers: set[str] = set(config.bots_appid_map.values())
+    # 也加入 bots_list 中的值（某些 bot 可能没在 appid_map 中）
+    known_qqbot_qq_numbers.update(config.bots_list.values())
+
+    try:
+        message = event.get_message()
+        for segment in message:
+            if segment.type == "at":
+                # OB11 V11 的 at segment: data.qq 是 QQ 号
+                at_qq = str(segment.data.get("qq", ""))
+                if at_qq in known_qqbot_qq_numbers:
+                    return True
+                # 也检查 user_id 字段（某些适配器版本可能不同）
+                at_user_id = str(segment.data.get("user_id", ""))
+                if at_user_id in known_qqbot_qq_numbers:
+                    return True
+    except Exception:
+        pass
+    return False
+
+
+def _should_bot_handle_in_shared_group(
+    bot: Bot, event: Event, bind: GroupBind
+) -> bool:
+    """
+    在同时含有 OB11 和 QQBot 的群聊中，判断当前 bot 是否应该处理此消息。
+    
+    规则：
+    - 如果 @ 了 QQ bot → QQBot 处理
+    - 否则 → OB11 优先处理
+    """
+    if isinstance(bot, QQBot):
+        # QQ bot: 只在被 @ 时处理
+        return bool(event.is_tome())
+    elif isinstance(bot, V11Bot):
+        # OB11 bot: 只在 QQ bot 未被 @ 时处理
+        # 如果 QQ bot 被 @，OB11 不处理
+        if _is_qqbot_at_mentioned_in_ob11(event):
+            return False
+        return True
+    else:
+        return True  # 其他类型的 bot 照常处理
+
+
 from nonebot.adapters.onebot.v11.event import PokeNotifyEvent
 from nonebot.adapters import Message
 
@@ -132,14 +240,15 @@ class ToMeProcessor:
         for segment in message:
             if segment.type == "at":
                 user_id = str(segment.get("user_id"))
-                if user_id in config.bots_list.keys():
+                # 检查 bots_list 的 key（对应 bot 的 code）和 bots_appid_map 的 key（app_id）
+                if user_id in config.bots_list.keys() or user_id in config.bots_appid_map.keys():
                     self.to_me = True
                     segment["user_id"] = self.bot.self_id
 
     def process_poke(self) -> None:
         event = cast(PokeNotifyEvent, self.event)
         target_id = str(event.target_id)
-        if target_id in config.bots_list.keys():
+        if target_id in config.bots_list.keys() or target_id in config.bots_appid_map.keys():
             event.target_id = int(self.bot.self_id)
             self.to_me = True
 
@@ -152,7 +261,8 @@ async def _(bot: Bot, event: Event, session_id: str = get_group_id()) -> None:
         user_id = None
 
     if user_id is not None:
-        if user_id in get_bots().keys():
+        # 忽略来自自身 bot 的消息（包括 QQ 官方 bot 通过 appid_map 识别）
+        if _is_self_bot_message(user_id):
             raise IgnoredException("忽略自身消息")
 
         # 检查是否为私聊消息
@@ -171,11 +281,29 @@ async def _(bot: Bot, event: Event, session_id: str = get_group_id()) -> None:
                     if plaintext != ".pm on":
                         raise IgnoredException("用户已关闭该 bot 的私聊")
 
-        ToMeProcessor(bot, event, session_id).process_to_me_event()
+    # 绑定验证码检测（优先于路由，确保绑定消息被正确处理）
+    # 仅在非私聊中检测
+    if not (user_id is not None and event.get_session_id() == user_id):
+        if await try_process_bind_code(bot, event, session_id):
+            raise IgnoredException("绑定验证码已处理")
 
-    if session_id in sessions and sessions[session_id][0] != bot.self_id:
-        raise IgnoredException(f"此群组已分配给帐号 {session_id}")
-    assign_session(session_id, bot.self_id)
+    # 在同时含有 OB11 和 QQBot 的群聊中使用优先级路由
+    bind = await _get_bound_group(session_id)
+    if bind is not None and bind.group_qq_number and bind.group_openid:
+        # 此群同时有 OB11 和 QQBot，使用优先级路由
+        if not _should_bot_handle_in_shared_group(bot, event, bind):
+            raise IgnoredException(f"此消息由其他 bot 优先处理 (session={session_id})")
+        # 如果此 bot 应该处理，分配 session
+        assign_session(session_id, bot.self_id)
+    else:
+        # 普通群聊：原有逻辑
+        # ToMe 处理
+        if user_id is not None:
+            ToMeProcessor(bot, event, session_id).process_to_me_event()
+
+        if session_id in sessions and sessions[session_id][0] != bot.self_id:
+            raise IgnoredException(f"此群组已分配给帐号 {session_id}")
+        assign_session(session_id, bot.self_id)
 
 
 @scheduler.scheduled_job("cron", minute="*", id="remove_expired_email")
@@ -198,12 +326,29 @@ async def get_group_bot(group_id: str) -> Optional[Bot]:
     :return: Bot 实例
     :rtype: Bot | None
     """
+    # 优先检查 session 中分配过的 bot
     if sessions.get(group_id) in (bots := get_bots()):
         return bots[sessions[group_id][0]]
+
     # 尝试遍历所有 bot 查找
     adapter_group_id = group_id.split("_", 1)[-1]
     for bot_id, bot in bots.items():
-        if isinstance(bot, V11Bot) and adapter_group_id in [gid["group_id"] for gid in await bot.get_group_list()]:
-            assign_session(group_id, bot_id)
-            return bot
+        if isinstance(bot, V11Bot):
+            try:
+                if adapter_group_id in [str(gid["group_id"]) for gid in await bot.get_group_list()]:
+                    assign_session(group_id, bot_id)
+                    return bot
+            except Exception:
+                continue
+
+    # 通过 GroupBind 查找：如果是 QQBot 的 group_openid，查找绑定的 OB11 bot
+    try:
+        bind = await _lookup_bind_by_qqbot_group(group_id)
+        if bind is not None and bind.group_qq_number:
+            ob11_group_id = f"onebot_v11_{bind.group_qq_number}"
+            if ob11_group_id in sessions:
+                return bots.get(sessions[ob11_group_id][0])
+    except Exception:
+        pass
+
     return None

--- a/src/plugins/nonebot_plugin_bots/__main__.py
+++ b/src/plugins/nonebot_plugin_bots/__main__.py
@@ -118,15 +118,14 @@ def _is_self_bot_message(user_id: str) -> bool:
 async def _lookup_bind_by_ob11_group(session_id: str) -> Optional[GroupBind]:
     """通过 OB11 的 session_id 查找 GroupBind"""
     from sqlalchemy import select
+
     # OB11 session_id 格式: onebot_v11_{qq_group_number}
     try:
         parts = session_id.rsplit("_", 1)
         if len(parts) == 2 and parts[0].startswith("onebot"):
             group_qq = parts[1]
             async with get_session() as db_session:
-                result = await db_session.execute(
-                    select(GroupBind).where(GroupBind.group_qq_number == group_qq)
-                )
+                result = await db_session.execute(select(GroupBind).where(GroupBind.group_qq_number == group_qq))
                 return result.scalar_one_or_none()
     except Exception:
         pass
@@ -136,14 +135,13 @@ async def _lookup_bind_by_ob11_group(session_id: str) -> Optional[GroupBind]:
 async def _lookup_bind_by_qqbot_group(session_id: str) -> Optional[GroupBind]:
     """通过 QQBot 的 session_id 查找 GroupBind"""
     from sqlalchemy import select
+
     try:
         # QQBot session_id 格式: qq_{group_openid}
         if session_id.startswith("qq_"):
             group_oid = session_id[3:]
             async with get_session() as db_session:
-                result = await db_session.execute(
-                    select(GroupBind).where(GroupBind.group_openid == group_oid)
-                )
+                result = await db_session.execute(select(GroupBind).where(GroupBind.group_openid == group_oid))
                 return result.scalar_one_or_none()
     except Exception:
         pass
@@ -160,7 +158,7 @@ async def _get_bound_group(session_id: str) -> Optional[GroupBind]:
 
 def _is_qqbot_at_mentioned_in_ob11(event: Event) -> bool:
     """在 OB11 事件中检查 QQ 官方 bot 是否被 @
-    
+
     通过 bots_appid_map 的值（QQ 号）和 bots_list 的值来匹配 @ 目标。
     """
     # 获取所有已知的 QQ bot 的 QQ 号
@@ -185,12 +183,10 @@ def _is_qqbot_at_mentioned_in_ob11(event: Event) -> bool:
     return False
 
 
-def _should_bot_handle_in_shared_group(
-    bot: Bot, event: Event, bind: GroupBind
-) -> bool:
+def _should_bot_handle_in_shared_group(bot: Bot, event: Event, bind: GroupBind) -> bool:
     """
     在同时含有 OB11 和 QQBot 的群聊中，判断当前 bot 是否应该处理此消息。
-    
+
     规则：
     - 如果 @ 了 QQ bot → QQBot 处理
     - 否则 → OB11 优先处理

--- a/src/plugins/nonebot_plugin_bots/bind.py
+++ b/src/plugins/nonebot_plugin_bots/bind.py
@@ -55,9 +55,9 @@ async def get_group_id_from_event(bot: Bot, event: Event) -> str | None:
 async def try_process_bind_code(bot: Bot, event: Event, session_id: str) -> bool:
     """
     检测并处理绑定验证码。
-    
+
     当任何 bot 检测到消息中含有绑定验证码时，尝试完成绑定。
-    
+
     返回 True 表示已处理绑定（应阻断后续处理），False 表示未检测到绑定码。
     """
     try:
@@ -76,9 +76,7 @@ async def try_process_bind_code(bot: Bot, event: Event, session_id: str) -> bool
         # 查找绑定了此验证码的记录
         from sqlalchemy import select
 
-        result = await session.execute(
-            select(GroupBind).where(GroupBind.bind_code == code)
-        )
+        result = await session.execute(select(GroupBind).where(GroupBind.bind_code == code))
         bind_record = result.scalar_one_or_none()
 
         if bind_record is None:
@@ -87,7 +85,9 @@ async def try_process_bind_code(bot: Bot, event: Event, session_id: str) -> bool
 
         # 检查验证码是否过期
         if bind_record.bind_code_created_at is not None:
-            elapsed = (datetime.now(timezone.utc) - bind_record.bind_code_created_at.replace(tzinfo=timezone.utc)).total_seconds()
+            elapsed = (
+                datetime.now(timezone.utc) - bind_record.bind_code_created_at.replace(tzinfo=timezone.utc)
+            ).total_seconds()
             if elapsed > config.bots_bind_group_timeout:
                 logger.info(f"[Bind] 验证码 {code} 已过期 ({elapsed:.0f}s > {config.bots_bind_group_timeout}s)")
                 return True  # 过期，阻断消息
@@ -130,21 +130,19 @@ async def handle_bind_group_id(bot: Bot, event: Event) -> None:
     """处理 /bind-group-id 命令"""
     code = generate_bind_code()
     now = datetime.now(timezone.utc)
-    
+
     async with get_session() as session:
         from sqlalchemy import select
-        
+
         if isinstance(bot, V11Bot):
             group_qq = await get_group_id_from_event(bot, event)
             if not group_qq:
                 await bind_group.finish("无法获取群 QQ 号，请稍后再试")
-            
+
             # 检查是否已有绑定记录（通过 group_qq_number 查找）
-            result = await session.execute(
-                select(GroupBind).where(GroupBind.group_qq_number == group_qq)
-            )
+            result = await session.execute(select(GroupBind).where(GroupBind.group_qq_number == group_qq))
             existing = result.scalar_one_or_none()
-            
+
             if existing:
                 # 更新验证码
                 existing.bind_code = code
@@ -160,20 +158,18 @@ async def handle_bind_group_id(bot: Bot, event: Event) -> None:
                 )
                 session.add(bind_record)
                 logger.info(f"[Bind] 创建群 {group_qq} 的绑定记录")
-            
+
             await session.commit()
-            
+
         elif isinstance(bot, QQBot):
             group_oid = await get_group_id_from_event(bot, event)
             if not group_oid:
                 await bind_group.finish("无法获取群 openid，请稍后再试")
-            
+
             # QQ bot 发起的绑定：检查是否已有记录
-            result = await session.execute(
-                select(GroupBind).where(GroupBind.group_openid == group_oid)
-            )
+            result = await session.execute(select(GroupBind).where(GroupBind.group_openid == group_oid))
             existing = result.scalar_one_or_none()
-            
+
             if existing:
                 existing.bind_code = code
                 existing.bind_code_created_at = now
@@ -187,9 +183,9 @@ async def handle_bind_group_id(bot: Bot, event: Event) -> None:
                 )
                 session.add(bind_record)
                 logger.info(f"[Bind] QQBot 创建群 openid={group_oid} 的绑定记录")
-            
+
             await session.commit()
-            
+
         else:
             await bind_group.finish("当前 bot 类型不支持群绑定")
             return

--- a/src/plugins/nonebot_plugin_bots/bind.py
+++ b/src/plugins/nonebot_plugin_bots/bind.py
@@ -1,0 +1,199 @@
+"""群 QQ 号与群聊 openid 绑定功能"""
+
+import re
+import random
+import string
+from datetime import datetime, timezone
+
+from nonebot import on_command, logger
+from nonebot.adapters.onebot.v11 import Bot as V11Bot
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot.adapters import Bot, Event
+from nonebot_plugin_orm import get_session
+from nonebot_plugin_larkutils import get_group_id, get_user_id
+
+from .config import config
+from .models import GroupBind
+
+# 绑定验证码的正则模式
+BIND_CODE_PATTERN = re.compile(r"\[MoonlarkBind:([A-Za-z0-9]{8})\]")
+
+# 验证码长度
+BIND_CODE_LENGTH = 8
+
+
+def generate_bind_code() -> str:
+    """生成一个随机的绑定验证码"""
+    return "".join(random.choices(string.ascii_letters + string.digits, k=BIND_CODE_LENGTH))
+
+
+def format_bind_message(code: str) -> str:
+    """格式化绑定消息"""
+    return f"[MoonlarkBind:{code}]"
+
+
+async def get_group_id_from_event(bot: Bot, event: Event) -> str | None:
+    """从事件中提取群 ID（OB11 用 QQ 号，QQ 官方 bot 用 openid）"""
+    try:
+        if isinstance(bot, V11Bot):
+            # onebot 11: group_id 已经是 QQ 群号格式
+            group_id = event.get_session_id()
+            # 格式: onebot_v11_{qq_number}
+            if group_id:
+                parts = group_id.rsplit("_", 1)
+                if len(parts) == 2:
+                    return parts[1]
+        elif isinstance(bot, QQBot):
+            # QQ 官方 bot: group_openid
+            if hasattr(event, "group_openid"):
+                return event.group_openid
+    except Exception as e:
+        logger.warning(f"获取群 ID 失败: {e}")
+    return None
+
+
+async def try_process_bind_code(bot: Bot, event: Event, session_id: str) -> bool:
+    """
+    检测并处理绑定验证码。
+    
+    当任何 bot 检测到消息中含有绑定验证码时，尝试完成绑定。
+    
+    返回 True 表示已处理绑定（应阻断后续处理），False 表示未检测到绑定码。
+    """
+    try:
+        message = event.get_plaintext()
+    except Exception:
+        return False
+
+    match = BIND_CODE_PATTERN.search(message)
+    if not match:
+        return False
+
+    code = match.group(1)
+    logger.info(f"[Bind] 检测到绑定验证码: {code}")
+
+    async with get_session() as session:
+        # 查找绑定了此验证码的记录
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(GroupBind).where(GroupBind.bind_code == code)
+        )
+        bind_record = result.scalar_one_or_none()
+
+        if bind_record is None:
+            logger.warning(f"[Bind] 未找到验证码 {code} 对应的绑定记录")
+            return True  # 仍然阻断，避免传播到其他 handler
+
+        # 检查验证码是否过期
+        if bind_record.bind_code_created_at is not None:
+            elapsed = (datetime.now(timezone.utc) - bind_record.bind_code_created_at.replace(tzinfo=timezone.utc)).total_seconds()
+            if elapsed > config.bots_bind_group_timeout:
+                logger.info(f"[Bind] 验证码 {code} 已过期 ({elapsed:.0f}s > {config.bots_bind_group_timeout}s)")
+                return True  # 过期，阻断消息
+
+        # 根据 bot 类型补全绑定信息
+        if isinstance(bot, V11Bot):
+            # OB11 bot 看到 QQ bot 发出的绑定码消息
+            # 补全 group_qq_number
+            group_qq = await get_group_id_from_event(bot, event)
+            if group_qq:
+                bind_record.group_qq_number = group_qq
+                logger.info(f"[Bind] OB11 补全群 QQ 号: {group_qq}")
+        elif isinstance(bot, QQBot):
+            # QQ bot 看到 OB11 发出的绑定码消息
+            # 补全 group_openid
+            group_oid = await get_group_id_from_event(bot, event)
+            if group_oid:
+                bind_record.group_openid = group_oid
+                logger.info(f"[Bind] QQBot 补全群 openid: {group_oid}")
+
+        # 检查是否两端都已填写（绑定完成）
+        if bind_record.group_qq_number and bind_record.group_openid:
+            bind_record.bound_at = datetime.now(timezone.utc)
+            bind_record.bind_code = None  # 清除验证码
+            logger.info(f"[Bind] 群绑定完成: QQ号={bind_record.group_qq_number} <-> openid={bind_record.group_openid}")
+        else:
+            logger.info(f"[Bind] 绑定信息补全中: QQ号={bind_record.group_qq_number}, openid={bind_record.group_openid}")
+
+        await session.commit()
+
+    return True  # 阻断消息传播
+
+
+# 绑定命令
+bind_group = on_command("bind-group-id", priority=1, block=True)
+
+
+@bind_group.handle()
+async def handle_bind_group_id(bot: Bot, event: Event) -> None:
+    """处理 /bind-group-id 命令"""
+    code = generate_bind_code()
+    now = datetime.now(timezone.utc)
+    
+    async with get_session() as session:
+        from sqlalchemy import select
+        
+        if isinstance(bot, V11Bot):
+            group_qq = await get_group_id_from_event(bot, event)
+            if not group_qq:
+                await bind_group.finish("无法获取群 QQ 号，请稍后再试")
+            
+            # 检查是否已有绑定记录（通过 group_qq_number 查找）
+            result = await session.execute(
+                select(GroupBind).where(GroupBind.group_qq_number == group_qq)
+            )
+            existing = result.scalar_one_or_none()
+            
+            if existing:
+                # 更新验证码
+                existing.bind_code = code
+                existing.bind_code_created_at = now
+                existing.group_openid = None  # 重置 openid，需要重新绑定
+                existing.bound_at = None
+                logger.info(f"[Bind] 重置群 {group_qq} 的绑定验证码")
+            else:
+                bind_record = GroupBind(
+                    group_qq_number=group_qq,
+                    bind_code=code,
+                    bind_code_created_at=now,
+                )
+                session.add(bind_record)
+                logger.info(f"[Bind] 创建群 {group_qq} 的绑定记录")
+            
+            await session.commit()
+            
+        elif isinstance(bot, QQBot):
+            group_oid = await get_group_id_from_event(bot, event)
+            if not group_oid:
+                await bind_group.finish("无法获取群 openid，请稍后再试")
+            
+            # QQ bot 发起的绑定：检查是否已有记录
+            result = await session.execute(
+                select(GroupBind).where(GroupBind.group_openid == group_oid)
+            )
+            existing = result.scalar_one_or_none()
+            
+            if existing:
+                existing.bind_code = code
+                existing.bind_code_created_at = now
+                existing.bound_at = None
+                logger.info(f"[Bind] 重置群 openid={group_oid} 的绑定验证码")
+            else:
+                bind_record = GroupBind(
+                    group_openid=group_oid,
+                    bind_code=code,
+                    bind_code_created_at=now,
+                )
+                session.add(bind_record)
+                logger.info(f"[Bind] QQBot 创建群 openid={group_oid} 的绑定记录")
+            
+            await session.commit()
+            
+        else:
+            await bind_group.finish("当前 bot 类型不支持群绑定")
+            return
+
+    # 发送绑定验证码
+    bind_msg = format_bind_message(code)
+    await bind_group.finish(f"群绑定验证码已生成，请等待另一个 bot 识别完成：\n{bind_msg}")

--- a/src/plugins/nonebot_plugin_bots/config.py
+++ b/src/plugins/nonebot_plugin_bots/config.py
@@ -7,11 +7,11 @@ class Config(BaseModel):
 
     bots_session_remain: int = 3 * 60
     bots_list: dict[str, str] = {}
-    
+
     # app_id -> QQ 号的映射表，用于识别 QQ 官方 bot 的自发自收消息
     # 例如: {"102xxxxxx": "3889000000"}
     bots_appid_map: dict[str, str] = {}
-    
+
     # 群绑定验证码过期时间（秒），默认 5 分钟
     bots_bind_group_timeout: int = 300
 

--- a/src/plugins/nonebot_plugin_bots/config.py
+++ b/src/plugins/nonebot_plugin_bots/config.py
@@ -7,6 +7,13 @@ class Config(BaseModel):
 
     bots_session_remain: int = 3 * 60
     bots_list: dict[str, str] = {}
+    
+    # app_id -> QQ 号的映射表，用于识别 QQ 官方 bot 的自发自收消息
+    # 例如: {"102xxxxxx": "3889000000"}
+    bots_appid_map: dict[str, str] = {}
+    
+    # 群绑定验证码过期时间（秒），默认 5 分钟
+    bots_bind_group_timeout: int = 300
 
 
 config = get_plugin_config(Config)

--- a/src/plugins/nonebot_plugin_bots/models.py
+++ b/src/plugins/nonebot_plugin_bots/models.py
@@ -1,4 +1,6 @@
-from sqlalchemy import String, Boolean
+from datetime import datetime
+from typing import Optional
+from sqlalchemy import String, Boolean, DateTime, func
 from sqlalchemy.orm import Mapped, mapped_column
 from nonebot_plugin_orm import Model
 
@@ -11,3 +13,24 @@ class UserBotPrivateChatSettings(Model):
     user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     bot_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     private_chat_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+
+
+class GroupBind(Model):
+    """群 QQ 号与群聊 openid 绑定表"""
+
+    __tablename__ = "nonebot_plugin_bots_group_bind"
+
+    # 自增主键
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    # 群 QQ 号（来自 onebot 11），可为空
+    group_qq_number: Mapped[Optional[str]] = mapped_column(String(64), nullable=True, unique=True, default=None)
+    # 群聊 openid（来自 QQ 官方 bot），可为空
+    group_openid: Mapped[Optional[str]] = mapped_column(String(128), nullable=True, unique=True, default=None)
+    # 绑定验证码
+    bind_code: Mapped[Optional[str]] = mapped_column(String(32), nullable=True, default=None)
+    # 验证码创建时间
+    bind_code_created_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, default=None)
+    # 绑定完成时间
+    bound_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, default=None)
+    # 记录创建时间
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())


### PR DESCRIPTION
## 变更概述

此 PR 为 Moonlark 的 bots 基础设施添加对 QQ 官方 bot 群聊全部消息接收功能的支持。

### 1. 新增 bots_appid_map 配置

在 `.env` 中新增 `BOTS_APPID_MAP` 配置项（app_id → QQ 号的映射表），用于在 bots 插件中识别来自 QQ 官方 bot 自身节点的消息并忽略。

### 2. 新增群绑定功能

- 新增 `/bind-group-id` 指令：在群聊中生成特殊识别码
- 新增 `GroupBind` 数据库模型：存储群 QQ 号与群 openid 的绑定关系
- 绑定验证码通过 `[MoonlarkBind:XXXXXXXX]` 特殊格式传递
- 验证码消息仅由 bind 模块处理，不传播到其他 handler

### 3. 修改优先级路由

在同时含有 OneBot 11 和 QQ 官方 bot 的群聊中：
- **@QQ bot** → 事件由 QQ 官方 bot 处理
- **其他情况** → 事件由 OneBot 11 bot 优先处理

### 修改的文件

| 文件 | 变更 |
|------|------|
| `config.py` | 新增 `bots_appid_map` 和 `bots_bind_group_timeout` 配置 |
| `models.py` | 新增 `GroupBind` 模型 |
| `__main__.py` | 重写 event_preprocessor，添加自识别、绑定检测、优先级路由 |
| `bind.py` | **新文件** 群绑定功能和验证码检测逻辑 |
| `__init__.py` | 导入 bind 模块 |
| `.env.template` | 添加新配置文档 |

### 待审核

@xxtg666 请审核喵～