### PR TITLE
feat(chat): 支持配置和风天气专属 API Host

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,6 +40,10 @@ R2_ENDPOINT_URL=
 R2_ADDRESSING_STYLE=
 # 和风天气 API Key（https://dev.qweather.com），用于获取实时天气与每日天气
 QWEATHER_API_KEY=
+# 和风天气 API Host（标准订阅为账号专属域名，如 https://xxxx.re.qweatherapi.com）；不填写则使用公共地址
+QWEATHER_API_HOST=
+# 和风天气 GeoAPI Host（城市搜索，一般无需填写）；专属 Host 不提供城市搜索时可另行指定
+QWEATHER_GEO_API_HOST=
 # Moonlark 所在地区的经纬度，用于获取所在地每日天气；不填写则天气相关功能不启用
 MOONLARK_LATITUDE=
 MOONLARK_LONGITUDE=

--- a/src/plugins/nonebot_plugin_chat/config.py
+++ b/src/plugins/nonebot_plugin_chat/config.py
@@ -34,11 +34,23 @@ class Config(BaseModel):
     meme_search_base_url: str = "https://meme-search.xxtg666.top"
     # 和风天气 API Key（https://dev.qweather.com），不填写则天气相关功能不启用
     qweather_api_key: str = ""
+    # 和风天气 API Host：标准订阅为账号专属域名（如 https://xxxx.re.qweatherapi.com），
+    # 不填写则使用公共地址 devapi.qweather.com（公共地址自 2026 年起逐步停用）
+    qweather_api_host: Optional[str] = None
+    # 和风天气 GeoAPI Host（城市搜索）：专属 Host 通常不提供城市搜索接口，
+    # 需要时可单独指定；不填写则使用公共地址 geoapi.qweather.com
+    qweather_geo_api_host: Optional[str] = None
     # Moonlark 所在地区的经纬度，不填写则不启用所在地每日天气
     moonlark_latitude: Optional[float] = None
     moonlark_longitude: Optional[float] = None
 
-    @field_validator("moonlark_latitude", "moonlark_longitude", mode="before")
+    @field_validator(
+        "qweather_api_host",
+        "qweather_geo_api_host",
+        "moonlark_latitude",
+        "moonlark_longitude",
+        mode="before",
+    )
     @classmethod
     def _empty_str_to_none(cls, value: Any) -> Any:
         if value == "":

--- a/src/plugins/nonebot_plugin_chat/utils/weather.py
+++ b/src/plugins/nonebot_plugin_chat/utils/weather.py
@@ -12,8 +12,9 @@ import httpx
 
 from ..config import config
 
-GEO_API_BASE = "https://geoapi.qweather.com"
-DEV_API_BASE = "https://devapi.qweather.com"
+# API Host：标准订阅为账号专属域名；未配置时回退到公共地址（公共地址自 2026 年起逐步停用）
+DEV_API_BASE = (config.qweather_api_host or "https://devapi.qweather.com").rstrip("/")
+GEO_API_BASE = (config.qweather_geo_api_host or "https://geoapi.qweather.com").rstrip("/")
 
 WEEKDAYS = ["星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日"]
 


### PR DESCRIPTION
## 背景

和风天气**标准订阅**为每个账号分配**专属 API Host**（如 `xxxx.re.qweatherapi.com`），该 Host 属于身份认证的一部分；公共地址（`devapi.qweather.com` / `geoapi.qweather.com`）自 **2026 年起逐步停止服务**。

而当前代码在 `utils/weather.py` 中硬编码了公共地址，导致标准订阅用户：

- 会话信息中的「今日天气」一直获取失败（实测公共地址对专属订阅 Key 返回 `403 invalid-host`），只剩「当前日期」一行；
- 实时天气工具（`get_weather`）同样无法使用。

## 改动

| 文件 | 内容 |
|---|---|
| `src/plugins/nonebot_plugin_chat/config.py` | 新增 `qweather_api_host`（天气数据接口 API Host）与 `qweather_geo_api_host`（城市搜索 GeoAPI Host）两个可选配置项，并纳入空串→None 的校验转换 |
| `src/plugins/nonebot_plugin_chat/utils/weather.py` | `DEV_API_BASE` / `GEO_API_BASE` 改为从配置读取，未配置时回退到原有公共地址，**完全向后兼容** |
| `.env.template` | 补充 `QWEATHER_API_HOST`、`QWEATHER_GEO_API_HOST` 的说明与示例 |

GeoAPI Host 单独配置的原因：实测专属 Host 上 `/v2/city/lookup`（城市搜索）为 404，专属订阅的天气接口（`/v7/weather/*`）正常，故两者分开配置，互不影响。

## 测试

- 实测 `https://n44ewve6q7.re.qweatherapi.com/v7/weather/3d` + 标准订阅 Key 返回 `code: 200` 真实天气数据（今日 中雨 25~31℃），会话信息的每日天气链路可用；
- `Config` 空串→None、默认回退公共地址、设置专属 Host 三种情况的取值均验证通过；
- `ruff format --check` / `ruff check` 通过（`weather.py` 中 2 处 `datetime.now()` 无 `tzinfo` 告警为存量代码，与本次改动无关）；`py_compile` 通过。
