### PR TITLE
fix: only mark triggered_reply when actually calling fetch_reply

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -330,12 +330,6 @@ class MessageProcessor:
         if (
             trigger_mode == "all" or (trigger_mode == "probability" and not self.session.message_queue)
         ) and not self.blocked:
-            # 标记触发回复的消息
-            if item[0] == "message":
-                for cached_msg in reversed(self.session.cached_messages):
-                    if not cached_msg.get("self", False):
-                        cached_msg["triggered_reply"] = True
-                        break
             asyncio.create_task(self.generate_reply(trigger_mode == "all", item[0] == "event"))
 
     async def handle_timer(self, description: str) -> None:
@@ -414,6 +408,11 @@ class MessageProcessor:
                     return
 
         logger.info(f"Generating reply ({important=})...")
+        # 标记触发回复的用户消息
+        for cached_msg in reversed(self.session.cached_messages):
+            if not cached_msg.get("self", False):
+                cached_msg["triggered_reply"] = True
+                break
         self.session.accumulated_text_length = 0
         await self.openai_messages.fetch_reply()
 


### PR DESCRIPTION
## Problem

Previously triggered_reply was set before generate_reply() async task was created in get_message(), causing all user messages to be marked as triggered_reply even though most would be blocked by cooling period, probability check, sleep mode, or pre-trigger signal analysis in generate_reply().

## Fix

Moved the marking logic from get_message() into generate_reply(), right before fetch_reply() is called. Now only messages that actually trigger an LLM response are marked.

## Changes

- get_message(): removed triggered_reply marking
- generate_reply(): added marking before fetch_reply()