### PR TITLE
feat(chat): 限制合并转发解析最多到第三层

### DIFF
--- a/src/lang/zh_hans/chat.yaml
+++ b/src/lang/zh_hans/chat.yaml
@@ -627,6 +627,7 @@ parser:
   forward:
     not_supported: '[合并转发：获取信息失败（不支持）]'
     failed: '[合并转发：获取信息失败（{}）]'
+    too_deep: '[合并转发：嵌套过深，已截断]'
     forward: '[合并转发：{}]'
     summary: '[合并转发（消息过多，已总结）：{}]'
     summary_prompt: |

--- a/src/plugins/nonebot_plugin_chat/utils/group.py
+++ b/src/plugins/nonebot_plugin_chat/utils/group.py
@@ -131,5 +131,9 @@ class LinkParser:
         )
 
 
-async def parse_message_to_string(message: UniMessage, event: Event, bot: Bot, state: T_State, lang_str: str) -> str:
-    return await LinkParser(await _parse_message_to_string(message, event, bot, state, lang_str), lang_str).parse()
+async def parse_message_to_string(
+    message: UniMessage, event: Event, bot: Bot, state: T_State, lang_str: str, forward_depth: int = 0
+) -> str:
+    return await LinkParser(
+        await _parse_message_to_string(message, event, bot, state, lang_str, forward_depth=forward_depth), lang_str
+    ).parse()

--- a/src/plugins/nonebot_plugin_chat/utils/message.py
+++ b/src/plugins/nonebot_plugin_chat/utils/message.py
@@ -33,15 +33,23 @@ from nonebot_plugin_openai import fetch_message, generate_message
 
 from nonebot_plugin_chat.config import config
 
+MAX_FORWARD_DEPTH = 3
+
 from .image import generate_image_id, get_image_summary
 from .file import get_file_summary
 from .emoji import QQ_EMOJI_MAP
 
 
 class MessageParser:
-
     def __init__(
-        self, message: UniMessage, event: Event, bot: Bot, state: T_State, lang_str: str, describe_image: bool = True
+        self,
+        message: UniMessage,
+        event: Event,
+        bot: Bot,
+        state: T_State,
+        lang_str: str,
+        describe_image: bool = True,
+        _forward_depth: int = 0,
     ) -> None:
         self.message = message
         self.event = event
@@ -50,6 +58,7 @@ class MessageParser:
         self.bot = bot
         self.state = state
         self.images = []
+        self._forward_depth = _forward_depth
 
     async def parse(self) -> str:
         return "".join([await self.parse_segment(segment) for segment in self.message])
@@ -108,6 +117,8 @@ class MessageParser:
     async def parse_forawrd_message(self, ref_id: str) -> str:
         if not isinstance(self.bot, OneBotV11Bot):
             return await lang.text("parser.forward.not_supported", self.user_id)
+        if self._forward_depth >= MAX_FORWARD_DEPTH:
+            return await lang.text("parser.forward.too_deep", self.user_id)
         try:
             message_list_str = await self.get_forawrd_message_list(ref_id)
         except ActionFailed as e:
@@ -145,7 +156,9 @@ class MessageParser:
 
     async def get_parsed_message(self, node_message: list[dict]) -> str:
         uni_message = await parse_dict_message(node_message, self.bot, self.event)
-        return await parse_message_to_string(uni_message, self.event, self.bot, self.state, self.user_id)
+        return await parse_message_to_string(
+            uni_message, self.event, self.bot, self.state, self.user_id, forward_depth=self._forward_depth + 1
+        )
 
     async def parse_mention(self, segment: At) -> str:
         user = await get_user(segment.target)
@@ -198,8 +211,10 @@ async def parse_dict_message(dict_message: list[dict], bot: Bot, event: Optional
     return uni_message
 
 
-async def parse_message_to_string(message: UniMessage, event: Event, bot: Bot, state: T_State, lang_str: str) -> str:
-    parser = MessageParser(message, event, bot, state, lang_str)
+async def parse_message_to_string(
+    message: UniMessage, event: Event, bot: Bot, state: T_State, lang_str: str, forward_depth: int = 0
+) -> str:
+    parser = MessageParser(message, event, bot, state, lang_str, _forward_depth=forward_depth)
     return await parser.parse()
 
 


### PR DESCRIPTION
为 chat 插件的 Message Parser 添加合并转发解析层数限制，最多解析到第三层。

### 变更内容
- **message.py**: 添加 \MAX_FORWARD_DEPTH = 3\ 常量，\MessageParser\ 增加 \_forward_depth\ 属性追踪嵌套深度，深度 ≥ 3 时返回截断提示
- **group.py**: \parse_message_to_string\ 传递 \orward_depth\ 参数
- **chat.yaml**: 添加 \parser.forward.too_deep\ 本地化键