### PR TITLE
fix(larkuid): use VARBINARY for credential_id on MySQL to fix BLOB key length error

### DIFF
--- a/migrations/versions/cdf298a5eb8b_add_passkey_tables.py
+++ b/migrations/versions/cdf298a5eb8b_add_passkey_tables.py
@@ -28,7 +28,7 @@ def upgrade(name: str = "") -> None:
         "nonebot_plugin_larkuid_passkeycredential",
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
         sa.Column("user_id", sa.String(length=128), nullable=False),
-        sa.Column("credential_id", sa.LargeBinary(length=768), nullable=False),
+        sa.Column("credential_id", sa.LargeBinary().with_variant(sa.VARBINARY(768), "mysql"), nullable=False),
         sa.Column("public_key", sa.LargeBinary(), nullable=False),
         sa.Column("sign_count", sa.Integer(), nullable=False),
         sa.Column("device_name", sa.String(length=128), nullable=False),

--- a/src/plugins/nonebot_plugin_larkuid/models.py
+++ b/src/plugins/nonebot_plugin_larkuid/models.py
@@ -5,7 +5,7 @@ from pydantic import Field
 from nonebot_plugin_orm import Model
 from openai import BaseModel
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy import Integer, LargeBinary, String
+from sqlalchemy import Integer, LargeBinary, String, VARBINARY
 
 from .config import config
 
@@ -33,7 +33,9 @@ class PasskeyCredential(Model):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[str] = mapped_column(String(128), index=True)
-    credential_id: Mapped[bytes] = mapped_column(LargeBinary(length=768), unique=True)
+    credential_id: Mapped[bytes] = mapped_column(
+        LargeBinary().with_variant(VARBINARY(768), "mysql"), unique=True
+    )
     public_key: Mapped[bytes] = mapped_column(LargeBinary)
     sign_count: Mapped[int] = mapped_column(Integer, default=0)
     device_name: Mapped[str] = mapped_column(String(128))

--- a/src/plugins/nonebot_plugin_larkuid/models.py
+++ b/src/plugins/nonebot_plugin_larkuid/models.py
@@ -33,9 +33,7 @@ class PasskeyCredential(Model):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[str] = mapped_column(String(128), index=True)
-    credential_id: Mapped[bytes] = mapped_column(
-        LargeBinary().with_variant(VARBINARY(768), "mysql"), unique=True
-    )
+    credential_id: Mapped[bytes] = mapped_column(LargeBinary().with_variant(VARBINARY(768), "mysql"), unique=True)
     public_key: Mapped[bytes] = mapped_column(LargeBinary)
     sign_count: Mapped[int] = mapped_column(Integer, default=0)
     device_name: Mapped[str] = mapped_column(String(128))


### PR DESCRIPTION
## 问题

MySQL 部署时创建 Passkey 凭据表失败：

```
sqlalchemy.exc.OperationalError: (pymysql.err.OperationalError) (1170, "BLOB/TEXT column 'credential_id' used in key specification without a key length")
```

## 根因

MySQL 不允许对 BLOB/TEXT 列创建 UNIQUE 约束。上一个 PR #1398 将 `LargeBinary()` 改为 `LargeBinary(length=768)`，但 SQLAlchemy 中 `LargeBinary(length=N)` 在 MySQL 上仍映射为 `BLOB(N)`（而非 `VARBINARY(N)`），MySQL 的 BLOB 类型无论是否带长度都无法直接用于 UNIQUE 约束。

## 修复

使用 SQLAlchemy 的 `with_variant` 机制：
- **MySQL**: `VARBINARY(768)` — 可用于 UNIQUE 约束
- **SQLite**: `LargeBinary()` — 无此限制

```python
credential_id = LargeBinary().with_variant(VARBINARY(768), "mysql")
```

这与项目中 `nonebot_plugin_chat` 的 `CompatibleBlob = LargeBinary().with_variant(MEDIUMBLOB(), "mysql")` 做法一致。

## 改动

- `src/plugins/nonebot_plugin_larkuid/models.py`: `credential_id` 列改为 `LargeBinary().with_variant(VARBINARY(768), "mysql")`
- `migrations/versions/cdf298a5eb8b_add_passkey_tables.py`: 同步修改迁移