### PR TITLE
feat(ego-monitor): 为 EGO 页面添加计划/会话事件/日记/博客 API

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3875,6 +3875,7 @@ optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
+    {file = "opencv_python_headless-4.14.0.94-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:bc7db37dc234f7bb3190a158fd9dd750357246fc7d8adb23698843ef721a993b"},
     {file = "opencv_python_headless-4.14.0.94-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:1777f43c9fa064f54b916ad70d944b4fde0a644a17e49f04a966bb24a4b5f1e1"},
     {file = "opencv_python_headless-4.14.0.94-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:29714d7716dbfddf9fec20ffb878765e94ccaecd7d3ebd6750877420296e2dc5"},
     {file = "opencv_python_headless-4.14.0.94-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5e02669eac0ba67b2a22d7245af1e8ee1a2ef1185ee526a063d8f0555224bd52"},

--- a/src/plugins/nonebot_plugin_chat_monitor/routers/ego.py
+++ b/src/plugins/nonebot_plugin_chat_monitor/routers/ego.py
@@ -80,12 +80,7 @@ async def list_ego_diaries(
         count_query = select(func.count()).select_from(DiaryPost)
         total = (await db_session.scalar(count_query)) or 0
 
-        query = (
-            select(DiaryPost)
-            .order_by(DiaryPost.created_at.desc())
-            .offset(offset)
-            .limit(limit)
-        )
+        query = select(DiaryPost).order_by(DiaryPost.created_at.desc()).offset(offset).limit(limit)
         result = await db_session.scalars(query)
         diaries = result.all()
 
@@ -118,12 +113,7 @@ async def list_ego_blogs(
         count_query = select(func.count()).select_from(BlogPost)
         total = (await db_session.scalar(count_query)) or 0
 
-        query = (
-            select(BlogPost)
-            .order_by(BlogPost.create_at.desc())
-            .offset(offset)
-            .limit(limit)
-        )
+        query = select(BlogPost).order_by(BlogPost.create_at.desc()).offset(offset).limit(limit)
         result = await db_session.scalars(query)
         blogs = result.all()
 

--- a/src/plugins/nonebot_plugin_chat_monitor/routers/ego.py
+++ b/src/plugins/nonebot_plugin_chat_monitor/routers/ego.py
@@ -1,5 +1,7 @@
 """EGO 相关的 REST API 路由（重写版）"""
 
+from datetime import datetime
+
 from fastapi import APIRouter, Query, Request
 from fastapi.exceptions import HTTPException
 from nonebot_plugin_orm import get_session
@@ -32,13 +34,120 @@ async def get_ego_status(request: Request):
     }
 
 
+@router.get("/chat-monitor/ego/plan")
+async def get_ego_plan(request: Request):
+    """获取今日计划详情（时间段+内容列表）"""
+    await verify_admin_request(request)
+    from nonebot_plugin_chat.core.ego.moonlark_main import moonlark_main
+
+    plan_items = moonlark_main.planner.get_plan()
+    if not plan_items:
+        return {"items": []}
+
+    return {
+        "items": [
+            {
+                "period": item.period,
+                "content": item.content,
+            }
+            for item in plan_items
+        ],
+    }
+
+
+@router.get("/chat-monitor/ego/session-events")
+async def get_session_events(request: Request, date: str = Query(default="")):
+    """获取 EventCollector 收集的会话事件摘要"""
+    await verify_admin_request(request)
+    from nonebot_plugin_chat.core.ego.event_collector import event_collector
+
+    target_date = date if date else datetime.now().strftime("%Y-%m-%d")
+    summary = await event_collector.get_all_events_summary(date=target_date)
+    return {"date": target_date, "summary": summary}
+
+
+@router.get("/chat-monitor/ego/diaries")
+async def list_ego_diaries(
+    request: Request,
+    limit: int = Query(10, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    """列出日记记录（替代废弃的 AgentEvent）"""
+    await verify_admin_request(request)
+    from nonebot_plugin_chat.models import DiaryPost
+
+    async with get_session() as db_session:
+        count_query = select(func.count()).select_from(DiaryPost)
+        total = (await db_session.scalar(count_query)) or 0
+
+        query = (
+            select(DiaryPost)
+            .order_by(DiaryPost.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await db_session.scalars(query)
+        diaries = result.all()
+
+    return {
+        "total": total,
+        "diaries": [
+            {
+                "id": d.id,
+                "content": d.content[:500],
+                "keywords": d.keywords,
+                "created_at": d.created_at.isoformat() if d.created_at else None,
+                "expire_at": d.expire_at.isoformat() if d.expire_at else None,
+            }
+            for d in diaries
+        ],
+    }
+
+
+@router.get("/chat-monitor/ego/blogs")
+async def list_ego_blogs(
+    request: Request,
+    limit: int = Query(10, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    """列出博客记录"""
+    await verify_admin_request(request)
+    from nonebot_plugin_chat.models import BlogPost
+
+    async with get_session() as db_session:
+        count_query = select(func.count()).select_from(BlogPost)
+        total = (await db_session.scalar(count_query)) or 0
+
+        query = (
+            select(BlogPost)
+            .order_by(BlogPost.create_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await db_session.scalars(query)
+        blogs = result.all()
+
+    return {
+        "total": total,
+        "blogs": [
+            {
+                "id": b.id,
+                "title": b.title,
+                "content": b.content[:300],
+                "created_at": b.create_at.isoformat() if b.create_at else None,
+            }
+            for b in blogs
+        ],
+    }
+
+
 @router.get("/chat-monitor/ego/events")
 async def list_ego_events(
     request: Request,
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
-    """列出 EGO 的智能体事件记录"""
+    """列出 EGO 的智能体事件记录（废弃中，保留兼容）"""
     await verify_admin_request(request)
     from nonebot_plugin_chat.models import AgentEvent
 
@@ -65,7 +174,7 @@ async def list_ego_events(
 
 @router.get("/chat-monitor/ego/events/{event_id}")
 async def get_ego_event(event_id: int, request: Request):
-    """获取单条 EGO 事件详情"""
+    """获取单条 EGO 事件详情（废弃中，保留兼容）"""
     await verify_admin_request(request)
     from nonebot_plugin_chat.models import AgentEvent
 


### PR DESCRIPTION
在后端增加 4 个新的 REST API 端点，供 chat-monitor 前端的全新 EGO 页面使用：

- GET /chat-monitor/ego/plan — 计划明细
- GET /chat-monitor/ego/session-events — 会话事件摘要
- GET /chat-monitor/ego/diaries — 日记记录（分页）
- GET /chat-monitor/ego/blogs — 博客记录（分页）

前端同步已推送到 chat-monitor main 分支（GitHub Pages）。