### PR TITLE
fix(chat): resolve QQ adapter @mention showing anonymous nickname

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -84,14 +84,14 @@ files = [
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main", "dev", "test"]
 files = [
-    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
-    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+    {file = "annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0"},
+    {file = "annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7"},
 ]
 
 [[package]]

--- a/src/plugins/nonebot_plugin_chat/utils/message.py
+++ b/src/plugins/nonebot_plugin_chat/utils/message.py
@@ -146,7 +146,34 @@ class MessageParser:
             nickname = user_info.user_displayname or user_info.user_name
         else:
             nickname = user.get_nickname()
+
+        # 如果昵称为空或为匿名，尝试从适配器事件中提取更准确的用户名
+        if not nickname or nickname.startswith("匿名-"):
+            if _nickname := await self._get_mention_username_from_event(segment.target):
+                nickname = _nickname
+
         return f"@{nickname}"
+
+    async def _get_mention_username_from_event(self, target: str) -> Optional[str]:
+        """
+        从适配器事件中提取 @ 提及用户的用户名
+
+        部分适配器（如 QQ adapter）的 At segment 只包含 user_id（OpenID），
+        但原始事件中可能包含更详细的用户名信息。
+        """
+        try:
+            from nonebot.adapters.qq.event import GroupAtMessageCreateEvent
+
+            if isinstance(self.event, GroupAtMessageCreateEvent):
+                for mention in getattr(self.event, "mentions", []) or []:
+                    mention_id = getattr(mention, "id", None) or getattr(mention, "member_openid", None)
+                    if str(mention_id) == target:
+                        if username := str(getattr(mention, "username", "") or ""):
+                            return username
+        except ImportError:
+            pass
+
+        return None
 
     async def parse_replied_message(self, msg: UniMessage) -> str:
         if msg == self.message:

--- a/src/plugins/nonebot_plugin_chat/utils/message.py
+++ b/src/plugins/nonebot_plugin_chat/utils/message.py
@@ -162,9 +162,9 @@ class MessageParser:
         但原始事件中可能包含更详细的用户名信息。
         """
         try:
-            from nonebot.adapters.qq.event import GroupAtMessageCreateEvent
+            from nonebot.adapters.qq.event import QQMessageEvent as QQMsgEvent
 
-            if isinstance(self.event, GroupAtMessageCreateEvent):
+            if isinstance(self.event, QQMsgEvent):
                 for mention in getattr(self.event, "mentions", []) or []:
                     mention_id = getattr(mention, "id", None) or getattr(mention, "member_openid", None)
                     if str(mention_id) == target:


### PR DESCRIPTION
## 问题描述

在 QQ 官方 bot（adapter-qq）的群聊中，收到带 @ 的消息时，被 @ 的人总是显示为 @匿名-XXXX，即使该用户发送消息时能正常显示昵称。

## 问题根因

1. QQ API 返回的消息 mentions 中有 username（昵称）
2. 但 Alconna 的 QQ builder 丢弃了 username，只取 user_id
3. nonebot_plugin_userinfo 对 GroupAtMessageCreateEvent 始终返回空 user_name
4. 最终 fallback 到 user.get_nickname() -> 匿名-XXXX

## 修复

在 parse_mention 中增加后备机制：当标准昵称解析返回空或匿名- 时，从 event.mentions 中提取用户名。