### PR TITLE
fix(chat): 决策历史去重并归一化查重比对

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -411,6 +411,10 @@ class MoonlarkMain:
         }
 
     def _update_decision_history(self, action_desc: str) -> None:
+        # 去重：如果有相同 action 的旧条目，先移除
+        self.state["decision_history"] = [
+            h for h in self.state["decision_history"] if h["action"] != action_desc
+        ]
         self.state["decision_history"].append(
             {
                 "time": datetime.now().isoformat(),

--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -412,9 +412,7 @@ class MoonlarkMain:
 
     def _update_decision_history(self, action_desc: str) -> None:
         # 去重：如果有相同 action 的旧条目，先移除
-        self.state["decision_history"] = [
-            h for h in self.state["decision_history"] if h["action"] != action_desc
-        ]
+        self.state["decision_history"] = [h for h in self.state["decision_history"] if h["action"] != action_desc]
         self.state["decision_history"].append(
             {
                 "time": datetime.now().isoformat(),

--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -761,7 +761,11 @@ class MessageProcessor:
                         return True
                 elif isinstance(content, list):
                     for part in content:
-                        if isinstance(part, dict) and "text" in part and norm_line in self._normalize_line(part["text"]):
+                        if (
+                            isinstance(part, dict)
+                            and "text" in part
+                            and norm_line in self._normalize_line(part["text"])
+                        ):
                             return True
         return False
 

--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -1,4 +1,5 @@
 import base64
+import html
 import math
 
 import aiofiles
@@ -740,18 +741,27 @@ class MessageProcessor:
     async def filter_info_lines(self, lines: list[str]) -> list[str]:
         return [line for line in lines if not await self.is_additional_info_line_showed(line)]
 
+    def _normalize_line(self, text: str) -> str:
+        """归一化行文本：去除时间戳前缀并解码 HTML 实体"""
+        # 去除 [ISO时间戳] 前缀
+        result = text
+        if result.startswith("[") and "] " in result:
+            result = result.split("] ", 1)[1]
+        return html.unescape(result)
+
     async def is_additional_info_line_showed(self, line: str) -> bool:
+        norm_line = self._normalize_line(line)
         async with self.openai_messages.fetcher_lock:
             for message in self.openai_messages.messages:
                 content = message.get("content") if isinstance(message, dict) else getattr(message, "content", None)
                 if content is None:
                     continue
                 if isinstance(content, str):
-                    if line in content:
+                    if norm_line in self._normalize_line(content):
                         return True
                 elif isinstance(content, list):
                     for part in content:
-                        if isinstance(part, dict) and "text" in part and line in part["text"]:
+                        if isinstance(part, dict) and "text" in part and norm_line in self._normalize_line(part["text"]):
                             return True
         return False
 


### PR DESCRIPTION
## 修复内容

修复「正在做的事」条目重复显示的问题，包含两个改动：

### 1️⃣ 决策历史去重
在 `_update_decision_history` 中添加新条目前先移除相同 action 文本的旧条目，避免 `chat()` 等重复调用产生重复记录。

### 2️⃣ 查重比对归一化
- 去除时间戳前缀再比对，避免不同时间戳导致同一条目被判定为不同
- 增加 `html.unescape()` 解码 `&#39;` 等 HTML 实体，解决编码不一致导致的匹配失败

## 相关 Issue
无