### PR TITLE
refactor(session): replace polling loop with event-driven message queue

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -72,6 +72,9 @@ class MessageProcessor:
         self.sticker_tools = StickerTools(self.session)
         self.functions = []
         self.loop_task = None
+        self._processing_task = None
+        self._message_processing = False
+        self._restored = False
         self.consecutive_message_count = 0
         # Token bucket 相关属性
         self.token_bucket = TokenBucket(6, -2)
@@ -92,7 +95,7 @@ class MessageProcessor:
         self.functions = await self.tool_manager.select_tools("group")
         await self.ai_agent.setup()
         if not self.loop_task:
-            self.loop_task = asyncio.create_task(self.loop())
+            self.loop_task = asyncio.create_task(self._startup())
 
     async def send_reaction(self, message_id: str, emoji_id: str, set: bool = True) -> Optional[str]:
         if isinstance(self.session.bot, OB11Bot) and self.session.is_napcat_bot():
@@ -217,14 +220,27 @@ class MessageProcessor:
             except Exception as e:
                 logger.exception(e)
 
-    async def loop(self) -> None:
+    async def _startup(self) -> None:
         await self.openai_messages.restore_from_db()
-        while self.enabled:
-            try:
-                await self.get_message()
-            except Exception as e:
-                logger.exception(e)
-                await asyncio.sleep(5)
+        self._restored = True
+        if self.enabled and self.session.message_queue:
+            self.notify_message_queued()
+
+    def notify_message_queued(self) -> None:
+        if not self._restored or not self.enabled or self._message_processing:
+            return
+        self._message_processing = True
+        self._processing_task = asyncio.create_task(self._process_until_idle())
+
+    async def _process_until_idle(self) -> None:
+        try:
+            while self.enabled and self.session.message_queue:
+                try:
+                    await self.get_message()
+                except Exception as e:
+                    logger.exception(e)
+        finally:
+            self._message_processing = False
 
     async def poke(self, target_name: str) -> Optional[str]:
         target_id = (await self.session.get_users()).get(target_name)

--- a/src/plugins/nonebot_plugin_chat/core/session/__init__.py
+++ b/src/plugins/nonebot_plugin_chat/core/session/__init__.py
@@ -103,6 +103,8 @@ async def reset_session(session_id: str) -> bool:
     session.processor.unanalyzed_message_count = 0
     if session.processor.loop_task:
         session.processor.loop_task.cancel()
+    if session.processor._processing_task:
+        session.processor._processing_task.cancel()
     if session.processor.openai_messages.fetcher_task:
         session.processor.openai_messages.fetcher_task.cancel()
 

--- a/src/plugins/nonebot_plugin_chat/core/session/base.py
+++ b/src/plugins/nonebot_plugin_chat/core/session/base.py
@@ -3,7 +3,7 @@ import math
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import Literal, Optional, TypeAlias
+from typing import Callable, Literal, Optional, TypeAlias
 
 from nonebot.adapters import Bot, Event
 from nonebot.adapters.onebot.v11.event import PokeNotifyEvent
@@ -26,6 +26,26 @@ MessageQueueItem: TypeAlias = (
     | tuple[Literal["event"], tuple[str, Literal["probability", "none", "all"]]]
 )
 
+
+class SessionQueue:
+    def __init__(self, on_item_queued: Callable[[], None]) -> None:
+        self._items: list[MessageQueueItem] = []
+        self._on_item_queued = on_item_queued
+
+    def append(self, item: MessageQueueItem) -> None:
+        self._items.append(item)
+        self._on_item_queued()
+
+    def pop(self, index: int = 0) -> MessageQueueItem:
+        return self._items.pop(index)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __bool__(self) -> bool:
+        return bool(self._items)
+
+
 from ..processor import MessageProcessor
 
 
@@ -40,7 +60,6 @@ class BaseSession(ABC):
         self.bot = bot
         self.lang_str = lang_str
         self.tool_calls_history = []
-        self.message_queue: list[MessageQueueItem] = []
         self.cached_messages: list[CachedMessage] = []
         self.message_cache_counter = 0
         self.ghot_coefficient = 1
@@ -53,6 +72,7 @@ class BaseSession(ABC):
         self.last_interest: Optional[float] = None  # 缓存的 interest 值
         self.last_interest_update_time: Optional[datetime] = None  # interest 最后更新时间
         self.processor = MessageProcessor(self)
+        self.message_queue = SessionQueue(self.processor.notify_message_queued)
 
     # interest 衰减配置
     INTEREST_HALF_LIFE = 420  # 半衰期（秒），默认 7 分钟


### PR DESCRIPTION
Introduced a `SessionQueue` class that notifies the processor when an item is enqueued, replacing the previous continuous polling loop (`loop()`). The processor now starts a background task upon restoration to process messages until the queue is empty, and cancels the task on session reset. This reduces idle CPU usage and ensures proper processing of queued messages.