### PR TITLE
fix(auto-bind): move Bot/Event imports out of TYPE_CHECKING to fix NameError at startup

### DIFF
--- a/src/plugins/nonebot_plugin_auto_bind/main.py
+++ b/src/plugins/nonebot_plugin_auto_bind/main.py
@@ -22,8 +22,9 @@ import hashlib
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from logging import getLogger
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
+from nonebot.adapters import Bot, Event  # ruff:ignore[typing-only-third-party-import]
 from nonebot.adapters.onebot.v11 import Bot as V11Bot
 from nonebot.adapters.qq import Bot as QQBot
 from nonebot.message import event_preprocessor
@@ -31,9 +32,6 @@ from nonebot_plugin_larkuser.user.utils import is_user_registered
 from nonebot_plugin_larkutils import set_main_account
 from nonebot_plugin_userinfo import EventUserInfo, UserInfo
 from PIL import Image
-
-if TYPE_CHECKING:
-    from nonebot.adapters import Bot, Event
 
 logger = getLogger(__name__)
 


### PR DESCRIPTION
由于 \rom __future__ import annotations\ 的存在，类型标注在运行时被存储为字符串。\event_preprocessor\ 在处理函数签名时会调用 \evaluate_forwardref\ 来求值这些字符串标注，但 \Bot\ 和 \Event\ 仅放在 \TYPE_CHECKING\ 下导入，导致 \NameError: name 'Event' is not defined\。

修复方式：移除 \TYPE_CHECKING\ 保护，将 \Bot\ 和 \Event\ 改为运行时导入。与 #1291 中的 \ix/jrrp-bot-event-import\ 相同的问题模式。