### PR TITLE
fix(chat): exclude plan-updated messages from pending note context

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -965,7 +965,11 @@ class MessageProcessor:
 
         async with self._pending_note_lock:
             try:
-                chat_history = await self.session.get_cached_messages_string(length=50, include_self_message=True)
+                chat_history = await self.session.get_cached_messages_string(
+                    length=50,
+                    include_self_message=True,
+                    exclude_content_prefixes=("今日计划已更新",),
+                )
                 if not chat_history.strip():
                     return
 

--- a/src/plugins/nonebot_plugin_chat/core/session/base.py
+++ b/src/plugins/nonebot_plugin_chat/core/session/base.py
@@ -465,14 +465,22 @@ class BaseSession(ABC):
             if rows:
                 logger.info(f"Restored {len(rows)} timers for session {self.session_id}")
 
-    async def get_cached_messages_string(self, length: int = 50, include_self_message: bool = False) -> str:
+    async def get_cached_messages_string(
+        self,
+        length: int = 50,
+        include_self_message: bool = False,
+        exclude_content_prefixes: Optional[tuple[str, ...]] = None,
+    ) -> str:
         messages = []
         for message in self.cached_messages:
             # 根据 include_self_message 参数决定是否包含自己的消息
             if not include_self_message and message.get("self", False):
                 continue
+            content = message.get("content", "")
+            if exclude_content_prefixes and content.startswith(exclude_content_prefixes):
+                continue
             messages.append(
-                f"[{message['send_time'].strftime('%H:%M:%S')}][{message['nickname']}]: {message['content']}",
+                f"[{message['send_time'].strftime('%H:%M:%S')}][{message['nickname']}]: {content}",
             )
         # 只返回最近的 length 条消息
         return "\n".join(messages[-length:])


### PR DESCRIPTION
When generating pending notes, filter out cached messages that start with "今日计划已更新" to prevent automatic plan update notifications from being included in the context. This avoids confusion in the generated notes.