### PR TITLE
fix(auto_bind): handle None user_info and wrap _try_bind in try/except

### DIFF
--- a/src/plugins/nonebot_plugin_auto_bind/main.py
+++ b/src/plugins/nonebot_plugin_auto_bind/main.py
@@ -125,6 +125,8 @@ async def _(bot: Bot, event: Event) -> None:
         user_info = await get_user_info(bot, event, user_id)
     except (ValueError, NotImplementedError):
         return
+    if user_info is None:
+        return
 
     avatar_hash = await _get_avatar_hash(user_info)
     if not avatar_hash:
@@ -145,4 +147,7 @@ async def _(bot: Bot, event: Event) -> None:
 
         _recent_messages.remove(cached)
 
-    await _try_bind(qq_openid, ob11_user_id)
+    try:
+        await _try_bind(qq_openid, ob11_user_id)
+    except Exception:
+        logger.exception("Failed to auto-bind %s to %s", qq_openid, ob11_user_id)


### PR DESCRIPTION
## 问题

event_preprocessor \_\ 中有两处未处理的异常会导致整个事件被 drop:

1. **\user_info\ 为 \None\ 时访问 \user_info.user_avatar\ 导致 \AttributeError\** — \get_user_info\ 可能返回 \None\，但代码未检查就直接传给 \_get_avatar_hash\
2. **\_try_bind\ 未被 try/except 包裹** — \set_main_account\ 和 \is_user_registered\ 都有数据库操作，异常同样导致事件被 drop

## 修复

- 在 \get_user_info\ 调用后增加 \user_info is None\ 检查
- 用 try/except 包裹 \_try_bind\ 调用并记录日志

Closes #