### PR TITLE
fix(ego): 触发 run_before_sleep 睡前博客生成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,10 @@ jobs:
       - name: Commit and push changes
         env:
           HEAD_REF: ${{ github.head_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # checkout 使用 persist-credentials: false，需显式配置 token 才能 push
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           git add .
           if ! git diff --cached --quiet; then
             git config --global user.name "github-actions[bot]"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2634,14 +2634,14 @@ testing = ["pytest"]
 
 [[package]]
 name = "markdown"
-version = "3.10.2"
+version = "3.10.3"
 description = "Python implementation of John Gruber's Markdown."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36"},
-    {file = "markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950"},
+    {file = "markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea"},
+    {file = "markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f"},
 ]
 
 [package.extras]
@@ -6443,14 +6443,14 @@ test = ["aiohttp (>=3.10.5)", "flake8 (>=6.1,<7.0)", "mypy (>=0.800)", "psutil",
 
 [[package]]
 name = "virtualenv"
-version = "21.7.0"
+version = "21.7.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.7.0-py3-none-any.whl", hash = "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd"},
-    {file = "virtualenv-21.7.0.tar.gz", hash = "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c"},
+    {file = "virtualenv-21.7.1-py3-none-any.whl", hash = "sha256:6394973f990536e34c05157179146c020284c42fe01da1dfeb0ba16c345280d9"},
+    {file = "virtualenv-21.7.1.tar.gz", hash = "sha256:d0dbfaa5483487baea28d7210ef8d24c9d1bd0f10f449eeb215568825a9b334e"},
 ]
 
 [package.dependencies]

--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -292,12 +292,20 @@ class MoonlarkMain:
 
     async def run_before_sleep(self) -> None:
         """睡前运行：博客 Decider + Writter"""
-        events_text = await event_collector.get_all_events_summary()
-        plan_text = self.planner.get_plan_text()
+        try:
+            events_text = await event_collector.get_all_events_summary()
+            plan_text = self.planner.get_plan_text()
 
-        decision = await self.blog_writer.decider(events_text, plan_text)
-        if decision is not None:
+            decision = await self.blog_writer.decider(events_text, plan_text)
+            if decision is None:
+                logger.info("[MoonlarkMain] 睡前博客 Decider 返回空，跳过")
+                return
+            if decision.skip:
+                logger.info("[MoonlarkMain] 睡前博客 Decider 决定跳过本次博客")
+                return
             self._blog_content = await self.blog_writer.writter(decision, events_text, plan_text)
+        except Exception as e:
+            logger.exception(f"[MoonlarkMain] 睡前博客生成失败: {e}")
 
 
 moonlark_main = MoonlarkMain()

--- a/src/plugins/nonebot_plugin_chat/core/ego/sleep_controller.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/sleep_controller.py
@@ -68,7 +68,7 @@ class SleepController:
 
         logger.debug(
             f"[SleepController] hour={hour:.1f} B={b:.3f} S={s:.3f} "
-            f"F={f:.3f} ε={epsilon:.4f} → tiredness={self.tiredness:.4f}"
+            f"F={f:.3f} ε={epsilon:.4f} → tiredness={self.tiredness:.4f}",
         )
         return self.tiredness
 
@@ -194,9 +194,8 @@ class SleepController:
         if deal_type == "ready":
             await self.handle_tired()
             return "已进入睡眠模式。"
-        else:
-            delay = min(delay_minutes, 30)
-            return f"已延迟 {delay} 分钟睡觉。" + (f"原因: {reason}" if reason else "")
+        delay = min(delay_minutes, 30)
+        return f"已延迟 {delay} 分钟睡觉。" + (f"原因: {reason}" if reason else "")
 
     async def wake_up(self, reason: str = "") -> None:
         self.sleep_state = False

--- a/src/plugins/nonebot_plugin_chat/core/ego/sleep_controller.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/sleep_controller.py
@@ -8,6 +8,7 @@
 有疲劳时：12:30(F=1,S=1)达到 SLEEP_THRESHOLD，14:30 恢复到 < WAKE_THRESHOLD
 """
 
+import asyncio
 import math
 import random
 from datetime import datetime
@@ -37,6 +38,7 @@ class SleepController:
         self.consecutive_replies: int = 0
         self.sleep_think_count: int = 0
         self.context_cleared: bool = False
+        self._sleep_tasks: set[asyncio.Task] = set()
 
         scheduler.scheduled_job("interval", minutes=10, id="sleep_controller_process_timer")(self.process_timer)
 
@@ -170,6 +172,10 @@ class SleepController:
         self.moonlark_main.state["sleep_mode"] = True
         self.moonlark_main.state["injected_note_ids"] = []
         logger.info("[SleepController] 进入睡眠模式")
+        # 睡前触发博客生成（后台任务，不阻塞入睡流程）
+        task = asyncio.create_task(self.moonlark_main.run_before_sleep())
+        self._sleep_tasks.add(task)
+        task.add_done_callback(self._sleep_tasks.discard)
 
     async def sleep(self) -> None:
         await self.handle_tired()


### PR DESCRIPTION
## 问题

EGO 重写（a9d4eda6）后，`MoonlarkMain.run_before_sleep()`（睡前博客 Decider + Writter）只定义了方法，但全仓库没有任何调用点，导致睡前博客生成功能完全失效（死代码）。

另外原实现存在两个隐患：
1. Decider 返回的 `skip=True` 决策被忽略，会用空主题直接写博客
2. 方法无异常保护，若被后台任务调用，异常会导致 task 静默失败

## 修复

`sleep_controller.py`:
- `handle_tired()`（进入睡眠模式的唯一入口，覆盖自动困倦入睡和手动"睡觉"指令）在设置睡眠状态后，后台触发 `run_before_sleep()`，不阻塞入睡流程
- 新增 `_sleep_tasks` 集合持有任务引用，防止后台任务被 GC 中断

`moonlark_main.py`:
- `run_before_sleep()` 增加 try/except 异常保护
- Decider 返回 `None`（冷却中/失败）或 `skip=True` 时跳过博客撰写，避免空主题发布

BlogWriter 自带 2 小时冷却（`_in_cooldown`），一天多次入睡不会重复发博客。

## 验证

- `py_compile` 通过
- ruff check：无新增告警（现有告警均为改动前已存在）
- ruff format：已格式化

---

## 追加修复

### ci: COMMANDS.md 自动提交步骤无法 push（6659e802）
- checkout 配置了 persist-credentials: false，自动提交步骤未配置凭据，生成差异后 push 报 could not read Username，导致 CI 必红
- 添加 GITHUB_TOKEN 的 insteadOf 重写，自动更新可正常推回 PR 分支
- 验证：修复后 CI 自动更新了 poetry.lock（markdown 3.10.2→3.10.3、virtualenv 21.7.0→21.7.1）并成功推送，全检查通过