### PR TITLE
feat: 网页端支持 Passkey 免密登录

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -55,3 +55,11 @@ BOTS_BIND_GROUP_TIMEOUT=300
 # 超管使用 NoneBot 标准 SUPERUSERS 配置，无需单独设置
 MENUPANEL_FRONTEND_HELP_URL="https://moonlark.itcdt.top/#/help"
 CORS_ALLOW_ORIGINS='["*"]'
+# ── Passkey (WebAuthn) 登录 ──
+# 网页前端的完整 origin（协议 + 域名，不含路径），例如 https://moonlark.itcdt.top
+# WebAuthn 以它校验浏览器回传的 origin；生产环境必须配置，否则只能回退到请求头（仅限本地开发）。
+# PASSKEY_ORIGIN="https://moonlark.itcdt.top"
+# Relying Party ID（默认为 PASSKEY_ORIGIN 的主机名；个别部署需要固定域名时再设置）
+# PASSKEY_RP_ID="moonlark.itcdt.top"
+# 注册 Passkey 时展示给用户的站点名称
+# PASSKEY_RP_NAME="Moonlark"

--- a/migrations/versions/cdf298a5eb8b_add_passkey_tables.py
+++ b/migrations/versions/cdf298a5eb8b_add_passkey_tables.py
@@ -1,0 +1,70 @@
+"""add passkey tables
+
+迁移 ID: cdf298a5eb8b
+父迁移: c3760946c865
+创建时间: 2026-08-30 10:00:00.000000
+
+为 Passkey（WebAuthn）登录新增凭据表与一次性挑战表。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "cdf298a5eb8b"
+down_revision: str | Sequence[str] | None = "c3760946c865"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade(name: str = "") -> None:
+    if name:
+        return
+    # 用户注册的 Passkey 公钥凭据
+    op.create_table(
+        "nonebot_plugin_larkuid_passkeycredential",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.String(length=128), nullable=False),
+        sa.Column("credential_id", sa.LargeBinary(), nullable=False),
+        sa.Column("public_key", sa.LargeBinary(), nullable=False),
+        sa.Column("sign_count", sa.Integer(), nullable=False),
+        sa.Column("device_name", sa.String(length=128), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_nonebot_plugin_larkuid_passkeycredential")),
+        sa.UniqueConstraint("credential_id", name=op.f("uq_nonebot_plugin_larkuid_passkeycredential_credential_id")),
+        info={"bind_key": "nonebot_plugin_larkuid"},
+    )
+    op.create_index(
+        op.f("ix_nonebot_plugin_larkuid_passkeycredential_user_id"),
+        "nonebot_plugin_larkuid_passkeycredential",
+        ["user_id"],
+        unique=False,
+        info={"bind_key": "nonebot_plugin_larkuid"},
+    )
+    # 一次性 WebAuthn 挑战
+    op.create_table(
+        "nonebot_plugin_larkuid_passkeychallenge",
+        sa.Column("challenge", sa.String(length=64), nullable=False),
+        sa.Column("purpose", sa.String(length=16), nullable=False),
+        sa.Column("user_id", sa.String(length=128), nullable=True),
+        sa.Column("origin", sa.String(length=256), nullable=False),
+        sa.Column("rp_id", sa.String(length=256), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("challenge", name=op.f("pk_nonebot_plugin_larkuid_passkeychallenge")),
+        info={"bind_key": "nonebot_plugin_larkuid"},
+    )
+
+
+def downgrade(name: str = "") -> None:
+    if name:
+        return
+    op.drop_table("nonebot_plugin_larkuid_passkeychallenge")
+    op.drop_index(
+        op.f("ix_nonebot_plugin_larkuid_passkeycredential_user_id"),
+        table_name="nonebot_plugin_larkuid_passkeycredential",
+    )
+    op.drop_table("nonebot_plugin_larkuid_passkeycredential")

--- a/poetry.lock
+++ b/poetry.lock
@@ -960,6 +960,65 @@ speedup = ["bitarray (<4.0.0)", "hiredis", "xxhash (<4.0.0)"]
 tests = ["hypothesis (==6.148.7)", "pytest (==9.0.2)", "pytest-asyncio (==1.3.0)", "pytest-cov (==7.0.0)", "pytest-randomly (==4.0.1)", "pytest-rerunfailures (==16.1)"]
 
 [[package]]
+name = "cbor2"
+version = "6.1.4"
+description = "CBOR (de)serializer with extensive tag support"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "cbor2-6.1.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3cfb7eec57406b86aab47183f6dc90ece888e03721d37a4d33315e79e486898d"},
+    {file = "cbor2-6.1.4-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:ae14eb3f2f251102d72625ab02a28c83a8d11adf3d0383bd6d7bd9d672e18119"},
+    {file = "cbor2-6.1.4-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:7b697c2a18eab9a3326447fe0f1c927db065a096febc57f064f0f5ed67fe96fc"},
+    {file = "cbor2-6.1.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:032ce71cbdc9267e9cec42132f6ac6c40f441ec27ebc87ca9dd209dcab6804ee"},
+    {file = "cbor2-6.1.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e8097e8259b78c8feb5dd5b833b23f83ed588e821ef44cf1455082cfc9434440"},
+    {file = "cbor2-6.1.4-cp310-cp310-win32.whl", hash = "sha256:41aae72e8863ac0d50705ea8290b72c49db90a6d953110feaa91360ae526fa8d"},
+    {file = "cbor2-6.1.4-cp310-cp310-win_amd64.whl", hash = "sha256:deff027a56e04caebfee649029bfd1836f4fb468d2cf66d2a396ae1018f655db"},
+    {file = "cbor2-6.1.4-cp310-cp310-win_arm64.whl", hash = "sha256:c435720a25c1de9b241df883b5890b35aff3bf64365efc8037d4d26df085724e"},
+    {file = "cbor2-6.1.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8156fdeb73c3ff6c8cf67ad414fb5c887cd708ff0af6d61f62629f41cb4c17b2"},
+    {file = "cbor2-6.1.4-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:e1fe2d62c50df290576280b18247ec63486f78be73e285bae269c2456c6ddff0"},
+    {file = "cbor2-6.1.4-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c204a75f91f8cd9ed0881f6b88ec395c59aeac9fcf4d08155e7f899db2a1c46e"},
+    {file = "cbor2-6.1.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:28fa5db05a7eae8fd80709959988d8a7f12838c6d4e5c58ec951414058641195"},
+    {file = "cbor2-6.1.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316e217a496640418d3137483279d0e70053b000cdd4b52a4dbf20ea478bc40a"},
+    {file = "cbor2-6.1.4-cp311-cp311-win32.whl", hash = "sha256:4903f24e0f9087275a0b6606c8b0aa586277001d51e4844fcdbc5b7211330aa8"},
+    {file = "cbor2-6.1.4-cp311-cp311-win_amd64.whl", hash = "sha256:5b99305d4013867e059f147752b95f728680682ab03d75a3f4dcfbb270d8dfe9"},
+    {file = "cbor2-6.1.4-cp311-cp311-win_arm64.whl", hash = "sha256:bd20ecc5c8ece24db952e48a91c8c47319eaa6358af707c85ac2bb388a79abc8"},
+    {file = "cbor2-6.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1fc15061553e4494dc10883237501e3402c645fe509248dd698e1faf2460d68b"},
+    {file = "cbor2-6.1.4-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d9ada5a6ccfbb8ea7a3aa2aeb028421b52d8e0cd9323f0a2aeaa9c09d25fbce2"},
+    {file = "cbor2-6.1.4-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:310f3dfb296ba48fe9b63c5cf26e691e3548a1eae6901d2f0c18e941d151f220"},
+    {file = "cbor2-6.1.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e6c76004d674ad1c620660cb0bc5a8a0b72a5d8c7b70926d8e09e6d7e87332f"},
+    {file = "cbor2-6.1.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32a4663425fbca4a4a7aa918eb5789d844c406439e58424cf34511f79f559242"},
+    {file = "cbor2-6.1.4-cp312-cp312-win32.whl", hash = "sha256:2310f07db3f9ba26f2a623774ff9f3dc7185af54f732ea119785a6b1bf7e1e7e"},
+    {file = "cbor2-6.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:cc8cd300e236e9797b2e1ce306109dc481fcccf78bfa2682bf36d99e6eab1ec6"},
+    {file = "cbor2-6.1.4-cp312-cp312-win_arm64.whl", hash = "sha256:553a46bda7d09552631a714e22b91e6ff2c867ecd91511596ce290d8879b8d5b"},
+    {file = "cbor2-6.1.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c48a7c938fc5fa5300ff82b5df09068dcb4838685ae8556b5ee8279d74f97ab4"},
+    {file = "cbor2-6.1.4-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:4bd29f21529e279d50fc14f1a811f7b05b4d8e66a7969163cce98983b6817245"},
+    {file = "cbor2-6.1.4-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:36ae16d64b1f7b620c1af748e7b6947e20069ef80eee56871c5fbb84cc635905"},
+    {file = "cbor2-6.1.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:69978901302ecbc8cda57b520487c5c5240ed217de783eb7728fceb258311d76"},
+    {file = "cbor2-6.1.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad4efa23fee6447e56a269191044e06eb39e809458bcd674e164fe9445feafd0"},
+    {file = "cbor2-6.1.4-cp313-cp313-win32.whl", hash = "sha256:d2560c2ba6a95904ba2a0ca257af878c4344409d9b46d8e646d8ebb617b1e0dd"},
+    {file = "cbor2-6.1.4-cp313-cp313-win_amd64.whl", hash = "sha256:c08b9c7d2ea013e24a0cb819b872b0119dde404f64a1182c0b24095b7bba781f"},
+    {file = "cbor2-6.1.4-cp313-cp313-win_arm64.whl", hash = "sha256:598710183daae69cbdeb177a870ec64aa601de8138a61491fd256826d15a860f"},
+    {file = "cbor2-6.1.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24da0a481294ac416e1e369e2d204b2b1d993cbd082d0d99fa3d6f5f27ae5e69"},
+    {file = "cbor2-6.1.4-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0859a0837e6e2d4fe5f5b849f6475797e4db545da98c19db4b1d3487bd47aa22"},
+    {file = "cbor2-6.1.4-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c0f5f2d6d3b58e44146860c049f3c082207a4005588b8926d51bf937ab66773c"},
+    {file = "cbor2-6.1.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:239db0f92d537fd29eaec4e40195fc3b2b48bc34a5887059658162489a9eb6ae"},
+    {file = "cbor2-6.1.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3f4a434c36bb0d33aeb48ddae8e8b673ca7e1f14545ee7cf4a4c7c39380ea9a2"},
+    {file = "cbor2-6.1.4-cp314-cp314-win32.whl", hash = "sha256:6abcf072b8c0fdc8ad7902ee26a906cafbf3427d026b662ff21166a253f85e18"},
+    {file = "cbor2-6.1.4-cp314-cp314-win_amd64.whl", hash = "sha256:855764e02dc60ab9413acd044e997c3170000fdea6155d6c43a923a1d966dbe6"},
+    {file = "cbor2-6.1.4-cp314-cp314-win_arm64.whl", hash = "sha256:c6b28b928c5f2dbf47dffa12dce9c8e36fe6ac1c1358bc326499c0736263b66f"},
+    {file = "cbor2-6.1.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7336ff4cb7d161ec43b65eef43bf3e9bcab44bd152efb54dd637b7afe711254f"},
+    {file = "cbor2-6.1.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:8f1019494b0ec81a3df3ebb01b6acb446d5b946fe35845b1726379abd66a71da"},
+    {file = "cbor2-6.1.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:179a794bf4be1d46ff190695929f65f0b42019c156919846ae539d2a7ec42e54"},
+    {file = "cbor2-6.1.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9b904b8d0f4ddac9259197d21d121fae4cb8b555700d65bc12c5d46a2e6c2025"},
+    {file = "cbor2-6.1.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:71fcf4f237d68bf4445bf45070f36f82b333f2e6a62612aa2c256683b51378a9"},
+    {file = "cbor2-6.1.4-cp314-cp314t-win32.whl", hash = "sha256:7deccc50fd0b55c4c7dd265b144c5358a645121e457c0ae3722b5ad59832b257"},
+    {file = "cbor2-6.1.4-cp314-cp314t-win_amd64.whl", hash = "sha256:f3fc7d15cba4174373df2496070faa4a927fe3ed772130d281808120aec7b61c"},
+    {file = "cbor2-6.1.4-cp314-cp314t-win_arm64.whl", hash = "sha256:164ca22b509408435b2d8236c80c964e4fc77c085ab034569cd04c40d5cc8883"},
+    {file = "cbor2-6.1.4.tar.gz", hash = "sha256:01ecc79a28f33d17331943ce508fc1e21f4b06553c73f874f4c77120d72b2ef9"},
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -3451,6 +3510,7 @@ pypinyin = ">=0.51.0, <0.52.0"
 pyproject-toml = ">=0.0.10, <0.0.11"
 scikit-image = ">=0.23.1, <0.26.0"
 sympy = ">=1.12.1, <2.0.0"
+webauthn = ">=2.6.0, <2.8.0"
 wordcloud = ">=1.9.4, <2.0.0"
 
 [package.source]
@@ -5290,6 +5350,26 @@ ed25519 = ["PyNaCl (>=1.6.2)"]
 rsa = ["cryptography (>=46.0.7)"]
 
 [[package]]
+name = "pyopenssl"
+version = "25.1.0"
+description = "Python wrapper module around the OpenSSL library"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "pyopenssl-25.1.0-py3-none-any.whl", hash = "sha256:2b11f239acc47ac2e5aca04fd7fa829800aeee22a2eb30d744572a157bd8a1ab"},
+    {file = "pyopenssl-25.1.0.tar.gz", hash = "sha256:8d031884482e0c67ee92bf9a4d8cceb08d92aba7136432ffb0703c5280fc205b"},
+]
+
+[package.dependencies]
+cryptography = ">=41.0.5,<46"
+typing-extensions = {version = ">=4.9", markers = "python_version < \"3.13\" and python_version >= \"3.8\""}
+
+[package.extras]
+docs = ["sphinx (!=5.2.0,!=5.2.0.post0,!=7.2.5)", "sphinx_rtd_theme"]
+test = ["pretend", "pytest (>=3.0.1)", "pytest-rerunfailures"]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 description = "pyparsing - Classes and methods to define and execute parsing grammars"
@@ -7095,6 +7175,24 @@ files = [
     {file = "wcwidth-0.8.3-py3-none-any.whl", hash = "sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4"},
     {file = "wcwidth-0.8.3.tar.gz", hash = "sha256:d128512515fbf4612e0ff21fd6380399210318b7b54a9af59dff8454cf9730eb"},
 ]
+
+[[package]]
+name = "webauthn"
+version = "2.7.1"
+description = "Pythonic WebAuthn"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "webauthn-2.7.1-py3-none-any.whl", hash = "sha256:d57e9613c65e0c6a4db7ee715fb49ebdf3c4a6eb3979729eeb497c99105e8181"},
+    {file = "webauthn-2.7.1.tar.gz", hash = "sha256:2a1ebbfffc4a83e31d3db5d69113944bc49d05fae77770c2d4e388386cb9656e"},
+]
+
+[package.dependencies]
+cbor2 = ">=5.6.5"
+cryptography = ">=44.0.2"
+pyasn1 = ">=0.6.2"
+pyOpenSSL = ">=25.0.0"
 
 [[package]]
 name = "websockets"

--- a/src/plugins/nonebot_plugin_larkuid/config.py
+++ b/src/plugins/nonebot_plugin_larkuid/config.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from nonebot import get_plugin_config
 from pydantic import BaseModel
 
@@ -21,6 +23,19 @@ class Config(BaseModel):
     # /api/login 限流（滑动窗口）：窗口秒数内每 IP+UA 最多 times 次
     login_rate_limit_times: int = 10
     login_rate_limit_window_seconds: int = 60
+    # ── Passkey (WebAuthn) ──
+    # PASSKEY_ORIGIN：网页前端的完整 origin，如 https://moonlark.example.com。
+    # WebAuthn 以它校验浏览器回传的 clientDataJSON.origin，生产环境必须显式配置；
+    # 未配置时回退到创建挑战请求的 Origin 头（仅建议本地开发）。
+    passkey_origin: Optional[str] = None
+    # PASSKEY_RP_ID：Relying Party ID，默认取 PASSKEY_ORIGIN 的主机名（不包含端口）。
+    passkey_rp_id: Optional[str] = None
+    # PASSKEY_RP_NAME：注册时展示给用户的站点名称。
+    passkey_rp_name: str = "Moonlark"
+    # 挑战有效期（秒），超过即失效，须重新发起。
+    passkey_challenge_ttl: int = 120
+    # 每个用户最多可注册的 Passkey 数量。
+    passkey_max_credentials: int = 10
 
 
 config = get_plugin_config(Config)

--- a/src/plugins/nonebot_plugin_larkuid/models.py
+++ b/src/plugins/nonebot_plugin_larkuid/models.py
@@ -1,13 +1,18 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from pydantic import Field
 from nonebot_plugin_orm import Model
 from openai import BaseModel
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy import String
+from sqlalchemy import Integer, LargeBinary, String
 
 from .config import config
+
+
+def _utcnow() -> datetime:
+    """UTC naive 时间基准（与 SessionData 的时间口径一致）。"""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 class SessionData(Model):
@@ -21,6 +26,30 @@ class SessionData(Model):
     created_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
     last_active_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
     device: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+
+
+class PasskeyCredential(Model):
+    """用户注册的 Passkey（WebAuthn）公钥凭据。"""
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(String(128), index=True)
+    credential_id: Mapped[bytes] = mapped_column(LargeBinary, unique=True)
+    public_key: Mapped[bytes] = mapped_column(LargeBinary)
+    sign_count: Mapped[int] = mapped_column(Integer, default=0)
+    device_name: Mapped[str] = mapped_column(String(128))
+    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    last_used_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
+
+
+class PasskeyChallenge(Model):
+    """一次 WebAuthn 仪式使用的挑战（一次性、有过期时间）。"""
+
+    challenge: Mapped[str] = mapped_column(String(64), primary_key=True)  # 32 字节随机数的 hex
+    purpose: Mapped[str] = mapped_column(String(16))  # register / login
+    user_id: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)  # 注册时为该用户，登录时可空
+    origin: Mapped[str] = mapped_column(String(256))  # 期望的 WebAuthn origin
+    rp_id: Mapped[str] = mapped_column(String(256))  # 期望的 Relying Party ID
+    expires_at: Mapped[datetime] = mapped_column()
 
 
 class LoginRequest(BaseModel):

--- a/src/plugins/nonebot_plugin_larkuid/session.py
+++ b/src/plugins/nonebot_plugin_larkuid/session.py
@@ -96,10 +96,21 @@ async def _evict_excess_sessions(user_id: str, keep: int) -> None:
         await session.commit()
 
 
-async def create_session(user_id: str, request: Request, retention_days: int) -> tuple[str, str]:
+async def create_session(
+    user_id: str,
+    request: Request,
+    retention_days: int,
+    activated: bool = False,
+) -> tuple[str, str]:
+    """创建 Web 会话。
+
+    `activated=True` 时直接创建已激活会话（不生成激活码），用于 Passkey 等
+    已完成身份验证的登录方式。
+    """
     days = max(1, min(retention_days, config.session_max_lifetime_days))
     await _evict_excess_sessions(user_id, config.max_sessions_per_user - 1)
     session_id = uuid.uuid4().hex
+    activate_code = None if activated else str(uuid.uuid4()).split("-")[0]
     async with get_session() as session:
         session.add(
             SessionData(
@@ -107,13 +118,13 @@ async def create_session(user_id: str, request: Request, retention_days: int) ->
                 user_id=user_id,
                 identifier=get_identifier(request),
                 expiration_time=utcnow() + timedelta(days=days),
-                activate_code=(activate_code := str(uuid.uuid4()).split("-")[0]),
+                activate_code=activate_code,
                 created_at=utcnow(),
                 device=get_device(request),
             )
         )
         await session.commit()
-    return session_id, activate_code
+    return session_id, activate_code or ""
 
 
 async def _apply_activity(data: SessionData, now: datetime) -> None:

--- a/src/plugins/nonebot_plugin_larkuid/web/__init__.py
+++ b/src/plugins/nonebot_plugin_larkuid/web/__init__.py
@@ -1,1 +1,1 @@
-from . import login, session_api, user, prefix, sub_account
+from . import login, passkey, prefix, session_api, sub_account, user

--- a/src/plugins/nonebot_plugin_larkuid/web/passkey.py
+++ b/src/plugins/nonebot_plugin_larkuid/web/passkey.py
@@ -1,0 +1,437 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+"""Passkey（WebAuthn）登录与凭据管理。
+
+- 登录（无需会话）：`POST /api/login/passkey/options` 获取挑战 → 浏览器
+  `navigator.credentials.get()` → `POST /api/login/passkey/verify` 验证断言并直接
+  创建已激活会话，绕过原来的「聊天内输入激活码」流程。
+- 注册（需已登录会话）：`POST /api/passkeys/register/options` → 浏览器
+  `navigator.credentials.create()` → `POST /api/passkeys/register/verify` 保存公钥。
+
+安全约定：
+- 挑战使用密码学安全随机数，入库存储（含用途 / 归属用户 / 期望 origin 与 rp_id /
+  过期时间），验证成功后立即删除（一次性），并定期清理过期挑战。
+- 期望 origin 严格取配置 `PASSKEY_ORIGIN`；未配置时回退到创建挑战请求的 `Origin`
+  头（仅建议本地开发，生产必须显式配置），该值随挑战一并落库，验证时按行内值校验。
+"""
+
+import json
+import secrets
+from datetime import timedelta
+from typing import Any, Optional, cast
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, HTTPException, Request, status
+from nonebot import get_app, logger
+from nonebot_plugin_apscheduler import scheduler
+from nonebot_plugin_larkuser.user.base import MoonlarkUser
+from nonebot_plugin_orm import get_session
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, select
+from webauthn import (
+    generate_authentication_options,
+    generate_registration_options,
+    verify_authentication_response,
+    verify_registration_response,
+)
+from webauthn.helpers import base64url_to_bytes, bytes_to_base64url, options_to_json_dict
+from webauthn.helpers.exceptions import (
+    InvalidAuthenticationResponse,
+    InvalidRegistrationResponse,
+)
+from webauthn.helpers.structs import (
+    AttestationConveyancePreference,
+    AuthenticatorSelectionCriteria,
+    PublicKeyCredentialDescriptor,
+    PublicKeyCredentialType,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+
+from ..config import config
+from ..models import PasskeyChallenge, PasskeyCredential
+from ..rate_limit import rate_limit
+from ..session import (
+    create_session,
+    get_user_data,
+    get_user_id,
+    utcnow,
+)
+
+app: FastAPI = cast("FastAPI", get_app())
+
+
+# ── 请求模型 ──
+
+
+class PasskeyLoginOptionsRequest(BaseModel):
+    user_id: Optional[str] = None  # 传入时限定只允许该用户的凭据；留空走可发现凭据（resident key）
+
+
+class PasskeyBrowserCredential(BaseModel):
+    """浏览器 PublicKeyCredential 的 JSON 形态（camelCase），验证时直接交给 py_webauthn 解析。"""
+
+    id: str
+    raw_id: str = Field(alias="rawId")
+    response: dict[str, Any]
+    type: str = "public-key"
+    authenticator_attachment: Optional[str] = Field(default=None, alias="authenticatorAttachment")
+
+    def to_browser_json(self, exclude: set[str] | None = None) -> dict[str, Any]:
+        return self.model_dump(by_alias=True, exclude=exclude or set())
+
+
+class PasskeyLoginVerifyRequest(PasskeyBrowserCredential):
+    retention_days: Optional[int] = None  # 「记住我」天数，缺省用服务端默认值
+
+
+class PasskeyRegisterOptionsRequest(BaseModel):
+    device_name: str = "Passkey 设备"
+
+
+class PasskeyRegisterVerifyRequest(PasskeyBrowserCredential):
+    device_name: str = "Passkey 设备"
+
+
+# ── 工具函数 ──
+
+
+def _effective_origin(request: Request) -> str:
+    """WebAuthn 期望 origin：优先配置项；未配置时回退请求头（本地开发）。"""
+    if config.passkey_origin:
+        return config.passkey_origin
+    origin = request.headers.get("Origin") or request.headers.get("Referer") or ""
+    if origin:
+        parsed = urlparse(origin)
+        if parsed.scheme and parsed.netloc:
+            logger.warning("PASSKEY_ORIGIN 未配置，使用请求头 Origin 作为 WebAuthn origin（仅建议开发环境）")
+            return f"{parsed.scheme}://{parsed.netloc}"
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Passkey 尚未配置：请设置 PASSKEY_ORIGIN 环境变量",
+    )
+
+
+def _effective_rp_id(request: Request, origin: str) -> str:
+    if config.passkey_rp_id:
+        return config.passkey_rp_id
+    hostname = urlparse(origin).hostname
+    if hostname:
+        return hostname
+    return (request.headers.get("Host") or "localhost").split(":")[0]
+
+
+def _options_to_dict(options: Any) -> dict[str, Any]:
+    """把 py_webauthn 生成的选项序列化成浏览器可直接使用的 JSON（库官方实现）。"""
+    return options_to_json_dict(options)
+
+
+async def _store_challenge(purpose: str, user_id: Optional[str], origin: str, rp_id: str) -> bytes:
+    challenge = secrets.token_bytes(32)
+    async with get_session() as session:
+        session.add(
+            PasskeyChallenge(
+                challenge=challenge.hex(),
+                purpose=purpose,
+                user_id=user_id,
+                origin=origin,
+                rp_id=rp_id,
+                expires_at=utcnow() + timedelta(seconds=config.passkey_challenge_ttl),
+            ),
+        )
+        await session.commit()
+    return challenge
+
+
+async def _consume_challenge(
+    challenge: bytes,
+    purpose: str,
+    user_id: Optional[str],
+) -> tuple[str, str, Optional[str]]:
+    """按挑战查找并删除（一次性）对应记录，返回 (期望 origin, rp_id, 归属用户)。
+
+    无效 / 过期 / 归属不符时返回 400。
+    """
+    key = challenge.hex()
+    async with get_session() as session:
+        data = await session.get(PasskeyChallenge, key)
+        if data is None or data.purpose != purpose or data.expires_at <= utcnow():
+            if data is not None:
+                await session.delete(data)
+                await session.commit()
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Passkey 挑战无效或已过期")
+        if user_id is not None and data.user_id != user_id:
+            await session.delete(data)
+            await session.commit()
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Passkey 挑战与当前用户不匹配")
+        origin, rp_id, bound_user = data.origin, data.rp_id, data.user_id
+        await session.delete(data)
+        await session.commit()
+        return origin, rp_id, bound_user
+
+
+def _challenge_within_client_data(client_data_json_b64: str) -> bytes:
+    """从浏览器回传的 clientDataJSON 中取出原始挑战（用于定位服务端存储的挑战）。"""
+    try:
+        client_data = json.loads(base64url_to_bytes(client_data_json_b64))
+        return base64url_to_bytes(client_data["challenge"])
+    except (KeyError, ValueError, TypeError) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="clientDataJSON 解析失败",
+        ) from e
+
+
+def _credential_id_from_url(path_credential_id: str) -> bytes:
+    try:
+        return base64url_to_bytes(path_credential_id)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="凭据 ID 格式错误") from e
+
+
+# ── 登录：Passkey 免密登录 ──
+
+
+@app.post("/api/login/passkey/options")
+async def login_passkey_options(
+    request: Request,
+    data: PasskeyLoginOptionsRequest,
+    _: None = rate_limit(config.login_rate_limit_times, config.login_rate_limit_window_seconds),
+) -> dict[str, Any]:
+    """为一次 Passkey 登录颁发挑战。`user_id` 可选：传入则只允许该用户的凭据。"""
+    origin = _effective_origin(request)
+    rp_id = _effective_rp_id(request, origin)
+    allow_credentials: list[PublicKeyCredentialDescriptor] = []
+    if data.user_id:
+        async with get_session() as session:
+            result = await session.scalars(select(PasskeyCredential).where(PasskeyCredential.user_id == data.user_id))
+            credentials = result.all()
+        if not credentials:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="该用户尚未注册 Passkey")
+        allow_credentials = [
+            PublicKeyCredentialDescriptor(type=PublicKeyCredentialType.PUBLIC_KEY, id=credential.credential_id)
+            for credential in credentials
+        ]
+    challenge = await _store_challenge("login", data.user_id, origin, rp_id)
+    options = generate_authentication_options(
+        rp_id=rp_id,
+        challenge=challenge,
+        timeout=60_000,
+        allow_credentials=allow_credentials,
+        user_verification=UserVerificationRequirement.PREFERRED,
+    )
+    return _options_to_dict(options)
+
+
+@app.post("/api/login/passkey/verify")
+async def login_passkey_verify(
+    request: Request,
+    data: PasskeyLoginVerifyRequest,
+    _: None = rate_limit(config.login_rate_limit_times, config.login_rate_limit_window_seconds),
+) -> dict[str, Any]:
+    """验证 Passkey 断言；通过后直接创建已激活的 Web 会话。"""
+    challenge = _challenge_within_client_data(data.response["clientDataJSON"])
+    origin, rp_id, bound_user = await _consume_challenge(challenge, "login", None)
+    credential_id = base64url_to_bytes(data.id)
+    async with get_session() as session:
+        credential = await session.scalar(
+            select(PasskeyCredential).where(PasskeyCredential.credential_id == credential_id),
+        )
+        if credential is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="未找到对应的 Passkey 凭据")
+        if bound_user is not None and credential.user_id != bound_user:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Passkey 凭据与请求的用户不匹配")
+        try:
+            verification = verify_authentication_response(
+                credential=data.to_browser_json(exclude={"retention_days"}),
+                expected_challenge=challenge,
+                expected_origin=origin,
+                expected_rp_id=rp_id,
+                credential_public_key=credential.public_key,
+                credential_current_sign_count=credential.sign_count,
+            )
+        except InvalidAuthenticationResponse as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Passkey 登录验证失败: {e}") from e
+        credential.sign_count = verification.new_sign_count
+        credential.last_used_at = utcnow()
+        user_id = credential.user_id
+        await session.commit()
+    session_id, _ = await create_session(
+        user_id,
+        request,
+        data.retention_days or config.session_retention_days,
+        activated=True,
+    )
+    return {
+        "session_id": session_id,
+        "user_id": user_id,
+        "command_prefix": config.command_start[0],
+    }
+
+
+# ── 凭据管理：注册 / 列表 / 重命名 / 删除（需已登录会话） ──
+
+
+@app.post("/api/passkeys/register/options")
+async def passkey_register_options(
+    request: Request,
+    user_data: MoonlarkUser = get_user_data(),
+) -> dict[str, Any]:
+    """为当前登录用户颁发注册挑战（绑定其账号）。"""
+    user_id = user_data.user_id
+    origin = _effective_origin(request)
+    rp_id = _effective_rp_id(request, origin)
+    async with get_session() as session:
+        result = await session.scalars(select(PasskeyCredential).where(PasskeyCredential.user_id == user_id))
+        credentials = result.all()
+        if len(credentials) >= config.passkey_max_credentials:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"每个账号最多可添加 {config.passkey_max_credentials} 个 Passkey",
+            )
+        exclude_credentials = [
+            PublicKeyCredentialDescriptor(type=PublicKeyCredentialType.PUBLIC_KEY, id=credential.credential_id)
+            for credential in credentials
+        ]
+    challenge = await _store_challenge("register", user_id, origin, rp_id)
+    display_name = user_data.get_nickname() or user_id
+    options = generate_registration_options(
+        rp_id=rp_id,
+        rp_name=config.passkey_rp_name,
+        user_id=user_id.encode("utf-8"),
+        user_name=user_id,
+        user_display_name=display_name,
+        challenge=challenge,
+        timeout=60_000,
+        attestation=AttestationConveyancePreference.NONE,
+        authenticator_selection=AuthenticatorSelectionCriteria(
+            resident_key=ResidentKeyRequirement.PREFERRED,
+            user_verification=UserVerificationRequirement.PREFERRED,
+        ),
+        exclude_credentials=exclude_credentials,
+    )
+    return _options_to_dict(options)
+
+
+@app.post("/api/passkeys/register/verify")
+async def passkey_register_verify(
+    data: PasskeyRegisterVerifyRequest,
+    user_data: MoonlarkUser = get_user_data(),
+) -> dict[str, Any]:
+    """校验注册证明并保存公钥。"""
+    user_id = user_data.user_id
+    challenge = _challenge_within_client_data(data.response["clientDataJSON"])
+    origin, rp_id, _ = await _consume_challenge(challenge, "register", user_id)
+    try:
+        verification = verify_registration_response(
+            credential=data.to_browser_json(exclude={"device_name"}),
+            expected_challenge=challenge,
+            expected_origin=origin,
+            expected_rp_id=rp_id,
+        )
+    except InvalidRegistrationResponse as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Passkey 注册验证失败: {e}") from e
+    async with get_session() as session:
+        duplicate = await session.scalar(
+            select(PasskeyCredential).where(PasskeyCredential.credential_id == verification.credential_id),
+        )
+        if duplicate is not None:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="该 Passkey 已注册，无需重复添加")
+        session.add(
+            PasskeyCredential(
+                user_id=user_id,
+                credential_id=verification.credential_id,
+                public_key=verification.credential_public_key,
+                sign_count=verification.sign_count,
+                device_name=data.device_name,
+            ),
+        )
+        await session.commit()
+    return {"success": True, "message": "Passkey 已添加"}
+
+
+@app.get("/api/passkeys")
+async def passkey_list(user_id: str = get_user_id()) -> list[dict[str, Any]]:
+    """列出当前账号的全部 Passkey。"""
+    async with get_session() as session:
+        result = await session.scalars(select(PasskeyCredential).where(PasskeyCredential.user_id == user_id))
+        credentials = result.all()
+        return [
+            {
+                "id": bytes_to_base64url(credential.credential_id),
+                "device_name": credential.device_name,
+                "created_at": credential.created_at.timestamp() if credential.created_at else None,
+                "last_used_at": credential.last_used_at.timestamp() if credential.last_used_at else None,
+            }
+            for credential in credentials
+        ]
+
+
+@app.patch("/api/passkeys/{credential_id}")
+async def passkey_rename(
+    credential_id: str,
+    data: PasskeyRegisterOptionsRequest,  # 仅使用 device_name 字段
+    user_id: str = get_user_id(),
+) -> dict[str, Any]:
+    """重命名某个 Passkey 的显示名称。"""
+    cid = _credential_id_from_url(credential_id)
+    async with get_session() as session:
+        credential = await session.scalar(
+            select(PasskeyCredential).where(
+                PasskeyCredential.credential_id == cid,
+                PasskeyCredential.user_id == user_id,
+            ),
+        )
+        if credential is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="未找到该 Passkey")
+        credential.device_name = data.device_name
+        await session.commit()
+    return {"success": True, "message": "已重命名"}
+
+
+@app.delete("/api/passkeys/{credential_id}")
+async def passkey_delete(
+    credential_id: str,
+    user_id: str = get_user_id(),
+) -> dict[str, Any]:
+    """删除某个 Passkey。"""
+    cid = _credential_id_from_url(credential_id)
+    async with get_session() as session:
+        result = await session.execute(
+            delete(PasskeyCredential).where(
+                PasskeyCredential.credential_id == cid,
+                PasskeyCredential.user_id == user_id,
+            ),
+        )
+        if result.rowcount == 0:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="未找到该 Passkey")
+        await session.commit()
+    return {"success": True, "message": "Passkey 已删除"}
+
+
+# ── 维护 ──
+
+
+@scheduler.scheduled_job("interval", minutes=10, id="remove_expired_passkey_challenges")
+async def _remove_expired_challenges() -> None:
+    session = get_session()
+    result = await session.scalars(select(PasskeyChallenge).where(PasskeyChallenge.expires_at <= utcnow()))
+    for item in result.all():
+        await session.delete(item)
+    await session.commit()
+    await session.close()

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -31,6 +31,7 @@ html2text = ">=2025.4.15, <2026.0.0"
 imagehash = ">=4.3.2, <5.0.0"
 markdown = ">=3.7, <4.0.0"
 psutil = ">= 7.1.0, < 8.0.0"
+webauthn = ">=2.6.0, <2.8.0"  # Passkey (WebAuthn) 登录支持
 
 aiobotocore = ">=2.17.0, <3.0.0"
 


### PR DESCRIPTION
## 概述

为 Moonlark 网页端（moonlark-frontend）增加 **Passkey（WebAuthn）免密登录**：用户注册 Passkey 后，可在登录页用指纹 / 面容 / PIN 直接登录，不再需要打开聊天软件输入激活码。

配套的前端改动（登录页按钮 + 设置页凭据管理）已在 moonlark-frontend main 分支直接推送（commit `24f9b5f`）。

## 后端改动

- **新增数据表**（迁移 `cdf298a5eb8b`）
  - `PasskeyCredential`：用户公钥凭据（用户 ID、凭据 ID、公钥、签名计数器、设备名、创建/最后使用时间）
  - `PasskeyChallenge`：一次性 WebAuthn 挑战（用途、归属用户、期望 origin / rp_id、过期时间）
- **登录接口**（无需会话）
  - `POST /api/login/passkey/options` — 颁发挑战；传入 `user_id` 时限定该用户凭据，留空走可发现凭据
  - `POST /api/login/passkey/verify` — 校验断言，通过后直接创建**已激活**会话（沿用 `create_session(..., activated=True)`，复用会话硬化逻辑：滑动过期、设备标识、限流）
- **凭据管理接口**（需登录会话）
  - `POST /api/passkeys/register/options|verify` — 注册 Passkey（校验 origin / rp_id / 挑战，保存公钥）
  - `GET /api/passkeys`、`PATCH /api/passkeys/{id}`、`DELETE /api/passkeys/{id}` — 列表 / 重命名 / 删除
- **安全设计**
  - 挑战使用密码学安全随机数，入库后一次性使用，定时任务清理过期挑战
  - 期望 origin 严格取 `PASSKEY_ORIGIN` 配置（未配置回退请求头，仅限本地开发），挑战落库时绑定、验证时按行内值校验
  - 签名计数器防重放；登录 / 注册校验接口复用滑动窗口限流
- **依赖**：新增 `webauthn`（py_webauthn 2.7.x，与项目现有 `cryptography>=44,<45` 约束兼容），已更新 `poetry.lock`
- `.env.template` 补充 `PASSKEY_ORIGIN` / `PASSKEY_RP_ID` / `PASSKEY_RP_NAME` 配置说明

## 使用方式

1. 部署时在 `.env` 设置 `PASSKEY_ORIGIN`（如 `https://moonlark.itcdt.top`）
2. 用户在「设置 → Passkey 登录」添加凭据
3. 登录页点击「使用 Passkey 登录」即可免密登录

## 测试

- 本地通过 ruff / black 检查；`moonlark-frontend` 通过 eslint + vue-tsc + `vite build`
- 使用真实密码学材料模拟 WebAuthn 注册 + 登录仪式（含错误挑战 / 重放签名计数拒绝）验证了 py_webauthn 调用链