### PR TITLE
fix(chat): correct off-by-one index in handle_ignore_mention

### DIFF
--- a/src/plugins/nonebot_plugin_chat/matcher/chat.py
+++ b/src/plugins/nonebot_plugin_chat/matcher/chat.py
@@ -228,18 +228,18 @@ class CommandHandler:
             await lang.finish("command.no_argv", self.user_id)
 
     async def handle_ignore_mention(self) -> None:
-        if len(self.argv) < 3:
+        if len(self.argv) < 2:
             await lang.finish("command.no_argv", self.user_id)
 
-        action = self.argv[2]
+        action = self.argv[1]
         ignore_list = json.loads(self.group_config.ignore_mention_user)
 
         if action == "list":
             await lang.finish("command.ignore_mention.list", self.user_id, ", ".join(ignore_list))
 
-        if len(self.argv) < 4:
+        if len(self.argv) < 3:
             await lang.finish("command.no_argv", self.user_id)
-        target_id = self.argv[3]
+        target_id = self.argv[2]
 
         if action == "add":
             if target_id not in ignore_list:


### PR DESCRIPTION
## 问题

`.chat ignore-mention add 2243265359` 返回错误：`无效参数，请使用 /help chat 获取该命令的使用方法！`

## 根因

`handle_ignore_mention` 方法中数组索引偏移了 1 位。`.chat ignore-mention add 2243265359` 解析后 `self.argv = ["ignore-mention", "add", "2243265359"]`，但代码用 `self.argv[2]` 取 action（拿到 `"2243265359"`），再用 `self.argv[3]` 取 target_id（越界），导致 `len(self.argv) < 4` 为真从而触发报错。

## 修复

- `len(self.argv) < 3` → `len(self.argv) < 2`
- `self.argv[2]` → `self.argv[1]`
- `len(self.argv) < 4` → `len(self.argv) < 3`
- `self.argv[3]` → `self.argv[2]`
