### PR TITLE
调整在不同时间展示回声洞中的疯狂星期四文案的概率

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,11 @@ jobs:
           poetry run nb orm check | grep '没有检测到新的升级操作' && exit 0
           exit 1
 
-      # - name: Run pytest
-      #   run: poetry run pytest
+      - name: Run pytest
+        env:
+          SQLALCHEMY_DATABASE_URL: sqlite+aiosqlite://
+          ALEMBIC_STARTUP_CHECK: "False"
+        run: poetry run pytest tests/test_cave.py -v
       
       - name: Generate COMMANDS.md
         run: |

--- a/src/plugins/nonebot_plugin_larkcave/utils/cave.py
+++ b/src/plugins/nonebot_plugin_larkcave/utils/cave.py
@@ -15,6 +15,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ##############################################################################
 
+import datetime
 import random
 
 from nonebot_plugin_orm import AsyncSession, async_scoped_session
@@ -27,11 +28,20 @@ from .comment import get_comments, add_cave_message
 from .cool_down import on_use
 from .decoder import decode_cave
 
+THURSDAY_KEYWORDS = ("星期四", "v50")
+
 
 async def get_cave(session: async_scoped_session | AsyncSession) -> CaveData:
     cave_id_list = (await session.scalars(select(CaveData.id).where(CaveData.public))).all()
     cave_id = random.choice(cave_id_list)
-    return await session.get_one(CaveData, {"id": cave_id})
+    cave_data = await session.get_one(CaveData, {"id": cave_id})
+    is_thursday = datetime.datetime.now().weekday() == 3
+    contains_all = all(keyword in cave_data.content for keyword in THURSDAY_KEYWORDS)
+    contains_any = any(keyword in cave_data.content for keyword in THURSDAY_KEYWORDS)
+    if (is_thursday and not contains_any) or (not is_thursday and contains_all):
+        cave_id = random.choice(cave_id_list)
+        cave_data = await session.get_one(CaveData, {"id": cave_id})
+    return cave_data
 
 
 async def send_cave(session: async_scoped_session, user_id: str, group_id: str, reverse: bool = False) -> None:

--- a/src/plugins/nonebot_plugin_larkcave/utils/cave.py
+++ b/src/plugins/nonebot_plugin_larkcave/utils/cave.py
@@ -31,7 +31,9 @@ from .decoder import decode_cave
 THURSDAY_KEYWORDS = ("星期四", "50", "KFC")
 
 
-async def _random_keyword_cave(session: async_scoped_session | AsyncSession, require_keywords: bool | None = None) -> CaveData | None:
+async def _random_keyword_cave(
+    session: async_scoped_session | AsyncSession, require_keywords: bool | None = None
+) -> CaveData | None:
     stmt = select(CaveData).where(CaveData.public)
     if require_keywords is not None:
         conditions = [CaveData.content.ilike(f"%{kw}%") for kw in THURSDAY_KEYWORDS]
@@ -61,7 +63,9 @@ async def get_cave(session: async_scoped_session | AsyncSession) -> CaveData:
     cave = await _random_keyword_cave(session)
     if cave is None:
         raise IndexError
-    contains_any = any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS) and "[[img" not in cave.content.lower()
+    contains_any = (
+        any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS) and "[[img" not in cave.content.lower()
+    )
     if contains_any and random.random() < 0.5:
         cave = await _random_keyword_cave(session) or cave
     return cave

--- a/src/plugins/nonebot_plugin_larkcave/utils/cave.py
+++ b/src/plugins/nonebot_plugin_larkcave/utils/cave.py
@@ -19,29 +19,50 @@ import datetime
 import random
 
 from nonebot_plugin_orm import AsyncSession, async_scoped_session
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import NoResultFound
 
 from ..lang import lang
 from ..models import CaveData
-from .comment import get_comments, add_cave_message
+from .comment import add_cave_message, get_comments
 from .cool_down import on_use
 from .decoder import decode_cave
 
-THURSDAY_KEYWORDS = ("星期四", "v50")
+THURSDAY_KEYWORDS = ("星期四", "v50", "KFC")
+
+
+async def _random_keyword_cave(session: async_scoped_session | AsyncSession, require_keywords: bool | None = None) -> CaveData | None:
+    stmt = select(CaveData).where(CaveData.public)
+    if require_keywords is not None:
+        for kw in THURSDAY_KEYWORDS:
+            condition = CaveData.content.ilike(f"%{kw}%")
+            stmt = stmt.where(condition if require_keywords else ~condition)
+    result = await session.execute(stmt.order_by(func.random()).limit(1))
+    return result.scalar_one_or_none()
 
 
 async def get_cave(session: async_scoped_session | AsyncSession) -> CaveData:
-    cave_id_list = (await session.scalars(select(CaveData.id).where(CaveData.public))).all()
-    cave_id = random.choice(cave_id_list)
-    cave_data = await session.get_one(CaveData, {"id": cave_id})
     is_thursday = datetime.datetime.now().weekday() == 3
-    contains_all = all(keyword in cave_data.content for keyword in THURSDAY_KEYWORDS)
-    contains_any = any(keyword in cave_data.content for keyword in THURSDAY_KEYWORDS)
-    if (is_thursday and not contains_any) or (not is_thursday and contains_all):
-        cave_id = random.choice(cave_id_list)
-        cave_data = await session.get_one(CaveData, {"id": cave_id})
-    return cave_data
+
+    if is_thursday:
+        if random.random() < 0.4:
+            cave = await _random_keyword_cave(session, require_keywords=True)
+            if cave is None:
+                cave = await _random_keyword_cave(session, require_keywords=False)
+        else:
+            cave = await _random_keyword_cave(session, require_keywords=False)
+            if cave is None:
+                cave = await _random_keyword_cave(session, require_keywords=True)
+        if cave is None:
+            raise NoResultFound
+        return cave
+    cave = await _random_keyword_cave(session)
+    if cave is None:
+        raise IndexError
+    contains_any = any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS)
+    if contains_any and random.random() < 0.5:
+        cave = await _random_keyword_cave(session) or cave
+    return cave
 
 
 async def send_cave(session: async_scoped_session, user_id: str, group_id: str, reverse: bool = False) -> None:

--- a/src/plugins/nonebot_plugin_larkcave/utils/cave.py
+++ b/src/plugins/nonebot_plugin_larkcave/utils/cave.py
@@ -19,7 +19,7 @@ import datetime
 import random
 
 from nonebot_plugin_orm import AsyncSession, async_scoped_session
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import NoResultFound
 
 from ..lang import lang
@@ -34,9 +34,11 @@ THURSDAY_KEYWORDS = ("星期四", "50", "KFC")
 async def _random_keyword_cave(session: async_scoped_session | AsyncSession, require_keywords: bool | None = None) -> CaveData | None:
     stmt = select(CaveData).where(CaveData.public)
     if require_keywords is not None:
-        for kw in THURSDAY_KEYWORDS:
-            condition = CaveData.content.ilike(f"%{kw}%")
-            stmt = stmt.where(condition if require_keywords else ~condition)
+        conditions = [CaveData.content.ilike(f"%{kw}%") for kw in THURSDAY_KEYWORDS]
+        if require_keywords:
+            stmt = stmt.where(or_(*conditions), ~CaveData.content.ilike("%[[Img%"))
+        else:
+            stmt = stmt.where(~or_(*conditions))
     result = await session.execute(stmt.order_by(func.random()).limit(1))
     return result.scalar_one_or_none()
 
@@ -59,7 +61,7 @@ async def get_cave(session: async_scoped_session | AsyncSession) -> CaveData:
     cave = await _random_keyword_cave(session)
     if cave is None:
         raise IndexError
-    contains_any = any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS)
+    contains_any = any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS) and "[[img" not in cave.content.lower()
     if contains_any and random.random() < 0.5:
         cave = await _random_keyword_cave(session) or cave
     return cave

--- a/src/plugins/nonebot_plugin_larkcave/utils/cave.py
+++ b/src/plugins/nonebot_plugin_larkcave/utils/cave.py
@@ -28,7 +28,7 @@ from .comment import add_cave_message, get_comments
 from .cool_down import on_use
 from .decoder import decode_cave
 
-THURSDAY_KEYWORDS = ("星期四", "v50", "KFC")
+THURSDAY_KEYWORDS = ("星期四", "50", "KFC")
 
 
 async def _random_keyword_cave(session: async_scoped_session | AsyncSession, require_keywords: bool | None = None) -> CaveData | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import nonebot
 from pytest_asyncio import is_async_test
@@ -5,6 +7,9 @@ from pytest_asyncio import is_async_test
 # 导入适配器
 from nonebot.adapters.console import Adapter as ConsoleAdapter
 from nonebot.adapters.onebot.v11 import Adapter as OneBotV11Adapter
+
+os.environ["SQLALCHEMY_DATABASE_URL"] = "sqlite+aiosqlite://"
+os.environ["ALEMBIC_STARTUP_CHECK"] = "False"
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]):

--- a/tests/test_cave.py
+++ b/tests/test_cave.py
@@ -1,0 +1,267 @@
+import pytest
+from unittest.mock import patch
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy.exc import NoResultFound
+
+
+@pytest.fixture
+async def eng():
+    from nonebot_plugin_larkcave.models import CaveData
+
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(CaveData.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(CaveData.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+async def session(eng):
+    factory = async_sessionmaker(eng, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+
+
+@pytest.fixture
+async def seed_caves(session):
+    from nonebot_plugin_larkcave.models import CaveData
+
+    caves = [
+        CaveData(id=1, author="a", content="普通内容没有关键词", time=datetime(2026, 1, 1), public=True),
+        CaveData(id=2, author="b", content="星期四快乐 50 KFC", time=datetime(2026, 1, 1), public=True),
+        CaveData(id=3, author="c", content="今天星期四", time=datetime(2026, 1, 1), public=True),
+        CaveData(id=4, author="d", content="[[Img:1674571532.0250726]]", time=datetime(2026, 1, 1), public=True),
+        CaveData(id=5, author="e", content="KFC疯狂星期四", time=datetime(2026, 1, 1), public=True),
+        CaveData(id=6, author="f", content="数字50在文本中", time=datetime(2026, 1, 1), public=True),
+        CaveData(id=7, author="g", content="kfc 小写", time=datetime(2026, 1, 1), public=True),
+        CaveData(id=8, author="h", content="private only", time=datetime(2026, 1, 1), public=False),
+    ]
+    session.add_all(caves)
+    await session.commit()
+    return caves
+
+
+# ========== _random_keyword_cave tests ==========
+
+
+@pytest.mark.asyncio
+async def test_random_cave_no_filter_returns_any(session, seed_caves):
+    from nonebot_plugin_larkcave.utils.cave import _random_keyword_cave
+
+    result = await _random_keyword_cave(session)
+    assert result is not None
+    assert result.public is True
+
+
+@pytest.mark.asyncio
+async def test_random_cave_no_filter_ignores_private(session, seed_caves):
+    from nonebot_plugin_larkcave.utils.cave import _random_keyword_cave
+
+    for _ in range(5):
+        result = await _random_keyword_cave(session)
+        assert result is not None
+        assert result.public is True
+
+
+@pytest.mark.asyncio
+async def test_random_cave_require_keywords_returns_matching(session, seed_caves):
+    from nonebot_plugin_larkcave.utils.cave import _random_keyword_cave, THURSDAY_KEYWORDS
+
+    for _ in range(10):
+        result = await _random_keyword_cave(session, require_keywords=True)
+        assert result is not None
+        assert any(kw.lower() in result.content.lower() for kw in THURSDAY_KEYWORDS)
+        assert "[[img" not in result.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_random_cave_require_keywords_excludes_image(session, seed_caves):
+    from nonebot_plugin_larkcave.utils.cave import _random_keyword_cave
+
+    for _ in range(10):
+        result = await _random_keyword_cave(session, require_keywords=True)
+        if result is not None:
+            assert "[[img" not in result.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_random_cave_exclude_keywords_returns_non_matching(session, seed_caves):
+    from nonebot_plugin_larkcave.utils.cave import _random_keyword_cave, THURSDAY_KEYWORDS
+
+    for _ in range(10):
+        result = await _random_keyword_cave(session, require_keywords=False)
+        assert result is not None
+        assert not any(kw.lower() in result.content.lower() for kw in THURSDAY_KEYWORDS)
+
+
+@pytest.mark.asyncio
+async def test_random_cave_keyword_empty_returns_none(session):
+    from nonebot_plugin_larkcave.utils.cave import _random_keyword_cave
+
+    result = await _random_keyword_cave(session, require_keywords=True)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_random_cave_nonkeyword_empty_returns_none(session):
+    from nonebot_plugin_larkcave.models import CaveData
+    from nonebot_plugin_larkcave.utils.cave import _random_keyword_cave
+
+    caves = [
+        CaveData(id=10, author="a", content="星期四快乐 50 KFC", time=datetime(2026, 1, 1), public=True),
+        CaveData(id=11, author="b", content="今天星期四", time=datetime(2026, 1, 1), public=True),
+    ]
+    session.add_all(caves)
+    await session.commit()
+    result = await _random_keyword_cave(session, require_keywords=False)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_random_cave_empty_db_returns_none(session):
+    from nonebot_plugin_larkcave.utils.cave import _random_keyword_cave
+
+    result = await _random_keyword_cave(session)
+    assert result is None
+
+
+# ========== get_cave: non-Thursday tests ==========
+
+
+@pytest.mark.asyncio
+async def test_get_cave_non_thursday_no_keywords(session, seed_caves):
+    from nonebot_plugin_larkcave.utils.cave import get_cave
+
+    with patch("nonebot_plugin_larkcave.utils.cave.datetime") as mock_dt:
+        mock_dt.datetime.now.return_value = datetime(2026, 7, 29)
+        mock_dt.datetime.now.weekday.return_value = 2
+        cave = await get_cave(session)
+        assert cave is not None
+        assert cave.public is True
+
+
+@pytest.mark.asyncio
+async def test_get_cave_non_thursday_empty_db(session):
+    from nonebot_plugin_larkcave.utils.cave import get_cave
+
+    with patch("nonebot_plugin_larkcave.utils.cave.datetime") as mock_dt:
+        mock_dt.datetime.now.return_value = datetime(2026, 7, 29)
+        mock_dt.datetime.now.weekday.return_value = 2
+        with pytest.raises(IndexError):
+            await get_cave(session)
+
+
+# ========== get_cave: Thursday tests ==========
+
+
+@pytest.mark.asyncio
+async def test_get_cave_thursday_keyword_path(session, seed_caves):
+    from nonebot_plugin_larkcave.utils.cave import get_cave, THURSDAY_KEYWORDS
+
+    with (
+        patch("nonebot_plugin_larkcave.utils.cave.datetime") as mock_dt,
+        patch("nonebot_plugin_larkcave.utils.cave.random.random", return_value=0.3),
+    ):
+        mock_dt.datetime.now.return_value = datetime(2026, 7, 30)
+        mock_dt.datetime.now.weekday.return_value = 3
+        cave = await get_cave(session)
+        assert cave is not None
+        assert any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS)
+        assert "[[img" not in cave.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_cave_thursday_nonkeyword_path(session, seed_caves):
+    from nonebot_plugin_larkcave.utils.cave import get_cave, THURSDAY_KEYWORDS
+
+    with (
+        patch("nonebot_plugin_larkcave.utils.cave.datetime") as mock_dt,
+        patch("nonebot_plugin_larkcave.utils.cave.random.random", return_value=0.7),
+    ):
+        mock_dt.datetime.now.return_value = datetime(2026, 7, 30)
+        mock_dt.datetime.now.weekday.return_value = 3
+        cave = await get_cave(session)
+        assert cave is not None
+        assert not any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS)
+
+
+@pytest.mark.asyncio
+async def test_get_cave_thursday_keyword_fallback_to_nonkeyword(session):
+    from nonebot_plugin_larkcave.models import CaveData
+    from nonebot_plugin_larkcave.utils.cave import get_cave, THURSDAY_KEYWORDS
+
+    caves = [
+        CaveData(id=20, author="a", content="普通内容", time=datetime(2026, 1, 1), public=True),
+    ]
+    session.add_all(caves)
+    await session.commit()
+    with (
+        patch("nonebot_plugin_larkcave.utils.cave.datetime") as mock_dt,
+        patch("nonebot_plugin_larkcave.utils.cave.random.random", return_value=0.3),
+    ):
+        mock_dt.datetime.now.return_value = datetime(2026, 7, 30)
+        mock_dt.datetime.now.weekday.return_value = 3
+        cave = await get_cave(session)
+        assert cave is not None
+        assert not any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS)
+
+
+@pytest.mark.asyncio
+async def test_get_cave_thursday_nonkeyword_fallback_to_keyword(session):
+    from nonebot_plugin_larkcave.models import CaveData
+    from nonebot_plugin_larkcave.utils.cave import get_cave, THURSDAY_KEYWORDS
+
+    caves = [
+        CaveData(id=30, author="a", content="星期四 50 KFC", time=datetime(2026, 1, 1), public=True),
+    ]
+    session.add_all(caves)
+    await session.commit()
+    with (
+        patch("nonebot_plugin_larkcave.utils.cave.datetime") as mock_dt,
+        patch("nonebot_plugin_larkcave.utils.cave.random.random", return_value=0.7),
+    ):
+        mock_dt.datetime.now.return_value = datetime(2026, 7, 30)
+        mock_dt.datetime.now.weekday.return_value = 3
+        cave = await get_cave(session)
+        assert cave is not None
+        assert any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS)
+
+
+@pytest.mark.asyncio
+async def test_get_cave_thursday_no_caves(session):
+    from nonebot_plugin_larkcave.utils.cave import get_cave
+
+    with (
+        patch("nonebot_plugin_larkcave.utils.cave.datetime") as mock_dt,
+        patch("nonebot_plugin_larkcave.utils.cave.random.random", return_value=0.3),
+    ):
+        mock_dt.datetime.now.return_value = datetime(2026, 7, 30)
+        mock_dt.datetime.now.weekday.return_value = 3
+        with pytest.raises(NoResultFound):
+            await get_cave(session)
+
+
+# ========== Edge cases ==========
+
+
+@pytest.mark.asyncio
+async def test_get_cave_thursday_40_60_distribution(session, seed_caves):
+    from nonebot_plugin_larkcave.utils.cave import get_cave, THURSDAY_KEYWORDS
+
+    for rand_val, expect_keyword in [(0.0, True), (0.39, True), (0.4, False), (0.99, False)]:
+        with (
+            patch("nonebot_plugin_larkcave.utils.cave.datetime") as mock_dt,
+            patch("nonebot_plugin_larkcave.utils.cave.random.random", return_value=rand_val),
+        ):
+            mock_dt.datetime.now.return_value = datetime(2026, 7, 30)
+            mock_dt.datetime.now.weekday.return_value = 3
+            cave = await get_cave(session)
+            assert cave is not None
+            if expect_keyword:
+                assert any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS)
+            else:
+                assert not any(kw.lower() in cave.content.lower() for kw in THURSDAY_KEYWORDS)


### PR DESCRIPTION
If today is Thursday, only caves containing at least one of "星期四" or "v50" are allowed; otherwise, caves must not contain all of them.