### PR TITLE
fix(chat): 空 tool_calls 清理 + 私聊白名单 QQ 用户可使用 chat 指令

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -52,14 +52,14 @@ docs = ["sphinx (==7.2.6)", "sphinx-mdinclude (==0.5.3)"]
 
 [[package]]
 name = "alembic"
-version = "1.19.0"
+version = "1.19.1"
 description = "A database migration tool for SQLAlchemy."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "alembic-1.19.0-py3-none-any.whl", hash = "sha256:cf839d3849116aab3cc047e09c6968b9bd6b2fde61b6bb7c1e97352fe5503580"},
-    {file = "alembic-1.19.0.tar.gz", hash = "sha256:6487c612fc719dcfa22b17d2dd5b2b458929641e6aa2f0b65b135727f5e6d501"},
+    {file = "alembic-1.19.1-py3-none-any.whl", hash = "sha256:b39018cb3d9413a19cbd54cf3c02ad33998641f0538eb77413a488a21c3e14be"},
+    {file = "alembic-1.19.1.tar.gz", hash = "sha256:e0fca0518118c78acc493e31bcb5402f190057aaf6df8b5b95ce94c4789cf648"},
 ]
 
 [package.dependencies]
@@ -5677,14 +5677,14 @@ unleash = ["UnleashClient (>=6.0.1)"]
 
 [[package]]
 name = "setuptools"
-version = "83.0.0"
+version = "84.0.0"
 description = "Most extensible Python build backend with support for C/C++ extension modules"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3"},
-    {file = "setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef"},
+    {file = "setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670"},
+    {file = "setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73"},
 ]
 
 [package.extras]
@@ -5940,14 +5940,14 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "starlette"
-version = "1.5.0"
+version = "1.6.0"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "starlette-1.5.0-py3-none-any.whl", hash = "sha256:9ca76b47375e56f279d7c66651e801ef11167e58557c429be7ec55702d81d4bb"},
-    {file = "starlette-1.5.0.tar.gz", hash = "sha256:7d5f63a7e4981a9587fc2a0fbc44cfb6cc4c9181d8c26d7e948871ed5da8c3df"},
+    {file = "starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c"},
+    {file = "starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b"},
 ]
 
 [package.dependencies]
@@ -6429,14 +6429,14 @@ test = ["aiohttp (>=3.10.5)", "flake8 (>=6.1,<7.0)", "mypy (>=0.800)", "psutil",
 
 [[package]]
 name = "virtualenv"
-version = "21.7.2"
+version = "21.7.3"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.7.2-py3-none-any.whl", hash = "sha256:7c7f4638881064cc57edd2dd55b307cf4da35bb3f6df6f036b5e8b658f6b5bf5"},
-    {file = "virtualenv-21.7.2.tar.gz", hash = "sha256:8bf688bd159b32c3bd6966555c5a2605a07724b93671c32cfe3e45ac28058987"},
+    {file = "virtualenv-21.7.3-py3-none-any.whl", hash = "sha256:26dfda3c34f29bf1a3ca167426a67658d59979b9954e705aef60a5f724ce1773"},
+    {file = "virtualenv-21.7.3.tar.gz", hash = "sha256:5e9e287f5c808070eea3b40403d3368248e64b24f1b60bd9a36e85ac841d2c3e"},
 ]
 
 [package.dependencies]

--- a/src/plugins/nonebot_plugin_chat/matcher/chat.py
+++ b/src/plugins/nonebot_plugin_chat/matcher/chat.py
@@ -18,7 +18,7 @@
 import json
 
 from nonebot import on_command
-from nonebot.adapters import Bot, Message
+from nonebot.adapters import Bot, Event, Message
 from nonebot.matcher import Matcher
 from nonebot.params import CommandArg
 from nonebot_plugin_larkutils import get_group_id, get_user_id
@@ -39,12 +39,14 @@ class CommandHandler:
         bot: Bot,
         session: async_scoped_session,
         message: Message,
+        event: Event,
         group_id: str,
         user_id: str,
     ):
         self.matcher = mathcer
         self.bot = bot
         self.session = session
+        self.event = event
         self.group_id = group_id
         self.user_id = user_id
         self.argv = message.extract_plain_text().split(" ")
@@ -54,7 +56,11 @@ class CommandHandler:
         from nonebot_plugin_openai import is_ai_enabled_for_group
 
         if not await is_ai_enabled_for_group(self.bot, self.group_id):
-            await lang.finish("command.not_available", self.user_id)
+            # 私聊白名单用户（如 QQ 适配器 C2C）：允许使用 chat 指令（reset 等）
+            from ..utils.group import enabled_private_chat
+
+            if not await enabled_private_chat(self.event, self.user_id):
+                await lang.finish("command.not_available", self.user_id)
         self.group_config = (await self.session.get(ChatGroup, {"group_id": self.group_id})) or ChatGroup(
             group_id=self.group_id,
             enabled=False,
@@ -356,9 +362,10 @@ async def _(
     bot: Bot,
     session: async_scoped_session,
     message: Message = CommandArg(),
+    event: Event = Event(),
     group_id: str = get_group_id(),
     user_id: str = get_user_id(),
 ) -> None:
-    handler = CommandHandler(matcher, bot, session, message, group_id, user_id)
+    handler = CommandHandler(matcher, bot, session, message, event, group_id, user_id)
     await handler.setup()
     await handler.handle()

--- a/src/plugins/nonebot_plugin_chat/matcher/chat.py
+++ b/src/plugins/nonebot_plugin_chat/matcher/chat.py
@@ -361,8 +361,8 @@ async def _(
     matcher: Matcher,
     bot: Bot,
     session: async_scoped_session,
+    event: Event,
     message: Message = CommandArg(),
-    event: Event = Event(),
     group_id: str = get_group_id(),
     user_id: str = get_user_id(),
 ) -> None:

--- a/src/plugins/nonebot_plugin_openai/utils/chat.py
+++ b/src/plugins/nonebot_plugin_openai/utils/chat.py
@@ -103,7 +103,17 @@ class LLMRequestSession(Generic[T2]):
             self._in_request = False
             await report_openai_history(self.messages, self.identify, self.model)
 
+    def _sanitize_messages(self) -> None:
+        """清理消息中的空 tool_calls 数组（部分 Provider 会拒绝 tool_calls=[]）"""
+        for msg in self.messages:
+            if isinstance(msg, dict):
+                if msg.get("tool_calls") == []:
+                    msg.pop("tool_calls", None)
+            elif getattr(msg, "tool_calls", None) == []:
+                msg.tool_calls = None
+
     async def create_completion(self) -> ChatCompletion:
+        self._sanitize_messages()
         tool_choice = self.tool_choice if self.func_list else "none"
         if not self.response_format:
             completion = await client.chat.completions.create(
@@ -155,6 +165,8 @@ class LLMRequestSession(Generic[T2]):
             logger.warning(f"请求取得了空回复")
             return
         logger.debug(f"{response=}")
+        if response.message.tool_calls == []:
+            response.message.tool_calls = None
         self.messages.append(response.message)
         self._content_yielded = False
         if response.message.content:


### PR DESCRIPTION
## 变更内容

### 1. 修复空 tool_calls 数组导致 Provider 400 报错

**报错**: `Invalid 'messages[35].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.`

**根因**: 模型返回 `tool_calls: []` 时，`LLMRequestSession.request()` 会把该 assistant 消息原样追加进 `self.messages`，下次请求时把空数组发给 Provider 被拒。Chat 插件 `message.py` 中虽有清理逻辑，但 `MessageQueue.get_messages()` 实际未被调用（死代码），真正发请求的 `create_completion()` 没有清理。

**修复** (`nonebot_plugin_openai/utils/chat.py`):
- 新增 `_sanitize_messages()`，在每次 `create_completion()` 发送前清理 assistant 消息中的空 `tool_calls`（dict 形式 pop，pydantic 形式置 None），覆盖模型原始响应与从数据库恢复的消息
- `request()` 追加响应前，若 `tool_calls == []` 先规范化为 `None`，避免空数组进入历史并被持久化

### 2. 私聊白名单的 QQ 适配器用户可使用 chat 指令

**问题**: `chat reset` 等指令的 `setup()` 用 `is_ai_enabled_for_group` 判断，QQ 官方适配器默认返回 False（除非在 AIWhitelist 表），导致只在 PrivateChatConfig 私聊白名单中的 QQ C2C 用户被拦在 `command.not_available`。

**修复** (`nonebot_plugin_chat/matcher/chat.py`):
- 注入 `Event` 到命令处理器
- `setup()` 中 AI 未启用时，回退检查 `enabled_private_chat(event, user_id)`：私聊白名单用户放行
- 群聊行为不变（`enabled_private_chat` 对群消息返回 False）

## 检查项

- [x] `python -m py_compile` 通过
- [x] ruff check 无新增告警（现有告警均为改动前已存在）
- [x] ruff format 无新增格式问题