### PR TITLE
fix(liang): 修复帮助分类、倒计时空格和梁文峰emoji

### DIFF
--- a/src/lang/zh_hans/liang.yaml
+++ b/src/lang/zh_hans/liang.yaml
@@ -2,7 +2,7 @@ help:
   description: 查看当前是梁文峰还是梁文谷
   details: 查看当前是梁文峰还是梁文谷，以及距离切换还有多久
   usage: liang (查看当前状态)
-result: "🔵 现在是{}\n距离切换到{}还有{}"
+result: "{} 现在是{}\n距离切换到{}还有 {}"
 time_wenfeng: 梁文峰（{}:00~{}:00, {}:00~{}:00）
 time_wengu: 梁文谷（其余时间）
 suffix_minutes: "{} 分钟"

--- a/src/plugins/nonebot_plugin_liang/__main__.py
+++ b/src/plugins/nonebot_plugin_liang/__main__.py
@@ -70,5 +70,6 @@ async def _(user_id: str = get_user_id()) -> None:
     current_name = "梁文峰" if current_wenfeng else "梁文谷"
     next_name = "梁文峰" if next_is_wenfeng else "梁文谷"
     countdown = format_countdown(delta)
+    emoji = "🔴" if current_wenfeng else "🔵"
 
-    await lang.finish("result", user_id, current_name, next_name, countdown)
+    await lang.finish("result", user_id, emoji, current_name, next_name, countdown)

--- a/src/plugins/nonebot_plugin_liang/help.yaml
+++ b/src/plugins/nonebot_plugin_liang/help.yaml
@@ -5,4 +5,4 @@ commands:
     details: help.details
     usages:
       - help.usage
-    category: fun
+    category: game


### PR DESCRIPTION
## 修复内容

1. **修复 help.yaml 分类**: 将不存在的 `fun` 分类改为 `game`
2. **修复倒计时空格**: lang 模板中 `距离切换到{}还有{}` 改为 `距离切换到{}还有 {}`，修复 "还有7分钟" 缺少空格的问题
3. **梁文峰 emoji 动态化**: 根据当前是否为梁文峰时段，显示 🔴（梁文峰）或 🔵（梁文谷）

## 修改文件

- `src/plugins/nonebot_plugin_liang/help.yaml` - category: fun → game
- `src/lang/zh_hans/liang.yaml` - 模板添加空格和 emoji 占位符
- `src/plugins/nonebot_plugin_liang/__main__.py` - 添加 emoji 逻辑