### PR TITLE
fix(orm): add migration to remove chat indexes

### DIFF
--- a/migrations/versions/ffdcbc994500_remove_chat_indexes.py
+++ b/migrations/versions/ffdcbc994500_remove_chat_indexes.py
@@ -1,0 +1,41 @@
+"""Remove chat indexes
+
+迁移 ID: ffdcbc994500
+父迁移: ffdcbc994499
+创建时间: 2026-08-21 07:15:00.000000
+
+移除 nonebot_plugin_chat 中不再需要的索引
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "ffdcbc994500"
+down_revision: str | Sequence[str] | None = "ffdcbc994499"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade(name: str = "") -> None:
+    if name:
+        return
+    op.drop_index("ix_agent_event_created_at", table_name="nonebot_plugin_chat_diaryentry")
+    op.drop_index("ix_note_created_time", table_name="nonebot_plugin_chat_note")
+
+
+def downgrade(name: str = "") -> None:
+    if name:
+        return
+    op.create_index(
+        "ix_agent_event_created_at",
+        "nonebot_plugin_chat_diaryentry",
+        ["created_at"],
+    )
+    op.create_index(
+        "ix_note_created_time",
+        "nonebot_plugin_chat_note",
+        ["created_time"],
+    )


### PR DESCRIPTION
## 修复 Moonlark 启动错误

修复 `AutogenerateDiffsDetected` 错误。`nonebot_plugin_chat` 的代码删除了两个索引但未生成对应的 Alembic 迁移文件，导致 ORM 启动检测到代码和数据库不一致后拒绝启动。

### 变更

添加迁移 `ffdcbc994500`，移除以下索引：
- `nonebot_plugin_chat_diaryentry.ix_agent_event_created_at`
- `nonebot_plugin_chat_note.ix_note_created_time`

### 复现

更新代码后启动 Moonlark 会报错：
```
nonebot_plugin_orm.exception.AutogenerateDiffsDetected: 检测到新的升级操作 :
[(remove_index, Index(ix_agent_event_created_at, ...)),
 (remove_index, Index(ix_note_created_time, ...))]
```