### PR TITLE
fix(chat): 移除 EGO 重写遗留的 update_reply_status 调用，修复 AttributeError

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -186,9 +186,6 @@ class MoonlarkMain:
     def on_message_cached(self, session_id: str) -> None:
         event_collector.on_message_cached(session_id)
 
-    async def on_private_message_replied(self, user_id: str) -> None:
-        await self.proactive_chat.update_reply_status(user_id)
-
     async def submit_sleep_request(self, session_id: str, future: Optional[asyncio.Future] = None) -> None:
         if future and not future.done():
             future.set_result("已提交睡觉申请，等待决策...")

--- a/src/plugins/nonebot_plugin_chat/core/matchers.py
+++ b/src/plugins/nonebot_plugin_chat/core/matchers.py
@@ -26,7 +26,6 @@ from sqlalchemy import select
 from ..config import config
 from ..models import PrivateChatSession
 from ..utils.group import enabled_group, enabled_private_chat
-from .ego import moonlark_main
 from .session import create_group_session, create_private_session, get_session_directly
 
 
@@ -89,9 +88,6 @@ async def _(
 ) -> None:
     # 记录私聊会话信息（用于主动消息时获取正确的 bot）
     await record_private_chat_session(user_id, session_key, bot.self_id)
-
-    # 检查是否是主动私聊的回复
-    await moonlark_main.on_private_message_replied(user_id)
 
     target = get_target(event)
     session = await create_private_session(session_key, target, bot)


### PR DESCRIPTION
## 问题

生产日志中，每条私聊消息都会触发异常：

```
File "matchers.py", line 94, in _
    await moonlark_main.on_private_message_replied(user_id)
File "moonlark_main.py", line 190, in on_private_message_replied
    await self.proactive_chat.update_reply_status(user_id)
AttributeError: 'ProactiveChatController' object has no attribute 'update_reply_status'
```

## 根因

EGO 模块重写（`a9d4eda6`）时，`ProactiveChatController` 被完全重写，
不再包含 `update_reply_status` 方法以及旧的回复跟踪机制
（`last_private_chats`、`_reply_events`、未回复计数等），
但 `MoonlarkMain.on_private_message_replied` 的调用被遗留在了 `matchers.py` 中，
导致每次收到私聊消息都抛出 AttributeError。

## 修复

- `matchers.py`：移除私聊处理器中对 `on_private_message_replied` 的调用（及对应注释）
- `moonlark_main.py`：移除已失效的 `on_private_message_replied` 方法
- `matchers.py`：清理因此不再使用的 `moonlark_main` 导入

## 验证

- `python -m py_compile` 通过
- `ruff check` 与 `origin/main` 相比无新增告警