### PR TITLE
fix(orm): 合并拉取后并存的 6 个迁移头

### DIFF
--- a/migrations/versions/0841fcf990e5_merge_migration_heads.py
+++ b/migrations/versions/0841fcf990e5_merge_migration_heads.py
@@ -1,0 +1,39 @@
+"""merge migration heads
+
+合并拉取上游后并存的 6 个迁移头，恢复单一迁移历史：
+- 5b174323b47f add unreplied count to private chat session
+- 9e8893de3642 drop AIWhitelist table
+- a3c1e5f7b9d2 remove dropping_enabled from chat_group
+- b5c6d7e8f9a1 add egg selection table
+- c8d9e0f1a2b3 add auto sign fields to sign_data
+- e1f2a3b4c5d6 Add command alias table
+
+迁移 ID: 0841fcf990e5
+父迁移: 5b174323b47f, 9e8893de3642, a3c1e5f7b9d2, b5c6d7e8f9a1, c8d9e0f1a2b3, e1f2a3b4c5d6
+创建时间: 2026-08-22 11:00:43.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+revision: str = "0841fcf990e5"
+down_revision: str | Sequence[str] | None = (
+    "5b174323b47f",
+    "9e8893de3642",
+    "a3c1e5f7b9d2",
+    "b5c6d7e8f9a1",
+    "c8d9e0f1a2b3",
+    "e1f2a3b4c5d6",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade(name: str = "") -> None:
+    pass
+
+
+def downgrade(name: str = "") -> None:
+    pass

--- a/src/plugins/nonebot_plugin_chat_monitor/__main__.py
+++ b/src/plugins/nonebot_plugin_chat_monitor/__main__.py
@@ -20,11 +20,9 @@ import hashlib
 import json
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
-from nonebot import get_app, get_driver
+from nonebot import get_app
 from nonebot.log import logger
 from nonebot_plugin_apscheduler import scheduler
-from nonebot_plugin_orm import get_session
-from sqlalchemy import text
 
 from .auth import verify_admin
 from .broadcast import _start_ws_broadcast  # noqa: F401 -- 注册启动时广播
@@ -40,40 +38,6 @@ app: FastAPI = get_app()  # type: ignore[assignment]
 app.include_router(sessions_router)
 app.include_router(notes_router)
 app.include_router(ego_router)
-
-
-# ========================================================================
-# 启动时创建数据库索引
-# ========================================================================
-
-
-@get_driver().on_startup
-async def _ensure_indexes():
-    """创建 Note 和 AgentEvent 表的必要索引（如果不存在）。"""
-    indexes = [
-        ("nonebot_plugin_chat_note", "ix_note_created_time", "created_time"),
-        ("nonebot_plugin_chat_diaryentry", "ix_agent_event_created_at", "created_at"),
-    ]
-    async with get_session() as db_session:
-        for table, index_name, column in indexes:
-            try:
-                # 通过 information_schema 检查索引是否存在（兼容 MySQL 8.0+）
-                result = await db_session.execute(
-                    text(
-                        "SELECT COUNT(*) FROM information_schema.statistics "
-                        "WHERE table_schema = DATABASE() "
-                        f"AND table_name = '{table}' "
-                        f"AND index_name = '{index_name}'"
-                    )
-                )
-                if result.scalar() == 0:
-                    await db_session.execute(text(f"CREATE INDEX {index_name} ON {table} ({column})"))
-                    logger.info(f"[ChatMonitor] 创建索引 {index_name}")
-            except Exception as exc:
-                logger.warning(f"[ChatMonitor] 处理索引 {index_name} 失败（可忽略）: {exc}")
-        await db_session.commit()
-    logger.info("[ChatMonitor] 数据库索引已确认")
-
 
 # ========================================================================
 # WebSocket 端点


### PR DESCRIPTION
## 变更内容

### 1. 合并 6 个迁移头

上游多个功能分支（自动签到、AI 白名单移除、私聊开关、鸡蛋选择表、命令别名表等）合入 `main` 后，迁移树出现 **6 个并存的 head**，alembic 无法确定唯一升级路径（`nb orm upgrade` 会报 "Multiple head revisions are present"）。

新增 merge 迁移 **`0841fcf990e5_merge_migration_heads.py`**，将以下 6 个头归并为单一线性历史：

| 迁移 | 说明 |
| --- | --- |
| `5b174323b47f` | add unreplied count to private chat session |
| `9e8893de3642` | drop AIWhitelist table |
| `a3c1e5f7b9d2` | remove dropping_enabled from chat_group |
| `b5c6d7e8f9a1` | add egg selection table |
| `c8d9e0f1a2b3` | add auto sign fields to sign_data |
| `e1f2a3b4c5d6` | Add command alias table |

### 2. 移除 chat-monitor 运行时建索引逻辑（修复启动崩溃）

生产环境（xdnas）拉取后启动报 `AutogenerateDiffsDetected`：orm 检测到数据库中存在模型未声明的
`ix_agent_event_created_at` 与 `ix_note_created_time`。

根因是 `nonebot_plugin_chat_monitor/__main__.py` 的 `_ensure_indexes()` 启动钩子绕过迁移系统，
用原生 SQL 重建这两个自定义命名索引；而 #1376 新增的迁移 `ffdcbc994500_remove_chat_indexes.py`
刚将它们判定为遗留索引删除——两者互相打架，导致一致性检查必然失败、应用退出。

本 PR 删除该启动钩子及相关 import。索引应通过模型声明 + Alembic 迁移维护；
若后续需要按时间查询的索引，请在模型上声明后走 autogenerate 流程。

## 验证

- ✅ 合并后 `alembic heads` 仅剩单一 head：`0841fcf990e5`
- ✅ 全图 107 个迁移可完整遍历（无悬垂引用）
- ✅ merge 迁移为纯合并，不含任何 schema 变更，对已部署环境无影响
- ✅ 移除运行时建索引后，`ffdcbc994500` 删除的索引不再被重建，autogenerate 检查可通过