### PR TITLE
fix: make downed_at migration idempotent

### DIFF
--- a/migrations/versions/a9e4b2c8f1d6_add_user_down_state_and_death_record.py
+++ b/migrations/versions/a9e4b2c8f1d6_add_user_down_state_and_death_record.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 revision: str = "a9e4b2c8f1d6"
 down_revision: str | Sequence[str] | None = "a8f3c1d2e4b5"
@@ -25,15 +26,23 @@ DATA_TABLE = "nonebot_plugin_larkuser_userdata"
 def upgrade(name: str = "") -> None:
     if name:
         return
-    with op.batch_alter_table(DATA_TABLE, schema=None) as batch_op:
-        batch_op.add_column(sa.Column("downed_at", sa.DateTime(), nullable=True))
-    op.create_table(
-        TABLE_NAME,
-        sa.Column("user_id", sa.String(length=128), nullable=False),
-        sa.Column("death_count", sa.Integer(), nullable=False),
-        sa.PrimaryKeyConstraint("user_id", name=op.f("pk_nonebot_plugin_larkuser_userdeathrecord")),
-        info={"bind_key": "nonebot_plugin_larkuser"},
-    )
+    conn = op.get_bind()
+    inspector = inspect(conn)
+
+    columns = [c["name"] for c in inspector.get_columns(DATA_TABLE)]
+    if "downed_at" not in columns:
+        with op.batch_alter_table(DATA_TABLE, schema=None) as batch_op:
+            batch_op.add_column(sa.Column("downed_at", sa.DateTime(), nullable=True))
+
+    existing_tables = inspector.get_table_names()
+    if TABLE_NAME not in existing_tables:
+        op.create_table(
+            TABLE_NAME,
+            sa.Column("user_id", sa.String(length=128), nullable=False),
+            sa.Column("death_count", sa.Integer(), nullable=False),
+            sa.PrimaryKeyConstraint("user_id", name=op.f("pk_nonebot_plugin_larkuser_userdeathrecord")),
+            info={"bind_key": "nonebot_plugin_larkuser"},
+        )
 
 
 def downgrade(name: str = "") -> None:


### PR DESCRIPTION
## 修复内容

与 PR #1367 同类问题，迁移脚本 `a9e4b2c8f1d6` 中添加 `downed_at` 列和创建 `UserDeathRecord` 表时未检查是否已存在，导致重复执行时报错：

```
sqlalchemy.exc.OperationalError: (pymysql.err.OperationalError) (1060, "Duplicate column name 'downed_at'")
```

## 修复方式

使用 `sqlalchemy.inspect` 检查列/表是否存在，仅在不存在时才执行 `ADD COLUMN` / `CREATE TABLE`。

## 影响范围

仅修改 `migrations/versions/a9e4b2c8f1d6_add_user_down_state_and_death_record.py`。