### PR TITLE
feat(ego): 移除定时 LLM 睡眠决策，改为困倦度曲线决定唤醒

### DIFF
--- a/src/lang/en_us/chat.yaml
+++ b/src/lang/en_us/chat.yaml
@@ -726,12 +726,6 @@ tools_desc:
     nickname: "要查询人品值的群友的昵称。"
     user_not_found: "未找到昵称为 {} 的群友。"
     result: "{} 的人品值是 {}。"
-  request_action:
-    desc: |
-      向你的“EGO”申请执行一个内部行为（如吃饭、工作）。
-      **何时必须调用**：你被要求“去做某事”时调用，例如“去吃点东西”。不要用于机器人回复用户消息或获取外部知识。
-    do: '想要做的事的名字，例如："吃午饭"、"玩一会游戏"'
-    duration: '建议的持续时间（分钟），意识会话会参考这个值但不一定完全采纳。'
   change_sleep_status:
     desc: |
       处理犯困提示，决定是否准备睡觉。
@@ -741,10 +735,6 @@ tools_desc:
     deal_type: "决策类型：'ready' 表示准备睡觉，'delay' 表示延迟。"
     delay_minutes: "延迟的分钟数（仅当 deal_type 为 'delay' 时有效），最大 30 分钟。"
     reason: "延迟的原因（仅当 deal_type 为 'delay' 时可选）。"
-  request_sleep:
-    desc: |
-      向你的"EGO"申请睡觉。
-      **何时必须调用**：当你收到犯困提示时，调用此工具申请去睡觉。
   query_history_message:
     desc: |
       查询其他会话的历史消息和即时记忆。
@@ -1278,10 +1268,6 @@ sleep:
   drowsy_prompt: "[提示]: 你感到有些犯困了。"
 sleep:
   drowsy_prompt: "[提示]: 你感到有些犯困了。请使用 `change_sleep_status` 工具来决定是否准备睡觉。"
-request_action:
-  timeout: "动作申请超时，意识会话未在规定时间内做出决定。"
-request_sleep:
-  timeout: "睡觉申请超时，意识会话未在规定时间内做出决定。"
 sleep_decision:
   timeout: "睡眠决策超时，意识会话未在规定时间内做出决定。"
 recall_fetch_failed: "消息内容获取失败"

--- a/src/lang/zh_hans/chat.yaml
+++ b/src/lang/zh_hans/chat.yaml
@@ -683,17 +683,6 @@ moonlark_main:
     ## 今日已发布
     {}
   tools:
-    start_action:
-      description: |
-        执行一个自主活动（如学习、研究、查找资料等）。
-        **调用时机参考：**
-        - 想要学习新知识或研究某个主题
-        - 需要通过 Agent 工具（搜索、浏览网页等）完成的任务
-        - 活动必须具体，例如"学习 CSS Flexbox 布局"而不是"学习 CSS"
-        - 同一时间只能进行一个活动
-      activity: |
-        活动的具体描述，必须足够具体。
-        例如："学习 CSS Flexbox 布局"、"研究 2024 年最新的自动驾驶算法"、"查找 YoASOBI 新单曲的信息"
     sleep: 
       description: |
         睡觉，醒来后恢复全部精力。
@@ -802,15 +791,6 @@ moonlark_main:
     error: "睡眠决策处理出错：{}"
 sleep:
   drowsy_prompt: "[提示]: 你感到有些犯困了。请使用 `change_sleep_status` 工具来决定是否准备睡觉。"
-
-start_action:
-  timeout: "动作请求超时，Moonlark 未在规定时间内做出决定。"
-
-request_action:
-  timeout: "动作申请超时，意识会话未在规定时间内做出决定。"
-
-request_sleep:
-  timeout: "睡觉申请超时，意识会话未在规定时间内做出决定。"
 
 sleep_decision:
   timeout: "睡眠决策超时，意识会话未在规定时间内做出决定。"

--- a/src/lang/zh_tw/chat.yaml
+++ b/src/lang/zh_tw/chat.yaml
@@ -726,12 +726,6 @@ tools_desc:
     nickname: "要查询人品值的群友的昵称。"
     user_not_found: "未找到昵称为 {} 的群友。"
     result: "{} 的人品值是 {}。"
-  request_action:
-    desc: |
-      向你的“EGO”申请执行一个内部行为（如吃饭、工作）。
-      **何时必须调用**：你被要求“去做某事”时调用，例如“去吃点东西”。不要用于机器人回复用户消息或获取外部知识。
-    do: '想要做的事的名字，例如："吃午饭"、"玩一会游戏"'
-    duration: '建议的持续时间（分钟），意识会话会参考这个值但不一定完全采纳。'
   change_sleep_status:
     desc: |
       处理犯困提示，决定是否准备睡觉。
@@ -741,10 +735,6 @@ tools_desc:
     deal_type: "决策类型：'ready' 表示准备睡觉，'delay' 表示延迟。"
     delay_minutes: "延迟的分钟数（仅当 deal_type 为 'delay' 时有效），最大 30 分钟。"
     reason: "延迟的原因（仅当 deal_type 为 'delay' 时可选）。"
-  request_sleep:
-    desc: |
-      向你的"EGO"申请睡觉。
-      **何时必须调用**：当你收到犯困提示时，调用此工具申请去睡觉。
   query_history_message:
     desc: |
       查询其他会话的历史消息和即时记忆。
@@ -1278,10 +1268,6 @@ sleep:
   drowsy_prompt: "[提示]: 你感到有些犯困了。"
 sleep:
   drowsy_prompt: "[提示]: 你感到有些犯困了。请使用 `change_sleep_status` 工具来决定是否准备睡觉。"
-request_action:
-  timeout: "动作申请超时，意识会话未在规定时间内做出决定。"
-request_sleep:
-  timeout: "睡觉申请超时，意识会话未在规定时间内做出决定。"
 sleep_decision:
   timeout: "睡眠决策超时，意识会话未在规定时间内做出决定。"
 recall_fetch_failed: "消息内容获取失败"

--- a/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/moonlark_main.py
@@ -189,10 +189,6 @@ class MoonlarkMain:
     async def on_private_message_replied(self, user_id: str) -> None:
         await self.proactive_chat.update_reply_status(user_id)
 
-    async def submit_sleep_request(self, session_id: str, future: Optional[asyncio.Future] = None) -> None:
-        if future and not future.done():
-            future.set_result("已提交睡觉申请，等待决策...")
-
     async def submit_sleep_decision(
         self,
         session_id: str,
@@ -205,32 +201,6 @@ class MoonlarkMain:
             result = await self.sleep_controller.submit_sleep_decision(deal_type, delay_minutes, reason)
             if future and not future.done():
                 future.set_result(result)
-        except Exception as e:
-            logger.exception(e)
-            if future and not future.done():
-                future.set_result(f"决策失败: {e}")
-
-    async def submit_action_request(
-        self,
-        session_id: str,
-        type: str,
-        info: str,
-        reason: str,
-        future: Optional[asyncio.Future] = None,
-    ) -> None:
-        if future and not future.done():
-            future.set_result(f"已收到动作请求「{type}: {info}」，正在处理")
-
-    async def submit_action_decision(
-        self,
-        session_id: str,
-        do: str,
-        duration: Optional[int] = None,
-        future: Optional[asyncio.Future] = None,
-    ) -> None:
-        try:
-            if future and not future.done():
-                future.set_result(f"已批准动作: {do}")
         except Exception as e:
             logger.exception(e)
             if future and not future.done():

--- a/src/plugins/nonebot_plugin_chat/core/ego/sleep_controller.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/sleep_controller.py
@@ -37,6 +37,7 @@ class SleepController:
         self.last_reply_time: datetime = datetime.now()
         self.consecutive_replies: int = 0
         self._sleep_tasks: set[asyncio.Task] = set()
+        self._pending_sleep_tasks: set[asyncio.Task] = set()
 
         scheduler.scheduled_job("interval", minutes=10, id="sleep_controller_process_timer")(self.process_timer)
 
@@ -148,9 +149,29 @@ class SleepController:
             await self.handle_tired()
             return "已进入睡眠模式。"
         delay = min(delay_minutes, 30)
+        if delay <= 0:
+            await self.handle_tired()
+            return "已进入睡眠模式。"
+        # 真正的延迟入睡：倒计时结束后自动进入睡眠
+        task = asyncio.create_task(self._delayed_sleep(delay))
+        self._pending_sleep_tasks.add(task)
+        task.add_done_callback(self._pending_sleep_tasks.discard)
         return f"已延迟 {delay} 分钟睡觉。" + (f"原因: {reason}" if reason else "")
 
+    async def _delayed_sleep(self, delay_minutes: int) -> None:
+        """延迟入睡：倒计时结束后进入睡眠（若期间已入睡则跳过）"""
+        await asyncio.sleep(delay_minutes * 60)
+        if self.sleep_state:
+            logger.info("[SleepController] 延迟入睡触发时已在睡眠中，跳过")
+            return
+        logger.info(f"[SleepController] 延迟 {delay_minutes} 分钟结束，进入睡眠")
+        await self.handle_tired()
+
     async def wake_up(self, reason: str = "") -> None:
+        # 唤醒时取消未触发的延迟入睡任务
+        for task in list(self._pending_sleep_tasks):
+            task.cancel()
+        self._pending_sleep_tasks.clear()
         self.sleep_state = False
         self.sleep_begin_time = None
         self.tiredness = 0.0

--- a/src/plugins/nonebot_plugin_chat/core/ego/sleep_controller.py
+++ b/src/plugins/nonebot_plugin_chat/core/ego/sleep_controller.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Optional
 
 from nonebot import logger
 from nonebot_plugin_apscheduler import scheduler
-from nonebot_plugin_openai.utils.chat import fetch_json, fetch_message
+from nonebot_plugin_openai.utils.chat import fetch_message
 from nonebot_plugin_openai.utils.message import get_messages
 
 if TYPE_CHECKING:
@@ -36,8 +36,6 @@ class SleepController:
         self.last_message_time: datetime = datetime.now()
         self.last_reply_time: datetime = datetime.now()
         self.consecutive_replies: int = 0
-        self.sleep_think_count: int = 0
-        self.context_cleared: bool = False
         self._sleep_tasks: set[asyncio.Task] = set()
 
         scheduler.scheduled_job("interval", minutes=10, id="sleep_controller_process_timer")(self.process_timer)
@@ -71,57 +69,6 @@ class SleepController:
             f"F={f:.3f} ε={epsilon:.4f} → tiredness={self.tiredness:.4f}",
         )
         return self.tiredness
-
-    async def request_think(self) -> None:
-        from ...models import SleepThinkResponse
-
-        self.sleep_think_count += 1
-        now = datetime.now()
-        sleep_duration = 0
-        if self.sleep_begin_time:
-            sleep_duration = (now - self.sleep_begin_time).total_seconds() / 60
-
-        try:
-            messages = await get_messages(
-                "sleep_think",
-                current_time=now.strftime("%Y-%m-%d %H:%M:%S"),
-                sleep_duration=str(int(sleep_duration)),
-                tiredness=str(round(self.tiredness, 2)),
-                wake_threshold=str(WAKE_THRESHOLD),
-            )
-
-            result = await fetch_json(
-                messages,
-                SleepThinkResponse,
-                identify="SleepController - Sleep Think",
-                reasoning_effort="low",
-            )
-
-            if result.wake_up:
-                await self.wake_up(result.reason or "睡眠决策")
-            else:
-                await self._maybe_clear_context(sleep_duration)
-
-        except Exception as e:
-            logger.exception(f"[SleepController] 睡眠决策失败: {e}")
-
-    async def _maybe_clear_context(self, sleep_duration: float) -> None:
-        if self.context_cleared:
-            return
-        if sleep_duration < 5:
-            return
-        logger.info("[SleepController] 入睡后首次继续睡决策，重置所有会话消息队列上下文")
-        await self._reset_all_message_queues()
-        self.context_cleared = True
-
-    async def _reset_all_message_queues(self) -> None:
-        from ..session import groups
-
-        for session_id, session in list(groups.items()):
-            try:
-                await session.processor.openai_messages._reset_and_clear_db(session_id)
-            except Exception as e:
-                logger.exception(f"[SleepController] 重置会话 {session_id} 消息队列失败: {e}")
 
     async def handle_mention(self, chat_context: list, session_name: str = "", nickname: str = "") -> bool:
         context_text = "\n".join(chat_context[-5:]) if chat_context else ""
@@ -182,7 +129,13 @@ class SleepController:
 
     async def process_timer(self) -> None:
         if self.sleep_state:
-            await self.request_think()
+            # 睡眠中：由困倦度曲线决定唤醒（不再定时询问 LLM）
+            now = datetime.now()
+            hour = now.hour + now.minute / 60.0
+            curve = self.circadian(hour)
+            if curve < WAKE_THRESHOLD:
+                logger.info(f"[SleepController] 困倦度曲线 {curve:.3f} < {WAKE_THRESHOLD}，自然唤醒")
+                await self.wake_up("困倦度曲线降至唤醒阈值以下")
             return
 
         tiredness = self.calculate_sleepiness_index()
@@ -202,8 +155,6 @@ class SleepController:
         self.sleep_begin_time = None
         self.tiredness = 0.0
         self.consecutive_replies = 0
-        self.sleep_think_count = 0
-        self.context_cleared = False
         self.moonlark_main.state["sleep_mode"] = False
         if reason:
             logger.info(f"[SleepController] 已唤醒, 原因: {reason}")

--- a/src/plugins/nonebot_plugin_chat/core/session/base.py
+++ b/src/plugins/nonebot_plugin_chat/core/session/base.py
@@ -390,36 +390,6 @@ class BaseSession(ABC):
         except asyncio.TimeoutError:
             return await self.text("sleep_decision.timeout")
 
-    async def start_action(self, type: str, info: str, reason: str) -> str:
-        """
-        向 Moonlark 申请执行一个动作
-
-        Args:
-            type: 动作类型，如 start_blog、sleep
-            info: 动作的补充信息
-            reason: 申请此动作的原因
-
-        Returns:
-            Moonlark 的决定结果
-        """
-        from ..ego import moonlark_main
-
-        result_future = asyncio.get_event_loop().create_future()
-
-        await moonlark_main.submit_action_request(
-            session_id=self.session_id,
-            type=type,
-            info=info,
-            reason=reason,
-            future=result_future,
-        )
-
-        try:
-            result = await asyncio.wait_for(result_future, timeout=120)
-            return result
-        except asyncio.TimeoutError:
-            return await self.text("start_action.timeout")
-
     async def process_timer(self) -> None:
         dt = datetime.now()
         if self.mute_until and dt > self.mute_until:

--- a/src/plugins/nonebot_plugin_chat/models.py
+++ b/src/plugins/nonebot_plugin_chat/models.py
@@ -221,13 +221,6 @@ class EgoDecisionResponse(BaseModel):
     private_chat: Optional[PrivateChatDecision] = None
 
 
-class SleepThinkResponse(BaseModel):
-    """SleepController request_think 的 LLM 返回格式"""
-
-    wake_up: bool = False
-    reason: str = ""
-
-
 class AgentEvent(Model):
     """智能体事件记录表，记录思考、动作、动作结果及外部事件"""
 

--- a/src/plugins/nonebot_plugin_chat/startup.py
+++ b/src/plugins/nonebot_plugin_chat/startup.py
@@ -75,10 +75,9 @@ async def _init_moonlark_main():
         """每 5 分钟检查是否是刚醒来，触发计划生成"""
         if moonlark_main.state["sleep_mode"]:
             return
-        # 使用 sleep_controller 的 sleep_think_count 来判断是否刚醒来：
-        # 如果刚醒来（sleep_think_count 刚被重置为 0）且 t=0，触发计划
+        # 清醒且困倦度低于唤醒阈值时触发计划生成（每天首次，0:00 重置标志）
         sc = moonlark_main.sleep_controller
-        if sc.sleep_think_count == 0 and sc.tiredness < 0.35 and hasattr(sc, "_morning_plan_scheduled") is False:
+        if sc.tiredness < 0.35 and hasattr(sc, "_morning_plan_scheduled") is False:
             sc._morning_plan_scheduled = True
             import asyncio
 

--- a/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
@@ -175,12 +175,6 @@ class ToolManager:
             deal_type=deal_type, delay_minutes=delay_minutes, reason=reason
         )
 
-    async def start_action(self, type: str, info: str, reason: str) -> str:
-        """向 Moonlark 申请执行一个动作"""
-        if self.processor is None:
-            raise RuntimeError("processor is None")
-        return await self.processor.session.start_action(type=type, info=info, reason=reason)
-
     async def apply_unlimited_tokens(self, reason: str, message_count: int) -> str:
         """申请额外的消息 Token，提交理由和最近聊天记录供审核。审核通过后在指定次数内不消耗 Token。
 
@@ -273,9 +267,6 @@ class ToolManager:
 
             # query_gift
             tools.append(self.query_gift)
-
-            # start_action（原 request_action + request_sleep）
-            tools.append(self.start_action)
 
             # apply_unlimited_tokens
             tools.append(self.apply_unlimited_tokens)


### PR DESCRIPTION
## 需求

删除「定时运行的睡眠决策」，只保留两种唤醒途径：
1. **mention 决定的唤醒**（被 @ 时由 LLM 判断是否唤醒）
2. **困倦度曲线决定的唤醒**（生物钟曲线降到阈值以下自然醒）

## 改动

### 删除：定时 LLM 睡眠决策
- `SleepController.request_think()`：睡眠状态下每 10 分钟定时询问 LLM 是否唤醒（`SleepThinkResponse`）
- 连带死代码：`sleep_think_count` / `context_cleared` 状态、`_maybe_clear_context` / `_reset_all_message_queues`、`SleepThinkResponse` 模型

### 新增：困倦度曲线唤醒
- `process_timer` 睡眠分支不再调 LLM，改为检查生物钟曲线：`circadian(hour) < WAKE_THRESHOLD(0.35)` 时自动唤醒
- 效果：晚上入睡后，早上 8 点左右困倦度曲线自然跌破阈值 → 自动醒来（与模块 docstring 设计的「无疲劳时 08:00 达到 WAKE_THRESHOLD」一致）
- 入睡逻辑不变：清醒时困倦度 ≥ SLEEP_THRESHOLD(0.75) 自动入睡（曲线决定入睡）

### 保留
- mention 唤醒：`handle_mention`（睡眠中被 @ 时 LLM 判断 `wake_up`）
- 命令触发入睡：`submit_sleep_decision`
- 重要事件强制唤醒（processor.py 中 `is_event` 分支，事件驱动，非定时决策）

### 适配
- `startup.py` 醒来检查不再依赖已删除的 `sleep_think_count`（改为清醒 + 困倦度 < 0.35 判断）

## 验证
- 全套测试 74 passed（本分支基于 main，不含 #1333 的测试）
- ruff 与 origin/main 对比零新增告警
- black + flake8（pre-commit）通过

> 注：`feat/chat/proactive-cooldown-reply-limit`（#1333）与本 PR 互不影响，可独立合并。