### PR TITLE
完善 QQ Adapter 下 Mention 用户名缓存逻辑

### DIFF
--- a/src/plugins/nonebot_plugin_larkuser/matchers/recorder.py
+++ b/src/plugins/nonebot_plugin_larkuser/matchers/recorder.py
@@ -29,6 +29,8 @@ async def _(session: async_scoped_session, user: UserInfo = EventUserInfo()) -> 
     if user_data.nickname != user.user_name and not config.get("lock_nickname"):
         logger.info(f"用户 {user_data.user_id} 修改了其昵称 ({user_data.nickname} => {user.user_name})")
         user_data.nickname = user.user_name
+        config.pop("nick_source", None)  # 清除自动补全标识，标记为通过自身消息更新
+        user_data.config = json.dumps(config)
     if user.user_avatar and user_data.register_time and not config.get("lock_avatar"):
         avatar = await user.user_avatar.get_image()
         if await is_user_avatar_updated(user_data.user_id, avatar):

--- a/src/plugins/nonebot_plugin_larkuser/matchers/setnick.py
+++ b/src/plugins/nonebot_plugin_larkuser/matchers/setnick.py
@@ -73,6 +73,7 @@ async def _(
         user.nickname = new_nick
         config = json.loads(user.config)
         config["lock_nickname"] = True
+        config.pop("nick_source", None)  # 清除自动补全标识，标记为手动设置
         user.config = json.dumps(config)
         await session.commit()
 

--- a/src/plugins/nonebot_plugin_larkutils/__init__.py
+++ b/src/plugins/nonebot_plugin_larkutils/__init__.py
@@ -35,3 +35,4 @@ from .user_id import parse_special_user_id
 from .file import open_file, FileManager, FileType
 from .jrrp import get_luck_value
 from .gift_session import get_or_create_session, trigger_gift_event
+from . import mention_nick

--- a/src/plugins/nonebot_plugin_larkutils/mention_nick.py
+++ b/src/plugins/nonebot_plugin_larkutils/mention_nick.py
@@ -10,6 +10,7 @@ QQ Adapter Mention 用户名缓存补全模块
 
 其他渠道（如 /setnick 命令、Recorder 自动识别）设置的昵称不会被覆盖。
 """
+
 import json
 
 from nonebot import on_message
@@ -77,10 +78,7 @@ async def _(
             # 昵称相同，无需更新
             continue
 
-        logger.info(
-            f"通过 @提及 补全用户 {mentioned_user_id} 的昵称: "
-            f"'{user_data.nickname}' -> '{username}'"
-        )
+        logger.info(f"通过 @提及 补全用户 {mentioned_user_id} 的昵称: " f"'{user_data.nickname}' -> '{username}'")
 
         user_data.nickname = username
         config[NICK_SOURCE_KEY] = NICK_SOURCE_MENTION

--- a/src/plugins/nonebot_plugin_larkutils/mention_nick.py
+++ b/src/plugins/nonebot_plugin_larkutils/mention_nick.py
@@ -1,0 +1,88 @@
+"""
+QQ Adapter Mention 用户名缓存补全模块
+
+在 QQ 群聊消息中，当消息包含 @提及 (MentionUser) 且带有 username 字段时，
+自动将被提及用户的昵称更新到 larkuser 数据中。
+
+更新条件：
+1. 被提及用户暂无昵称（nickname 为空）
+2. 被提及用户的当前昵称是通过本机制设置的（config 中 nick_source == "mention"）
+
+其他渠道（如 /setnick 命令、Recorder 自动识别）设置的昵称不会被覆盖。
+"""
+import json
+
+from nonebot import on_message
+from nonebot.log import logger
+from nonebot_plugin_orm import async_scoped_session
+from sqlalchemy.exc import NoResultFound
+
+from nonebot.adapters.qq.bot import Bot as QQBot
+from nonebot.adapters.qq.event import GroupMessageCreateEvent
+from nonebot.adapters.qq.message import MentionUser
+
+# 配置键名：用于标记昵称来源
+NICK_SOURCE_KEY = "nick_source"
+NICK_SOURCE_MENTION = "mention"
+
+
+async def _is_qq_bot(bot) -> bool:
+    """规则：仅处理 QQ Bot 适配器的消息"""
+    return isinstance(bot, QQBot)
+
+
+mention_nick_matcher = on_message(block=False, priority=3, rule=_is_qq_bot)
+
+
+@mention_nick_matcher.handle()
+async def _(
+    session: async_scoped_session,
+    bot: QQBot,
+    event: GroupMessageCreateEvent,
+) -> None:
+    from nonebot_plugin_larkuser.models import UserData
+
+    message = event.get_message()
+    mention_segments = message.get("mention_user")
+
+    if not mention_segments:
+        return
+
+    for seg in mention_segments:
+        if not isinstance(seg, MentionUser):
+            continue
+
+        username = seg.data.get("username")
+        mentioned_user_id = seg.data.get("user_id")
+
+        if not username or not mentioned_user_id:
+            continue
+
+        try:
+            user_data = await session.get_one(UserData, {"user_id": mentioned_user_id})
+        except NoResultFound:
+            # 被提及用户尚未注册，跳过
+            continue
+
+        config = json.loads(user_data.config)
+        nick_source = config.get(NICK_SOURCE_KEY)
+
+        # 判断是否需要更新：无昵称 或 昵称来源于本机制
+        should_update = bool(not user_data.nickname or nick_source == NICK_SOURCE_MENTION)
+
+        if not should_update:
+            continue
+
+        if user_data.nickname == username:
+            # 昵称相同，无需更新
+            continue
+
+        logger.info(
+            f"通过 @提及 补全用户 {mentioned_user_id} 的昵称: "
+            f"'{user_data.nickname}' -> '{username}'"
+        )
+
+        user_data.nickname = username
+        config[NICK_SOURCE_KEY] = NICK_SOURCE_MENTION
+        user_data.config = json.dumps(config)
+        await session.commit()


### PR DESCRIPTION
## 背景

QQ Adapter 的群聊 @提及 事件中，MentionUser 片段有时会携带 username 字段（QQ 用户名），
但当前 larkuser 数据中缺少利用该字段自动补全昵称的机制。

## 变更内容

### 新增: `mention_nick.py` (`nonebot_plugin_larkutils`)
- 在 larkutils 中新增 on_message 事件处理器，仅在 QQ Adapter 下生效
- 提取 MentionUser 消息段中的 username 字段，自动补全被提及用户的昵称
- 更新条件：用户无昵称 或 昵称来源为本机制（nick_source == "mention"）
- 使用 config 中的 `nick_source` 键标记昵称来源，避免覆盖用户主动设置的昵称

### 修改: `recorder.py`
- 通过 Recorder 自动更新昵称时，清除 `nick_source` 标识，标记为通过自身消息识别

### 修改: `setnick.py`
- 通过 `/setnick` 命令设置昵称时，清除 `nick_source` 标识，标记为手动设置

## 审查说明

请 @xxtg666 审查。