### PR TITLE
fix(auto_bind): also catch ValueError from get_plaintext for messageless events

### DIFF
--- a/src/plugins/nonebot_plugin_auto_bind/main.py
+++ b/src/plugins/nonebot_plugin_auto_bind/main.py
@@ -114,7 +114,7 @@ async def _(bot: Bot, event: Event) -> None:
 
     try:
         plain_text = event.get_plaintext().strip()
-    except NotImplementedError:
+    except (NotImplementedError, ValueError):
         return
 
     if not plain_text:


### PR DESCRIPTION
与之前修复同一 preprocessor 的问题，get_plaintext() 内部调用 get_message() 时对 Heartbeat 等无消息事件会抛出 ValueError('Event has no message!')。将 ValueError 加入异常捕获中。