### PR TITLE
fix: is_private_message 对 QQ Bot C2C 私聊判断错误导致 rua 错误创建 GroupSession

### DIFF
--- a/src/plugins/nonebot_plugin_larkutils/user.py
+++ b/src/plugins/nonebot_plugin_larkutils/user.py
@@ -16,10 +16,24 @@ async def _get_user_id(event: Event) -> str:
 
 
 async def private_message(event: Event) -> bool:
+    """判断当前消息是否为私聊
+
+    通用的判断方式是比较 event.get_session_id() 和 event.get_user_id()，
+    但某些适配器（如 QQ Bot 的 C2C）的 session ID 包含前缀，无法直接比较。
+    这里针对已知的适配器做额外判断。
+    """
     try:
-        return event.get_session_id() == event.get_user_id()
-    except ValueError:
-        return False
+        if event.get_session_id() == event.get_user_id():
+            return True
+    except (ValueError, NotImplementedError):
+        pass
+    # QQ Bot C2C（私聊）消息：session_id 带有 "c2c_" 前缀，不能直接比较
+    if event.__class__.__module__.startswith("nonebot.adapters.qq"):
+        from nonebot.adapters.qq.event import C2CMessageCreateEvent
+
+        if isinstance(event, C2CMessageCreateEvent):
+            return True
+    return False
 
 
 def get_user_id() -> Any:


### PR DESCRIPTION
## 问题

私聊发 `rua` 时，会话被错误初始化为 `GroupSession` 而非 `PrivateSession`。

## 根因

`larkutils/user.py` 的 `private_message()` 只通过比较 `event.get_session_id() == event.get_user_id()` 来判断是否私聊。

但 **QQ Bot 适配器的 C2C 消息** 的 `get_session_id()` 返回带 `c2c_` 前缀的字符串（如 `c2c_<open_id>`），而 `get_user_id()` 返回的是裸 openID，两者永远不相等，导致私聊判断恒为 False。

在 `rua.py` 中，`is_private = False` 导致代码进入 `else` 分支调用了 `get_group_session_forced()`，错误创建了 `GroupSession`。

## 修复

在 `larkutils/user.py` 的 `private_message()` 函数中增加对 `nonebot.adapters.qq` 的 `C2CMessageCreateEvent` 的显式判断，逻辑与原 `chat.py` 的 `_is_private_chat()` 一致。

`rua.py` 已从 `nonebot_plugin_larkutils.user` 导入 `is_private_message`，无需额外修改即可自动修复。

同时修复了多个同样依赖 `is_private_message` 的插件（present、use、everyday_wife、last_seen、bots 等）的相同问题。