### PR TITLE
fix(larkuser): resolve main account before nickname lookup in setup_user()

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -84,14 +84,14 @@ files = [
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main", "dev", "test"]
 files = [
-    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
-    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+    {file = "annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0"},
+    {file = "annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7"},
 ]
 
 [[package]]

--- a/src/plugins/nonebot_plugin_larkuser/user/registered.py
+++ b/src/plugins/nonebot_plugin_larkuser/user/registered.py
@@ -67,9 +67,11 @@ class MoonlarkRegisteredUser(MoonlarkUser):
         self.main_account = False
 
     async def setup_user(self) -> None:
+        await self.setup_user_id()
         async with get_session() as session:
             user = await session.get(UserData, self.user_id)
             if user is None:
+                self.user_has_nickname = False
                 return
             self.nickname = user.nickname
             self.register_time = user.register_time


### PR DESCRIPTION
## 问题描述

当使用 OpenID（子账号）调用 `get_user()` 时，`MoonlarkRegisteredUser.setup_user()` 在数据库查询前未调用 `setup_user_id()` 解析主账号，导致 `user_id` 保持为 OpenID（如 `B795A477BCCFA89F52B860374AAA32D3`）。

数据库查询使用 OpenID 查找 `UserData` 记录失败（数据以主账号 `1747433912` 存储），造成:
1. 昵称未能加载，`nickname` 保持为空字符串
2. `has_nickname()` 返回 `True`（类属性 `user_has_nickname = True` 未更新），误导外层判断

最终 `get_nickname()` 返回 `匿名-32D3`（OpenID 末尾四位），即使数据库中存在绑定了昵称 `xxtg666` 的用户记录。

## 修复

1. 在 `setup_user()` 开头调用 `setup_user_id()`，先解析主账号，再进行数据库查询
2. 当 `session.get()` 返回 None 时，将 `user_has_nickname` 设为 `False`，防止误导

## 影响范围

仅影响 `MoonlarkRegisteredUser.setup_user()` 方法。该改动不改变其他用户类型（`MoonlarkRegisteredGuest`、`MoonlarkGuestUser`、`MoonlarkUnknownUser`）的行为。