### PR TITLE
feat(menupanel): QQ 自定义菜单/指令面板网页配置支持

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -41,4 +41,8 @@ BOTS_LIST='{"main": "123456789", "secondary": "987654321"}'
 BOTS_APPID_MAP='{"102xxxxxx": "3889000000"}'
 # 群绑定验证码过期时间（秒）
 BOTS_BIND_GROUP_TIMEOUT=300
+# menupanel 插件：QQ 自定义菜单「在线帮助」link 项跳转的前端帮助页地址
+MENUPANEL_FRONTEND_HELP_URL="https://moonlark.itcdt.top/#/help"
+# menupanel 插件：允许配置 QQ 菜单/面板展示指令的超级管理员用户 ID
+MENUPANEL_SUPERUSERS='["123456789"]'
 CORS_ALLOW_ORIGINS='["*"]'

--- a/.env.template
+++ b/.env.template
@@ -42,7 +42,6 @@ BOTS_APPID_MAP='{"102xxxxxx": "3889000000"}'
 # 群绑定验证码过期时间（秒）
 BOTS_BIND_GROUP_TIMEOUT=300
 # menupanel 插件：QQ 自定义菜单「在线帮助」link 项跳转的前端帮助页地址
+# 超管使用 NoneBot 标准 SUPERUSERS 配置，无需单独设置
 MENUPANEL_FRONTEND_HELP_URL="https://moonlark.itcdt.top/#/help"
-# menupanel 插件：允许配置 QQ 菜单/面板展示指令的超级管理员用户 ID
-MENUPANEL_SUPERUSERS='["123456789"]'
 CORS_ALLOW_ORIGINS='["*"]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ plugins = [
     "nonebot_plugin_schedule",
     "nonebot_plugin_wordle",
     "nonebot_plugin_message_summary",
+    "nonebot_plugin_menupanel",
     "nonebot_plugin_chatterbox_ranking",
     "nonebot_plugin_chat",
     "nonebot_plugin_hkrpg_calendar",

--- a/src/plugins/nonebot_plugin_larkhelp/api.py
+++ b/src/plugins/nonebot_plugin_larkhelp/api.py
@@ -31,7 +31,7 @@ async def _() -> list[str]:
 
 
 @app.get("/api/help/list")
-async def _(user_id: str = get_user_id("-1")) -> list[dict]:
+async def get_help_list_by_category(user_id: str = get_user_id("-1")) -> list[dict]:
     """按分类聚合的全部指令帮助数据，供在线帮助页面使用"""
     try:
         return await get_templates(user_id)

--- a/src/plugins/nonebot_plugin_larkhelp/api.py
+++ b/src/plugins/nonebot_plugin_larkhelp/api.py
@@ -20,7 +20,7 @@ from typing import cast
 from fastapi import FastAPI, HTTPException, status
 
 from nonebot_plugin_larkuid.session import get_user_id
-from .__main__ import lang, get_help_list, get_help_dict
+from .__main__ import lang, get_help_list, get_help_dict, get_templates
 
 app = cast(FastAPI, get_app())
 
@@ -28,6 +28,15 @@ app = cast(FastAPI, get_app())
 @app.get("/api/help/commands")
 async def _() -> list[str]:
     return list(get_help_list().keys())
+
+
+@app.get("/api/help/list")
+async def _(user_id: str = get_user_id("-1")) -> list[dict]:
+    """按分类聚合的全部指令帮助数据，供在线帮助页面使用"""
+    try:
+        return await get_templates(user_id)
+    except ValueError:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE)
 
 
 @app.get("/api/help/commands/{name}")

--- a/src/plugins/nonebot_plugin_menupanel/__init__.py
+++ b/src/plugins/nonebot_plugin_menupanel/__init__.py
@@ -1,0 +1,35 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from nonebot import require
+from nonebot.plugin import PluginMetadata
+
+from .config import Config
+
+__plugin_meta__ = PluginMetadata(
+    name="nonebot_plugin_menupanel",
+    description="QQ 自定义菜单与指令面板的网页配置支持",
+    usage="超管在 moonlark-frontend 超级管理员面板选择对外展示的指令并同步到 QQ",
+    config=Config,
+)
+
+require("nonebot_plugin_larkuid")
+require("nonebot_plugin_larkhelp")
+require("nonebot_plugin_localstore")
+
+from . import web  # noqa: E402, F401
+from .store import load_settings, save_settings  # noqa: E402, F401

--- a/src/plugins/nonebot_plugin_menupanel/config.py
+++ b/src/plugins/nonebot_plugin_menupanel/config.py
@@ -1,0 +1,32 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from pydantic import BaseModel
+from nonebot import get_plugin_config
+
+
+class Config(BaseModel):
+    """NoneBot Plugin MenuPanel Config"""
+
+    superusers: list[str] = []
+    # 前端在线帮助页地址，用于 QQ 自定义菜单的 link 菜单项
+    menupanel_frontend_help_url: str = "https://moonlark.itcdt.top/#/help"
+    # 同步到 QQ 的指令面板备注（用于识别 Moonlark 创建的面板）
+    menupanel_panel_remark: str = "moonlark-menupanel"
+
+
+config = get_plugin_config(Config)

--- a/src/plugins/nonebot_plugin_menupanel/models.py
+++ b/src/plugins/nonebot_plugin_menupanel/models.py
@@ -1,0 +1,33 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from pydantic import BaseModel
+
+
+class MenuPanelSettings(BaseModel):
+    """超管在网页端选择的对外展示指令配置"""
+
+    commands: list[str] = []
+    updated_at: float = 0.0
+
+
+class SyncResult(BaseModel):
+    """单个 bot 的同步结果"""
+
+    self_id: str
+    success: bool
+    message: str = ""

--- a/src/plugins/nonebot_plugin_menupanel/store.py
+++ b/src/plugins/nonebot_plugin_menupanel/store.py
@@ -1,0 +1,46 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+import json
+
+from aiofiles import open as aio_open
+from nonebot import require
+
+require("nonebot_plugin_localstore")
+from nonebot_plugin_localstore import get_data_file  # noqa: E402
+
+from .models import MenuPanelSettings  # noqa: E402
+
+SETTINGS_FILE = get_data_file("nonebot_plugin_menupanel", "settings.json")
+
+
+async def load_settings() -> MenuPanelSettings:
+    """读取本地保存的菜单/面板配置"""
+    if not SETTINGS_FILE.exists():
+        return MenuPanelSettings()
+    try:
+        async with aio_open(SETTINGS_FILE, encoding="utf-8") as f:
+            data = json.loads(await f.read())
+        return MenuPanelSettings.model_validate(data)
+    except (json.JSONDecodeError, ValueError):
+        return MenuPanelSettings()
+
+
+async def save_settings(settings: MenuPanelSettings) -> None:
+    """保存菜单/面板配置到本地文件"""
+    async with aio_open(SETTINGS_FILE, "w", encoding="utf-8") as f:
+        await f.write(settings.model_dump_json())

--- a/src/plugins/nonebot_plugin_menupanel/sync.py
+++ b/src/plugins/nonebot_plugin_menupanel/sync.py
@@ -1,0 +1,137 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+import traceback
+
+import httpx
+from nonebot import get_bots, logger
+from nonebot.adapters.qq.bot import Bot as QQBot
+
+from .config import config
+from .models import MenuPanelSettings, SyncResult
+
+HELP_USER_ID = "mlsid::--lang=zh_hans"
+MENU_ITEM_NAME_LIMIT = 10  # 菜单按钮名称上限，一个中文汉字算 2 个字符
+PANEL_ITEM_DESC_LIMIT = 30  # 面板元素描述上限，一个中文汉字算 2 个字符
+
+
+def text_width(text: str) -> int:
+    """按 QQ 官方规则计算文本宽度：中文汉字算 2 个字符"""
+    return sum(2 if ord(char) > 127 else 1 for char in text)
+
+
+def build_menu_items(settings: MenuPanelSettings) -> list[dict]:
+    """由配置生成 QQ 自定义菜单（C2C 单聊底部，最多 10 个顶层菜单项）"""
+    items: list[dict] = [
+        {"type": "send_message", "name": "帮助", "send_message": "/help"},
+        {"type": "link", "name": "在线帮助", "link": config.menupanel_frontend_help_url},
+    ]
+    for command in settings.commands:
+        if text_width(command) + 1 > MENU_ITEM_NAME_LIMIT:
+            logger.warning(f"menupanel: 指令名过长，已跳过菜单项: {command}")
+            continue
+        items.append({"type": "send_message", "name": f"/{command}", "send_message": f"/{command}"})
+    return items[:10]
+
+
+async def build_panel_items(commands: list[str]) -> list[dict]:
+    """由配置生成指令面板元素（每个面板最多 20 个）"""
+    from nonebot_plugin_larkhelp.__main__ import get_help_dict
+
+    items: list[dict] = []
+    for command in commands[:20]:
+        try:
+            help_dict = await get_help_dict(command, HELP_USER_ID)
+            desc = help_dict["description"]
+        except Exception:
+            desc = command
+        while text_width(desc) > PANEL_ITEM_DESC_LIMIT and desc:
+            desc = desc[:-1]
+        items.append({"type": "command", "name": command[:7], "desc": desc})
+    return items
+
+
+class QQApiError(Exception):
+    pass
+
+
+async def qq_request(bot: QQBot, method: str, path: str, json_body: dict | None = None) -> dict:
+    """调用 QQ 官方 API"""
+    url = str(bot.adapter.get_api_base()).rstrip("/") + path
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.request(method, url, json=json_body, headers=await bot.get_authorization_header())
+    if response.status_code >= 300:
+        raise QQApiError(f"HTTP {response.status_code}: {response.text[:200]}")
+    return response.json() if response.content else {}
+
+
+async def find_panel_id(bot: QQBot, scope: str) -> str | None:
+    """查找 Moonlark 创建的同场景指令面板"""
+    cursor = ""
+    for _ in range(5):  # 每页最大 50 条，翻页兜底
+        params = f"?scope={scope}&limit=50" + (f"&cursor={cursor}" if cursor else "")
+        data = await qq_request(bot, "GET", f"/v2/panels{params}")
+        for record in data.get("records", []):
+            if record.get("panel", {}).get("remark") == config.menupanel_panel_remark:
+                return record.get("panel_id")
+        if data.get("is_end", True):
+            break
+        cursor = data.get("next_cursor", "")
+    return None
+
+
+async def sync_panels(bot: QQBot, commands: list[str]) -> str:
+    """同步 C2C 与群聊场景的全局指令面板，返回结果描述"""
+    items = await build_panel_items(commands)
+    messages = []
+    for scope, scope_name in (("c2c", "单聊"), ("group", "群聊")):
+        panel = {"items": items, "remark": config.menupanel_panel_remark}
+        try:
+            panel_id = await find_panel_id(bot, scope)
+            if panel_id is None:
+                await qq_request(
+                    bot, "POST", "/v2/panels", {"scope": scope, "target_type": "all", "panel": panel}
+                )
+                messages.append(f"{scope_name}面板已创建")
+            else:
+                await qq_request(bot, "PUT", f"/v2/panels/{panel_id}", {"panel": panel})
+                messages.append(f"{scope_name}面板已更新")
+        except QQApiError as e:
+            messages.append(f"{scope_name}面板同步失败: {e}")
+    return "；".join(messages)
+
+
+async def sync_bot(bot: QQBot, settings: MenuPanelSettings) -> SyncResult:
+    """将菜单与面板配置同步到单个 QQ 官方 bot"""
+    try:
+        await qq_request(bot, "PUT", "/v2/menu", {"menu": {"items": build_menu_items(settings)}})
+        message = "自定义菜单已更新"
+        if settings.commands:
+            message += "；" + await sync_panels(bot, settings.commands)
+        return SyncResult(self_id=bot.self_id, success=True, message=message)
+    except Exception as e:
+        logger.warning(f"menupanel: 同步到 bot {bot.self_id} 失败\n{traceback.format_exc()}")
+        return SyncResult(self_id=bot.self_id, success=False, message=str(e))
+
+
+async def sync_all(settings: MenuPanelSettings) -> list[SyncResult]:
+    """遍历所有在线的 QQ 官方 bot 执行同步"""
+    results = []
+    for bot in get_bots().values():
+        if isinstance(bot, QQBot) and bot.ready:
+            results.append(await sync_bot(bot, settings))
+    return results

--- a/src/plugins/nonebot_plugin_menupanel/sync.py
+++ b/src/plugins/nonebot_plugin_menupanel/sync.py
@@ -103,9 +103,7 @@ async def sync_panels(bot: QQBot, commands: list[str]) -> str:
         try:
             panel_id = await find_panel_id(bot, scope)
             if panel_id is None:
-                await qq_request(
-                    bot, "POST", "/v2/panels", {"scope": scope, "target_type": "all", "panel": panel}
-                )
+                await qq_request(bot, "POST", "/v2/panels", {"scope": scope, "target_type": "all", "panel": panel})
                 messages.append(f"{scope_name}面板已创建")
             else:
                 await qq_request(bot, "PUT", f"/v2/panels/{panel_id}", {"panel": panel})

--- a/src/plugins/nonebot_plugin_menupanel/web.py
+++ b/src/plugins/nonebot_plugin_menupanel/web.py
@@ -55,7 +55,9 @@ async def _(request: Request, settings: MenuPanelSettings, user_id: str = get_us
     if unknown:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, f"未知指令: {', '.join(unknown)}")
     # 去重保序，且不允许展示超管专属指令
-    commands = list(dict.fromkeys(command for command in settings.commands if help_list[command].category != "superuser"))
+    commands = list(
+        dict.fromkeys(command for command in settings.commands if help_list[command].category != "superuser")
+    )
     if len(commands) > MAX_COMMANDS:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, f"最多选择 {MAX_COMMANDS} 个指令")
     await save_settings(MenuPanelSettings(commands=commands, updated_at=time.time()))

--- a/src/plugins/nonebot_plugin_menupanel/web.py
+++ b/src/plugins/nonebot_plugin_menupanel/web.py
@@ -1,0 +1,76 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+import time
+from typing import cast
+
+from fastapi import FastAPI, HTTPException, Request, status
+from nonebot import get_app
+from nonebot_plugin_larkuid.session import get_user_id
+
+from .config import config
+from .models import MenuPanelSettings
+from .store import load_settings, save_settings
+
+app = cast(FastAPI, get_app())
+
+# 菜单固定项（帮助、在线帮助）之外可配置的指令数量上限（QQ 菜单顶层最多 10 项）
+MAX_COMMANDS = 8
+
+
+@app.get("/api/menupanel/permission")
+async def _(request: Request, user_id: str = get_user_id()) -> dict[str, bool]:
+    return {"superuser": user_id in config.superusers}
+
+
+@app.get("/api/menupanel/settings")
+async def _(request: Request, user_id: str = get_user_id()) -> MenuPanelSettings:
+    if user_id not in config.superusers:
+        raise HTTPException(status.HTTP_403_FORBIDDEN)
+    return await load_settings()
+
+
+@app.put("/api/menupanel/settings")
+async def _(request: Request, settings: MenuPanelSettings, user_id: str = get_user_id()) -> dict[str, bool]:
+    if user_id not in config.superusers:
+        raise HTTPException(status.HTTP_403_FORBIDDEN)
+    from nonebot_plugin_larkhelp.__main__ import get_help_list
+
+    help_list = get_help_list()
+    unknown = [command for command in settings.commands if command not in help_list]
+    if unknown:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"未知指令: {', '.join(unknown)}")
+    # 去重保序，且不允许展示超管专属指令
+    commands = list(dict.fromkeys(command for command in settings.commands if help_list[command].category != "superuser"))
+    if len(commands) > MAX_COMMANDS:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"最多选择 {MAX_COMMANDS} 个指令")
+    await save_settings(MenuPanelSettings(commands=commands, updated_at=time.time()))
+    return {"success": True}
+
+
+@app.post("/api/menupanel/sync")
+async def _(request: Request, user_id: str = get_user_id()) -> dict:
+    if user_id not in config.superusers:
+        raise HTTPException(status.HTTP_403_FORBIDDEN)
+    from .sync import sync_all
+
+    settings = await load_settings()
+    results = await sync_all(settings)
+    return {
+        "success": all(result.success for result in results),
+        "results": [result.model_dump() for result in results],
+    }

--- a/src/plugins/nonebot_plugin_menupanel/web.py
+++ b/src/plugins/nonebot_plugin_menupanel/web.py
@@ -33,19 +33,21 @@ MAX_COMMANDS = 8
 
 
 @app.get("/api/menupanel/permission")
-async def _(request: Request, user_id: str = get_user_id()) -> dict[str, bool]:
+async def get_permission(request: Request, user_id: str = get_user_id()) -> dict[str, bool]:
     return {"superuser": user_id in config.superusers}
 
 
 @app.get("/api/menupanel/settings")
-async def _(request: Request, user_id: str = get_user_id()) -> MenuPanelSettings:
+async def read_settings(request: Request, user_id: str = get_user_id()) -> MenuPanelSettings:
     if user_id not in config.superusers:
         raise HTTPException(status.HTTP_403_FORBIDDEN)
     return await load_settings()
 
 
 @app.put("/api/menupanel/settings")
-async def _(request: Request, settings: MenuPanelSettings, user_id: str = get_user_id()) -> dict[str, bool]:
+async def update_settings(
+    request: Request, settings: MenuPanelSettings, user_id: str = get_user_id()
+) -> dict[str, bool]:
     if user_id not in config.superusers:
         raise HTTPException(status.HTTP_403_FORBIDDEN)
     from nonebot_plugin_larkhelp.__main__ import get_help_list
@@ -65,7 +67,7 @@ async def _(request: Request, settings: MenuPanelSettings, user_id: str = get_us
 
 
 @app.post("/api/menupanel/sync")
-async def _(request: Request, user_id: str = get_user_id()) -> dict:
+async def trigger_sync(request: Request, user_id: str = get_user_id()) -> dict:
     if user_id not in config.superusers:
         raise HTTPException(status.HTTP_403_FORBIDDEN)
     from .sync import sync_all

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -103,6 +103,7 @@ packages = [
     { include = "nonebot_plugin_wordle", from = "./plugins" },
     { include = "nonebot_plugin_sudoku", from = "./plugins" },
     { include = "nonebot_plugin_message_summary", from = "./plugins" },
+    { include = "nonebot_plugin_menupanel", from = "./plugins" },
     { include = "nonebot_plugin_chatterbox_ranking", from = "./plugins" },
     { include = "nonebot_plugin_chat", from = "./plugins" },
     { include = "nonebot_plugin_hkrpg_calendar", from = "./plugins" },


### PR DESCRIPTION
## 概述

基于 [QQ 官方「自定义菜单与指令面板」文档](https://bot.q.qq.com/wiki/develop/api-v2/server-inter/menu-panel/)，为 Moonlark 增加菜单/面板的网页化配置能力，与 moonlark-frontend 的超管面板页面（Moonlark-Dev/moonlark-frontend@5b84c78）配套。

## 新增插件 `nonebot_plugin_menupanel`

**Web API**（鉴权复用 larkuid session，超管校验复用 email 插件模式）：
- `GET /api/menupanel/permission` — 当前用户是否超管
- `GET /api/menupanel/settings` — 读取展示指令配置
- `PUT /api/menupanel/settings` — 保存配置（校验指令存在、去重、过滤 superuser 类别、上限 8 个）
- `POST /api/menupanel/sync` — 同步到所有在线 QQ 官方 bot

**同步逻辑**（`sync.py`）：
- 复用 adapter 公开的 `get_authorization_header()` 与 `get_api_base()`，httpx 直调官方接口，不改动 fork
- **自定义菜单**：固定「帮助」(`/help`) + 「在线帮助」（link 跳转前端帮助页）+ 所选指令按钮；按官方规则校验名称宽度（汉字算 2），顶层 ≤10
- **指令面板**：c2c/group 两场景各维护一个全局面板（remark=`moonlark-menupanel` 标识，翻页查找已有面板后 PUT 更新或 POST 创建）；desc 取 LarkLang 描述并按官方宽度规则截断
- 遵守 QPM 语义：仅显式触发同步，不做高频轮询

## larkhelp 改动

新增 `GET /api/help/list`：返回按分类聚合的全部指令帮助数据（匿名可用），供前端在线帮助页渲染。

## 配套前端

moonlark-frontend 已直接提交到 main：
- `/help` 在线帮助页（QQ 菜单 link 项跳转目标）
- `/admin/menupanel` 超管配置页（勾选指令 → 保存 → 一键同步）

## 配置

超管校验复用 NoneBot 标准 `SUPERUSERS` 环境变量（与 email 插件一致），无独立配置项。

```env
MENUPANEL_FRONTEND_HELP_URL="https://moonlark.itcdt.top/#/help"
```

## 测试

- [x] 所有新文件通过 py_compile
- [ ] 真实环境验证同步（需线上 bot 凭据，建议合并后在沙箱 `qq_is_sandbox=True` 下先跑一遍）
