### PR TITLE
refactor(status_report): 拆分 /admin/status 为多个独立端点

### DIFF
--- a/src/plugins/nonebot_plugin_status_report/__main__.py
+++ b/src/plugins/nonebot_plugin_status_report/__main__.py
@@ -271,20 +271,66 @@ async def cleanup_old_records() -> None:
         await session.commit()
 
 
-@app.get("/admin/status")
-async def get_status_report(request: Request, token: str, salt: str) -> StatusReport:
+async def verify_admin(token: str, salt: str) -> None:
     if token != hashlib.sha256(f"{config.status_report_password}+{salt}".encode()).hexdigest():
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
-    return StatusReport(
-        bots=await bots_status(request),
-        exceptions=await get_exceptions(),
-        plugins=[plugin.name for plugin in get_loaded_plugins()],
-        event_counter=EventCounter(
+
+
+@app.get("/admin/status")
+async def get_status_overview(request: Request, token: str, salt: str) -> dict:
+    await verify_admin(token, salt)
+    return {
+        "bots": await bots_status(request),
+        "plugins": [plugin.name for plugin in get_loaded_plugins()],
+        "event_counter": EventCounter(
             success=event_counter[1],
             total=event_counter[0],
             failed=event_counter[0] - event_counter[1],
         ),
-        openai=await get_openai_history(),
-        command_usage=await get_command_usage(),
-        handler_results=await get_handler_results(),
+    }
+
+
+@app.get("/admin/status/bots")
+async def get_status_bots(request: Request, token: str, salt: str) -> dict:
+    await verify_admin(token, salt)
+    return await bots_status(request)
+
+
+@app.get("/admin/status/exceptions")
+async def get_status_exceptions(token: str, salt: str) -> list[ExceptionStatus]:
+    await verify_admin(token, salt)
+    return await get_exceptions()
+
+
+@app.get("/admin/status/plugins")
+async def get_status_plugins(token: str, salt: str) -> list[str]:
+    await verify_admin(token, salt)
+    return [plugin.name for plugin in get_loaded_plugins()]
+
+
+@app.get("/admin/status/events")
+async def get_status_events(token: str, salt: str) -> EventCounter:
+    await verify_admin(token, salt)
+    return EventCounter(
+        success=event_counter[1],
+        total=event_counter[0],
+        failed=event_counter[0] - event_counter[1],
     )
+
+
+@app.get("/admin/status/openai")
+async def get_status_openai(token: str, salt: str) -> list[OpenAIHistory]:
+    await verify_admin(token, salt)
+    return await get_openai_history()
+
+
+@app.get("/admin/status/commands")
+async def get_status_commands(token: str, salt: str) -> dict[str, int]:
+    await verify_admin(token, salt)
+    return await get_command_usage()
+
+
+@app.get("/admin/status/handlers")
+async def get_status_handlers(token: str, salt: str) -> list[HandlerResult]:
+    await verify_admin(token, salt)
+    return await get_handler_results()


### PR DESCRIPTION
## 变更内容

将 Moonlark 监控面板的单一  端点拆分为多个独立端点，避免一次性加载全部数据导致请求超时。

### 后端变更 (Moonlark)

- 新增  鉴权辅助函数，减少重复代码
- 拆分原单一  端点为 7 个独立端点：
  -  — Bot 状态
  -  — 异常记录
  -  — 已加载插件列表
  -  — 事件计数器
  -  — OpenAI 历史
  -  — 命令使用统计
  -  — Handler 结果
-  保留为轻量概览（仅返回 bots/plugins/event_counter）

### 前端变更 (moonlark-frontend, 已合并到 main)

- 新增监控仪表盘页面和 7 个独立子页面
- 新增后端地址设置，支持在设置页面修改并保存在 localStorage
- 新增管理员密码配置

### 需要验证

- [x] 各独立端点的鉴权逻辑正确
- [x] 前后端 API 路径一致
- [x]  概览端点保持向后兼容

cc @xxtg666