### PR TITLE
feat: auto-bind QQ adapter OpenID to OneBot 11 User ID

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ plugins = [
     "nonebot_plugin_wakeuprank",
     "nonebot_plugin_qsend",
     "nonebot_plugin_chat_monitor",
+    "nonebot_plugin_auto_bind",
 ]
 plugin_dirs = []
 builtin_plugins = []

--- a/src/plugins/nonebot_plugin_auto_bind/__init__.py
+++ b/src/plugins/nonebot_plugin_auto_bind/__init__.py
@@ -1,0 +1,32 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from nonebot import require
+from nonebot.plugin import PluginMetadata
+
+__plugin_meta__ = PluginMetadata(
+    name="nonebot_plugin_auto_bind",
+    description="Auto-bind QQ adapter OpenID to OneBot 11 User ID when detecting simultaneous messages",
+    usage="",
+)
+
+require("nonebot_plugin_larkuser")
+require("nonebot_plugin_larkutils")
+require("nonebot_plugin_userinfo")
+require("nonebot_plugin_orm")
+
+from . import main  # ruff:ignore[module-import-not-at-top-of-file, unused-import]

--- a/src/plugins/nonebot_plugin_auto_bind/main.py
+++ b/src/plugins/nonebot_plugin_auto_bind/main.py
@@ -1,0 +1,149 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from logging import getLogger
+from typing import TYPE_CHECKING, Optional
+
+from nonebot import on_message
+from nonebot.adapters.onebot.v11 import Bot as V11Bot
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot_plugin_larkuser.user.utils import is_user_registered
+from nonebot_plugin_larkutils import set_main_account
+from nonebot_plugin_userinfo import EventUserInfo, UserInfo
+from PIL import Image
+
+if TYPE_CHECKING:
+    from nonebot.adapters import Bot, Event
+
+logger = getLogger(__name__)
+
+_MAX_CACHE_AGE = timedelta(seconds=2)
+_TIME_THRESHOLD = timedelta(seconds=0.5)
+_MAX_CACHE_SIZE = 200
+
+_recent_messages: list[dict] = []
+_cache_lock = asyncio.Lock()
+
+
+def _get_adapter_type(bot: Bot) -> Optional[str]:
+    if isinstance(bot, V11Bot):
+        return "onebot_v11"
+    if isinstance(bot, QQBot):
+        return "qq"
+    return None
+
+
+def _hash_avatar(image_bytes: bytes) -> str:
+    try:
+        img = Image.open(BytesIO(image_bytes)).convert("RGB")
+        img = img.resize((64, 64), Image.LANCZOS)
+        return hashlib.md5(img.tobytes()).hexdigest()  # ruff:ignore[hashlib-insecure-hash-function]
+    except Exception:
+        return ""
+
+
+auto_bind_matcher = on_message(block=False, priority=1)
+
+
+@auto_bind_matcher.handle()
+async def _(bot: Bot, event: Event, user_info: UserInfo = EventUserInfo()) -> None:
+    adapter_type = _get_adapter_type(bot)
+    if adapter_type is None:
+        return
+
+    plain_text = event.get_plaintext().strip()
+    if not plain_text:
+        return
+
+    avatar = user_info.user_avatar
+    if avatar is None:
+        return
+
+    try:
+        avatar_bytes = await avatar.get_image()
+    except Exception:
+        return
+
+    if not avatar_bytes:
+        return
+
+    avatar_hash = _hash_avatar(avatar_bytes)
+    if not avatar_hash:
+        return
+
+    now = datetime.now(timezone.utc)
+    user_id = event.get_user_id()
+
+    async with _cache_lock:
+        for cached in _recent_messages:
+            if cached["adapter"] == adapter_type:
+                continue
+            if now - cached["timestamp"] > _TIME_THRESHOLD:
+                continue
+            if cached["plain_text"] != plain_text:
+                continue
+            if cached["avatar_hash"] != avatar_hash:
+                continue
+
+            if adapter_type == "qq":
+                qq_openid = user_id
+                ob11_user_id = cached["user_id"]
+            else:
+                qq_openid = cached["user_id"]
+                ob11_user_id = user_id
+
+            if await is_user_registered(qq_openid, include_subaccount=False):
+                return
+
+            try:
+                await set_main_account(qq_openid, ob11_user_id)
+                logger.info(
+                    "Auto-bound QQ OpenID %s to OneBot 11 User ID %s",
+                    qq_openid,
+                    ob11_user_id,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to auto-bind QQ OpenID %s to OneBot 11 User ID %s",
+                    qq_openid,
+                    ob11_user_id,
+                )
+
+            _recent_messages.remove(cached)
+            return
+
+        _recent_messages.append(
+            {
+                "adapter": adapter_type,
+                "user_id": user_id,
+                "plain_text": plain_text,
+                "avatar_hash": avatar_hash,
+                "timestamp": now,
+            },
+        )
+
+        cutoff = now - _MAX_CACHE_AGE
+        _recent_messages[:] = [m for m in _recent_messages if m["timestamp"] > cutoff]
+
+        if len(_recent_messages) > _MAX_CACHE_SIZE:
+            _recent_messages[:] = _recent_messages[-_MAX_CACHE_SIZE:]

--- a/src/plugins/nonebot_plugin_auto_bind/main.py
+++ b/src/plugins/nonebot_plugin_auto_bind/main.py
@@ -24,9 +24,9 @@ from io import BytesIO
 from logging import getLogger
 from typing import TYPE_CHECKING, Optional
 
-from nonebot import on_message
 from nonebot.adapters.onebot.v11 import Bot as V11Bot
 from nonebot.adapters.qq import Bot as QQBot
+from nonebot.message import event_preprocessor
 from nonebot_plugin_larkuser.user.utils import is_user_registered
 from nonebot_plugin_larkutils import set_main_account
 from nonebot_plugin_userinfo import EventUserInfo, UserInfo
@@ -108,16 +108,17 @@ def _add_to_cache(adapter_type: str, user_id: str, plain_text: str, avatar_hash:
         _recent_messages[:] = _recent_messages[-_MAX_CACHE_SIZE:]
 
 
-auto_bind_matcher = on_message(block=False, priority=1)
-
-
-@auto_bind_matcher.handle()
+@event_preprocessor
 async def _(bot: Bot, event: Event, user_info: UserInfo = EventUserInfo()) -> None:
     adapter_type = _get_adapter_type(bot)
     if adapter_type is None:
         return
 
-    plain_text = event.get_plaintext().strip()
+    try:
+        plain_text = event.get_plaintext().strip()
+    except NotImplementedError:
+        return
+
     if not plain_text:
         return
 

--- a/src/plugins/nonebot_plugin_auto_bind/main.py
+++ b/src/plugins/nonebot_plugin_auto_bind/main.py
@@ -53,13 +53,59 @@ def _get_adapter_type(bot: Bot) -> Optional[str]:
     return None
 
 
-def _hash_avatar(image_bytes: bytes) -> str:
+async def _get_avatar_hash(user_info: UserInfo) -> str:
+    avatar = user_info.user_avatar
+    if avatar is None:
+        return ""
     try:
-        img = Image.open(BytesIO(image_bytes)).convert("RGB")
-        img = img.resize((64, 64), Image.LANCZOS)
-        return hashlib.md5(img.tobytes()).hexdigest()  # ruff:ignore[hashlib-insecure-hash-function]
+        avatar_bytes = await avatar.get_image()
     except Exception:
         return ""
+    if not avatar_bytes:
+        return ""
+    try:
+        img = Image.open(BytesIO(avatar_bytes)).convert("RGB")
+        img = img.resize((64, 64), Image.LANCZOS)
+        return hashlib.md5(img.tobytes(), usedforsecurity=False).hexdigest()
+    except Exception:
+        return ""
+
+
+def _find_cache_match(adapter_type: str, plain_text: str, avatar_hash: str, now: datetime) -> Optional[dict]:
+    for cached in _recent_messages:
+        if cached["adapter"] == adapter_type:
+            continue
+        if now - cached["timestamp"] > _TIME_THRESHOLD:
+            continue
+        if cached["plain_text"] != plain_text:
+            continue
+        if cached["avatar_hash"] != avatar_hash:
+            continue
+        return cached
+    return None
+
+
+async def _try_bind(qq_openid: str, ob11_user_id: str) -> None:
+    if await is_user_registered(qq_openid, include_subaccount=False):
+        return
+    await set_main_account(qq_openid, ob11_user_id)
+    logger.info("Auto-bound QQ OpenID %s to OneBot 11 User ID %s", qq_openid, ob11_user_id)
+
+
+def _add_to_cache(adapter_type: str, user_id: str, plain_text: str, avatar_hash: str, now: datetime) -> None:
+    _recent_messages.append(
+        {
+            "adapter": adapter_type,
+            "user_id": user_id,
+            "plain_text": plain_text,
+            "avatar_hash": avatar_hash,
+            "timestamp": now,
+        },
+    )
+    cutoff = now - _MAX_CACHE_AGE
+    _recent_messages[:] = [m for m in _recent_messages if m["timestamp"] > cutoff]
+    if len(_recent_messages) > _MAX_CACHE_SIZE:
+        _recent_messages[:] = _recent_messages[-_MAX_CACHE_SIZE:]
 
 
 auto_bind_matcher = on_message(block=False, priority=1)
@@ -75,19 +121,7 @@ async def _(bot: Bot, event: Event, user_info: UserInfo = EventUserInfo()) -> No
     if not plain_text:
         return
 
-    avatar = user_info.user_avatar
-    if avatar is None:
-        return
-
-    try:
-        avatar_bytes = await avatar.get_image()
-    except Exception:
-        return
-
-    if not avatar_bytes:
-        return
-
-    avatar_hash = _hash_avatar(avatar_bytes)
+    avatar_hash = await _get_avatar_hash(user_info)
     if not avatar_hash:
         return
 
@@ -95,55 +129,16 @@ async def _(bot: Bot, event: Event, user_info: UserInfo = EventUserInfo()) -> No
     user_id = event.get_user_id()
 
     async with _cache_lock:
-        for cached in _recent_messages:
-            if cached["adapter"] == adapter_type:
-                continue
-            if now - cached["timestamp"] > _TIME_THRESHOLD:
-                continue
-            if cached["plain_text"] != plain_text:
-                continue
-            if cached["avatar_hash"] != avatar_hash:
-                continue
-
-            if adapter_type == "qq":
-                qq_openid = user_id
-                ob11_user_id = cached["user_id"]
-            else:
-                qq_openid = cached["user_id"]
-                ob11_user_id = user_id
-
-            if await is_user_registered(qq_openid, include_subaccount=False):
-                return
-
-            try:
-                await set_main_account(qq_openid, ob11_user_id)
-                logger.info(
-                    "Auto-bound QQ OpenID %s to OneBot 11 User ID %s",
-                    qq_openid,
-                    ob11_user_id,
-                )
-            except Exception:
-                logger.warning(
-                    "Failed to auto-bind QQ OpenID %s to OneBot 11 User ID %s",
-                    qq_openid,
-                    ob11_user_id,
-                )
-
-            _recent_messages.remove(cached)
+        cached = _find_cache_match(adapter_type, plain_text, avatar_hash, now)
+        if cached is None:
+            _add_to_cache(adapter_type, user_id, plain_text, avatar_hash, now)
             return
 
-        _recent_messages.append(
-            {
-                "adapter": adapter_type,
-                "user_id": user_id,
-                "plain_text": plain_text,
-                "avatar_hash": avatar_hash,
-                "timestamp": now,
-            },
-        )
+        if adapter_type == "qq":
+            qq_openid, ob11_user_id = user_id, cached["user_id"]
+        else:
+            qq_openid, ob11_user_id = cached["user_id"], user_id
 
-        cutoff = now - _MAX_CACHE_AGE
-        _recent_messages[:] = [m for m in _recent_messages if m["timestamp"] > cutoff]
+        _recent_messages.remove(cached)
 
-        if len(_recent_messages) > _MAX_CACHE_SIZE:
-            _recent_messages[:] = _recent_messages[-_MAX_CACHE_SIZE:]
+    await _try_bind(qq_openid, ob11_user_id)

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -118,6 +118,7 @@ packages = [
     { include = "nonebot_plugin_wdym", from = "./plugins" },
     { include = "nonebot_plugin_wakeuprank", from = "./plugins" },
     { include = "nonebot_plugin_chat_monitor", from = "./plugins" },
+    { include = "nonebot_plugin_auto_bind", from = "./plugins" },
 ]
 
 


### PR DESCRIPTION
## Summary

Adds a new \
onebot_plugin_auto_bind\ plugin that automatically detects when the same user sends a message that is received by both the QQ official bot and the OneBot 11 bot in a shared group, and binds the QQ adapter's OpenID as a sub-account of the OneBot 11 User ID.

## How it works

- An \on_message\ matcher (priority 1, block=False) caches recently received plain-text messages
- When messages from both QQ adapter and OneBot 11 adapter match all of the following conditions:
  - Same plain text content
  - Time difference < 0.5s
  - Matching avatar (normalized to 64x64 via PIL, then MD5 compared)
  - QQ adapter's OpenID is **not** already registered
- The QQ OpenID is set as a sub-account of the OneBot 11 User ID via \set_main_account\

## Files changed

- \pyproject.toml\ - Register plugin in nonebot plugins list
- \src/pyproject.toml\ - Register plugin package
- \src/plugins/nonebot_plugin_auto_bind/__init__.py\ - Plugin metadata
- \src/plugins/nonebot_plugin_auto_bind/main.py\ - Auto-bind logic