### PR TITLE
fix(larkuid): 恢复 patch_header 中的 CORS fallback header

### DIFF
--- a/src/plugins/nonebot_plugin_larkuid/middlewares.py
+++ b/src/plugins/nonebot_plugin_larkuid/middlewares.py
@@ -1,12 +1,14 @@
 import time
 from typing import cast
+
 from fastapi import FastAPI, Request, Response
-from nonebot import get_app
 from fastapi.middleware.cors import CORSMiddleware
+from nonebot import get_app
+from starlette.middleware.base import RequestResponseEndpoint
 
 from .config import config
 
-app = cast(FastAPI, get_app())
+app = cast("FastAPI", get_app())
 
 app.add_middleware(
     CORSMiddleware,
@@ -18,9 +20,10 @@ app.add_middleware(
 
 
 @app.middleware("http")
-async def patch_header(request: Request, call_next):
+async def patch_header(request: Request, call_next: RequestResponseEndpoint):
     start_time = time.time()
-    response = cast(Response, await call_next(request))
+    response = cast("Response", await call_next(request))
     process_time = time.time() - start_time
-    response.headers["X-Process-Time"] = f"{round(process_time*1000, 1)} ms"
+    response.headers["X-Process-Time"] = f"{round(process_time * 1000, 1)} ms"
+    response.headers["Access-Control-Allow-Origin"] = config.cors_allow_origins[0] if config.cors_allow_origins else "*"
     return response


### PR DESCRIPTION
## 问题

提交 312f32a1 移除了 \patch_header\ 中间件中手动设置 \Access-Control-Allow-Origin\ 的代码，仅依赖 \CORSMiddleware\ 处理 CORS。但 \CORSMiddleware\ 在某些情况下（请求缺 \Origin\ 头、响应被反向代理拦截返回非标准状态码等）不会添加该头部，导致下游出现 CORS 错误。

## 修复

恢复 \Access-Control-Allow-Origin\ header 作为 fallback，确保所有响应都包含 CORS 头部。\CORSMiddleware\ 作为最外层中间件仍会最终覆写该值（\llow_credentials=True\ 时回显具体 origin），不会产生冲突。

同时补充 \call_next\ 类型注解、修复 ruff lint 警告。