### PR TITLE
feat: 将 Main Account 映射数据从文件迁移到数据库

### DIFF
--- a/migrations/versions/ffdcbc994499_add_main_account_mapping.py
+++ b/migrations/versions/ffdcbc994499_add_main_account_mapping.py
@@ -1,0 +1,48 @@
+"""Add main account mapping table
+
+迁移 ID: ffdcbc994499
+父迁移: ffdcbc994498
+创建时间: 2026-07-24 17:31:00.000000
+
+将 Main Account 的映射数据从文件存储迁移到数据库表
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "ffdcbc994499"
+down_revision: str | Sequence[str] | None = "ffdcbc994498"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+TABLE_NAME = "nonebot_plugin_larkutils_mainaccountmapping"
+
+
+def upgrade(name: str = "") -> None:
+    if name:
+        return
+
+    # 创建主账号映射表
+    op.create_table(
+        TABLE_NAME,
+        sa.Column("user_id", sa.String(length=128), nullable=False),
+        sa.Column("main_account", sa.String(length=128), nullable=False),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+
+    # 注意：文件数据的迁移通过 subaccount.py 中的 on_startup 钩子完成
+
+
+def downgrade(name: str = "") -> None:
+    if name:
+        return
+
+    # 删除表
+    op.drop_table(TABLE_NAME)
+
+    # 注意：downgrade 不会恢复文件，数据通过文件系统保留

--- a/src/plugins/nonebot_plugin_larkutils/models.py
+++ b/src/plugins/nonebot_plugin_larkutils/models.py
@@ -1,0 +1,27 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from nonebot_plugin_orm import Model
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class MainAccountMapping(Model):
+    """子账号到主账号的映射表"""
+
+    user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    main_account: Mapped[str] = mapped_column(String(128))

--- a/src/plugins/nonebot_plugin_larkutils/subaccount.py
+++ b/src/plugins/nonebot_plugin_larkutils/subaccount.py
@@ -14,37 +14,87 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ##############################################################################
-#
-#  This program is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU Affero General Public License as published
-#  by the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU Affero General Public License for more details.
-#
-#  You should have received a copy of the GNU Affero General Public License
-#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-# ##############################################################################
 
 import aiofiles
+import asyncio
+
+from nonebot import get_driver
 from nonebot_plugin_localstore import get_data_dir
-import json
+from nonebot_plugin_orm import get_session
+
+from .models import MainAccountMapping
+
+# 文件迁移锁，确保启动时的数据迁移只执行一次
+_migration_lock = asyncio.Lock()
+_migration_done = False
 
 data_file = get_data_dir("nonebot_plugin_larkutils")
 
 
 async def set_main_account(user_id: str, main_account: str) -> None:
-    async with aiofiles.open(data_file.joinpath(user_id), "w", encoding="utf-8") as f:
-        await f.write(main_account)
+    """设置子账号对应的主账号映射"""
+    async with get_session() as session:
+        mapping = await session.get(MainAccountMapping, {"user_id": user_id})
+        if mapping is None:
+            mapping = MainAccountMapping(user_id=user_id, main_account=main_account)
+            session.add(mapping)
+        else:
+            mapping.main_account = main_account
+        await session.commit()
 
 
 async def get_main_account(user_id: str) -> str:
-    file = data_file.joinpath(user_id)
-    if file.exists():
-        async with aiofiles.open(file, "r", encoding="utf-8") as f:
-            return (await f.read()) or user_id
-    else:
-        return user_id
+    """获取子账号对应的主账号 user_id，如果不存在则返回自身"""
+    await _ensure_migrated()
+    async with get_session() as session:
+        mapping = await session.get(MainAccountMapping, {"user_id": user_id})
+        if mapping is not None:
+            return mapping.main_account
+    return user_id
+
+
+async def _migrate_from_files() -> None:
+    """将旧的文件存储的主账号映射数据迁移到数据库"""
+    global _migration_done
+    async with _migration_lock:
+        if _migration_done:
+            return
+        _migration_done = True
+
+    if not data_file.exists():
+        return
+
+    migrated_count = 0
+    for file_path in data_file.iterdir():
+        if not file_path.is_file():
+            continue
+        user_id = file_path.name
+        try:
+            async with aiofiles.open(file_path, "r", encoding="utf-8") as f:
+                main_account = (await f.read()).strip()
+        except Exception:
+            continue
+        if not main_account:
+            continue
+
+        async with get_session() as session:
+            existing = await session.get(MainAccountMapping, {"user_id": user_id})
+            if existing is None:
+                session.add(MainAccountMapping(user_id=user_id, main_account=main_account))
+                await session.commit()
+                migrated_count += 1
+
+    if migrated_count > 0:
+        pass  # log if needed later
+
+
+async def _ensure_migrated() -> None:
+    """确保文件到数据库的迁移已完成"""
+    if not _migration_done:
+        await _migrate_from_files()
+
+
+@get_driver().on_startup
+async def _() -> None:
+    """在启动时自动迁移旧的文件数据到数据库"""
+    await _migrate_from_files()

--- a/src/plugins/nonebot_plugin_larkutils/subaccount.py
+++ b/src/plugins/nonebot_plugin_larkutils/subaccount.py
@@ -15,14 +15,19 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ##############################################################################
 
-import aiofiles
-import asyncio
+from __future__ import annotations
 
+import asyncio
+from logging import getLogger
+
+import aiofiles
 from nonebot import get_driver
 from nonebot_plugin_localstore import get_data_dir
 from nonebot_plugin_orm import get_session
 
 from .models import MainAccountMapping
+
+logger = getLogger(__name__)
 
 # 文件迁移锁，确保启动时的数据迁移只执行一次
 _migration_lock = asyncio.Lock()
@@ -72,7 +77,8 @@ async def _migrate_from_files() -> None:
         try:
             async with aiofiles.open(file_path, "r", encoding="utf-8") as f:
                 main_account = (await f.read()).strip()
-        except Exception:
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.warning("读取主账号映射文件 %s 失败: %s", file_path, exc)
             continue
         if not main_account:
             continue
@@ -85,7 +91,7 @@ async def _migrate_from_files() -> None:
                 migrated_count += 1
 
     if migrated_count > 0:
-        pass  # log if needed later
+        logger.info("已从文件迁移 %d 条主账号映射数据到数据库", migrated_count)
 
 
 async def _ensure_migrated() -> None:


### PR DESCRIPTION
## 变更内容

将 Main Account 的映射数据从文件存储迁移到数据库。

### 修改的文件

- **新增** `src/plugins/nonebot_plugin_larkutils/models.py`: 添加 `MainAccountMapping` ORM 模型
- **修改** `src/plugins/nonebot_plugin_larkutils/subaccount.py`: `get_main_account` / `set_main_account` 改用数据库存储，启动时自动从旧的文件迁移数据到数据库
- **新增** `migrations/versions/ffdcbc994499_add_main_account_mapping.py`: 数据库迁移脚本，创建主账号映射表

### 迁移说明

旧的文件数据保留在文件系统中，不会被自动删除。启动时通过 `on_startup` 钩子将文件中的数据迁移到数据库表中。如果某条数据已经在数据库中存在，则跳过该条数据，保证幂等性。