### PR TITLE
fix: 移除 get_message 中错误的 triggered_reply 提前标记

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -331,12 +331,6 @@ class MessageProcessor:
         if (
             trigger_mode == "all" or (trigger_mode == "probability" and not self.session.message_queue)
         ) and not self.blocked:
-            # 标记触发回复的消息
-            if item[0] == "message":
-                for cached_msg in reversed(self.session.cached_messages):
-                    if not cached_msg.get("self", False):
-                        cached_msg["triggered_reply"] = True
-                        break
             asyncio.create_task(self.generate_reply(trigger_mode == "all", item[0] == "event"))
 
     async def handle_timer(self, description: str) -> None:


### PR DESCRIPTION
## 问题

chat-monitor 中几乎所有消息都显示为「💬 触发回复」标签。

## 根因

`processor.py` 的 `get_message()` 方法在概率检查之前就标记了 `triggered_reply = True`，导致概率检查失败后消息仍被标记。

`generate_reply()` 内部已在所有检查通过后正确标记，故 `get_message()` 中的标记是多余的且有害的。

## 修复

移除 `get_message()` 中对 `triggered_reply` 的提前标记逻辑。