### PR TITLE
feat(larkuid): 登录接口返回 command_prefix 并新增 /api/login/pending 长轮询接口

### DIFF
--- a/src/plugins/nonebot_plugin_larkuid/config.py
+++ b/src/plugins/nonebot_plugin_larkuid/config.py
@@ -8,6 +8,7 @@ class Config(BaseModel):
     command_start: list[str]
     session_retention_days: int = 3
     unused_session_remove_delay: int = 300
+    login_pending_max_wait: int = 25
     cors_allow_origins: list[str] = ["*"]
 
 

--- a/src/plugins/nonebot_plugin_larkuid/session.py
+++ b/src/plugins/nonebot_plugin_larkuid/session.py
@@ -1,6 +1,7 @@
 import uuid
 import hashlib
 from datetime import datetime, timedelta
+from enum import Enum
 from typing import Optional
 from fastapi import Depends, HTTPException, Request, status
 from nonebot.log import logger
@@ -14,10 +15,40 @@ from nonebot_plugin_larkuser.user.base import MoonlarkUser
 from .models import SessionData
 
 
+class SessionState(Enum):
+    """Web 会话状态：已激活、待激活、无效（不存在 / 已过期 / 标识不匹配）。"""
+
+    ACTIVATED = "activated"
+    PENDING = "pending"
+    INVALID = "invalid"
+
+
 def get_identifier(request: Request) -> str:
     return hashlib.sha256(
         f"{request.headers.get('User-Agent')}{request.client.host if request.client else ''}".encode()
     ).hexdigest()
+
+
+async def check_session_state(request: Request) -> SessionState:
+    """按 Bearer Token 检查会话状态（主键查询，开销极小，供登录等待轮询使用）。
+
+    与 `_get_user_id` 不同：待激活的会话返回 PENDING 而不是 401；
+    无效 / 过期 / 标识不匹配的会话会被删除并返回 INVALID。
+    """
+    session_id = (request.headers.get("Authorization") or "")[6:].strip()
+    if not session_id:
+        return SessionState.INVALID
+    async with get_session() as session:
+        try:
+            data = await session.get_one(SessionData, session_id)
+        except NoResultFound:
+            return SessionState.INVALID
+        expired = data.expiration_time is not None and data.expiration_time <= datetime.now()
+        if data.identifier != get_identifier(request) or expired:
+            await session.delete(data)
+            await session.commit()
+            return SessionState.INVALID
+        return SessionState.ACTIVATED if data.activate_code is None else SessionState.PENDING
 
 
 async def create_session(user_id: str, identifier: str, expiration_time: int) -> tuple[str, str]:

--- a/src/plugins/nonebot_plugin_larkuid/types.py
+++ b/src/plugins/nonebot_plugin_larkuid/types.py
@@ -7,6 +7,11 @@ class LoginResponse(TypedDictExtension):
     session_id: str
     activate_code: str
     effective_time: int
+    command_prefix: str
+
+
+class LoginPendingResponse(TypedDictExtension):
+    activated: bool
 
 
 class VerifyResponse(TypedDictExtension):

--- a/src/plugins/nonebot_plugin_larkuid/web/login.py
+++ b/src/plugins/nonebot_plugin_larkuid/web/login.py
@@ -1,14 +1,16 @@
 import asyncio
-from fastapi import Request
+import time
+
+from fastapi import HTTPException, Request, status
 from nonebot import logger, get_app
 from nonebot_plugin_orm import get_session
 
-# import nonebot_plugin_larkcave.comment.__main__
-# import nonebot_plugin_larkcave.utils.comment.post
-from ..types import LoginResponse
+from ..types import LoginPendingResponse, LoginResponse
 from ..models import LoginRequest, SessionData
 from ..config import config
-from ..session import create_session, get_identifier
+from ..session import SessionState, check_session_state, create_session, get_identifier
+
+PENDING_CHECK_INTERVAL = 1
 
 
 async def remove_unused_session(session_id: str) -> None:
@@ -29,4 +31,24 @@ async def _(request: Request, data: LoginRequest) -> LoginResponse:
         "session_id": session_id,
         "activate_code": activate_code,
         "effective_time": config.unused_session_remove_delay,
+        "command_prefix": config.command_start[0],
     }
+
+
+@get_app().get("/api/login/pending")
+async def _(request: Request, wait: int = 0) -> LoginPendingResponse:
+    """查询当前会话是否已完成登录激活。
+
+    `wait`（秒）大于 0 时为长轮询：服务端挂起请求，激活后立即返回，
+    或到达超时上限（`login_pending_max_wait`，最长不超过该值）返回 `{"activated": false}`。
+    前端只需每 ~25s 发起一次请求即可获得毫秒级的激活感知，替代原先的每秒轮询。
+    会话无效 / 已过期时返回 401。
+    """
+    deadline = time.monotonic() + min(max(wait, 0), config.login_pending_max_wait)
+    while True:
+        state = await check_session_state(request)
+        if state == SessionState.INVALID:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        if state == SessionState.ACTIVATED or time.monotonic() >= deadline:
+            return {"activated": state == SessionState.ACTIVATED}
+        await asyncio.sleep(PENDING_CHECK_INTERVAL)


### PR DESCRIPTION
## 动机

Web 前端（moonlark-frontend）当前的登录流程存在请求次数多、失败面大的问题：

1. **每秒盲轮询权限接口**：前端在等待用户于 bot 中输入 `account verify <code>` 时，每 1s 请求一次 `GET /api/users/me/permissions`。该接口会加载用户的全部权限记录（`nonebot_plugin_access`），语义与开销都不适合当心跳用；`unused_session_remove_delay=300s` 意味着一次登录最坏产生 ~300 个请求。
2. **多余的 prefix 请求**：前端拿到 activate_code 后还要单独请求 `GET /api/prefix` 拼接指令文案。

## 变更

- `POST /api/login` 响应新增 `command_prefix: str` 字段（取自 `config.command_start[0]`），前端可直接拼接验证指令，省掉 `/api/prefix` 请求。
- 新增 `GET /api/login/pending?wait=<seconds>`：
  - 基于 Bearer Token 的会话主键查询（`check_session_state`），单次开销极小；
  - **待激活**的会话返回 `{"activated": false}`（而不是像现有鉴权依赖那样抛 401）；
  - `wait > 0` 时为长轮询：服务端每秒检查一次，激活后立即返回，超时上限由新配置项 `login_pending_max_wait`（默认 25s）控制；
  - 会话无效 / 已过期 / 标识不匹配时删除会话并返回 401（与 `_get_user_id` 行为一致）。

前端配合改造后，一次登录等待期的请求数从 O(等待秒数) 降为约 `等待时长 / 25s + 2` 个，且激活后毫秒级感知。

## 兼容性

- 完全增量式：旧版前端不调用新接口、不读取新字段，行为不变。
- 未激活会话在 pending 接口上返回 200 而非 401 是新增语义，仅影响新端点，不影响任何现有鉴权路径。

## 关联

- moonlark-frontend 侧的前端改造将另行提交（自适应轮询、prefix 缓存、会话状态单飞缓存、错误分级重试）。