### PR TITLE
fix: make interaction_mode migration idempotent

### DIFF
--- a/migrations/versions/a8f3c1d2e4b5_add_interaction_mode_to_chat_group.py
+++ b/migrations/versions/a8f3c1d2e4b5_add_interaction_mode_to_chat_group.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 revision: str = "a8f3c1d2e4b5"
 down_revision: str | Sequence[str] | None = "ffdcbc994499"
@@ -22,10 +23,14 @@ depends_on: str | Sequence[str] | None = None
 def upgrade(name: str = "") -> None:
     if name:
         return
-    with op.batch_alter_table("nonebot_plugin_chat_chatgroup", schema=None) as batch_op:
-        batch_op.add_column(
-            sa.Column("interaction_mode", sa.String(length=16), nullable=False, server_default="standard")
-        )
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    columns = [c["name"] for c in inspector.get_columns("nonebot_plugin_chat_chatgroup")]
+    if "interaction_mode" not in columns:
+        with op.batch_alter_table("nonebot_plugin_chat_chatgroup", schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column("interaction_mode", sa.String(length=16), nullable=False, server_default="standard")
+            )
 
 
 def downgrade(name: str = "") -> None:


### PR DESCRIPTION
## 修复内容

迁移脚本 `a8f3c1d2e4b5` 添加 `interaction_mode` 列时未检查列是否已存在，导致重复添加时报错：

```
sqlalchemy.exc.OperationalError: (pymysql.err.OperationalError) (1060, "Duplicate column name 'interaction_mode'")
```

## 修复方式

使用 `sqlalchemy.inspect` 检查列是否存在，仅在不存在时才执行 `ADD COLUMN`。与项目中其他幂等迁移（如 `7f8a9b0c1d2e_add_message_hash`）保持一致。

## 影响范围

仅修改 `migrations/versions/a8f3c1d2e4b5_add_interaction_mode_to_chat_group.py`，无其他代码变更。