### PR TITLE
feat(jrrp): QQ 官方机器人 jrrp 回复新增幸运星/倒霉蛋/重新抽取按钮并在最前面附加 @

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,39 @@ All user-facing text must be localized using LarkLang:
 4. **Commands**: Use Alconna for command parsing
 5. **User Data**: Access user info through LarkUser, not directly
 6. **Localization**: All user-visible text must use LarkLang
+7. **Message Sending**: Send messages with `UniMessage.send()` and read the returned `Receipt` — do NOT use `matcher.send(message)`. Example:
+   ```python
+   receipt = await UniMessage().text("hello").send(target=event, bot=bot, at_sender=True)
+   msg_id = receipt.msg_ids[0]["message_id"]  # msg_ids[0] may be a dict or a pydantic model
+   ```
+
+### QQ Official Bot Interactive Buttons (Keyboard)
+
+The QQ official bot adapter (`nonebot.adapters.qq`, imported as `QQBot`) supports keyboard buttons attached to messages. Follow this convention (see `nonebot_plugin_sign`, `nonebot_plugin_larkhelp`, `nonebot_plugin_quick_math`, `nonebot_plugin_jrrp`):
+
+```python
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot_plugin_alconna import Button, UniMessage
+from nonebot_plugin_larkutils.command import get_command_prefix
+
+# Inside an alconna handler (bot/event are injected)
+if isinstance(bot, QQBot):
+    message = (
+        UniMessage()
+        .style('消息文本', "markdown")
+        .keyboard(
+            Button("enter", "按钮名称", text=f"{get_command_prefix()}jrrp r"),
+            Button("enter", "按钮名称", text=f"{get_command_prefix()}jrrp rr"),
+        )
+    )
+    await message.send(target=event, bot=bot)
+```
+
+Guidelines:
+- A `Button("enter", label, text=...)` sends the `text` back into the chat when clicked, so it should be a full command like `f"{get_command_prefix()}jrrp r"` (use `get_command_prefix()` from `nonebot_plugin_larkutils.command`).
+- Attach the keyboard with `.keyboard(*buttons)`; the button "enter" type triggers a normal message that the alconna matcher will match.
+- To mention a user, prepend `<qqbot-at-user id="{user_id}" />` inside the markdown content; for non-QQ platforms keep plain text with `at_sender=True` instead.
+- Always send with `UniMessage.send()` (never `matcher.send()`); extract the message id from the returned `Receipt.msg_ids` when needed.
 
 ### Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,10 +163,15 @@ All user-facing text must be localized using LarkLang:
 4. **Commands**: Use Alconna for command parsing
 5. **User Data**: Access user info through LarkUser, not directly
 6. **Localization**: All user-visible text must use LarkLang
-7. **Message Sending**: Send messages with `UniMessage.send()` and read the returned `Receipt` — do NOT use `matcher.send(message)`. Example:
+7. **Message Sending**: Use `UniMessage.send()` when the message carries a keyboard/buttons (e.g. QQ official bot interactive messages) and read the returned `Receipt` for message ids. `UniMessage.send()` only sends — after it you must separately call `matcher.finish()` to end the handler. Plain text messages without a keyboard keep using `matcher.send(text, at_sender=...)`:
    ```python
-   receipt = await UniMessage().text("hello").send(target=event, bot=bot, at_sender=True)
+   # Keyboard/button message (QQ official bot): UniMessage.send + separate matcher.finish
+   receipt = await UniMessage().style("text", "markdown").keyboard(...).send(target=event, bot=bot)
    msg_id = receipt.msg_ids[0]["message_id"]  # msg_ids[0] may be a dict or a pydantic model
+   await matcher.finish()
+
+   # Plain text without keyboard: matcher.send(at_sender=True) is fine
+   await matcher.send("text", at_sender=True)
    ```
 
 ### QQ Official Bot Interactive Buttons (Keyboard)
@@ -189,13 +194,16 @@ if isinstance(bot, QQBot):
         )
     )
     await message.send(target=event, bot=bot)
+    # UniMessage.send 只负责发送，必须单独调用 matcher.finish 结束处理器
+    await matcher.finish()
 ```
 
 Guidelines:
 - A `Button("enter", label, text=...)` sends the `text` back into the chat when clicked, so it should be a full command like `f"{get_command_prefix()}jrrp r"` (use `get_command_prefix()` from `nonebot_plugin_larkutils.command`).
 - Attach the keyboard with `.keyboard(*buttons)`; the button "enter" type triggers a normal message that the alconna matcher will match.
-- To mention a user, prepend `<qqbot-at-user id="{user_id}" />` inside the markdown content; for non-QQ platforms keep plain text with `at_sender=True` instead.
-- Always send with `UniMessage.send()` (never `matcher.send()`); extract the message id from the returned `Receipt.msg_ids` when needed.
+- `UniMessage.send()` is for messages that carry a keyboard — it does NOT finish the handler, so always write `matcher.finish()` separately afterwards; extract the message id from the returned `Receipt.msg_ids` when needed.
+- To mention a user, prepend `<qqbot-at-user id="{user_id}" />` inside the markdown content.
+- Non-QQ platforms (no keyboard) keep plain text: `matcher.send(text, at_sender=True)`.
 
 ### Code Style
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3143,6 +3143,13 @@ files = [
     {file = "lxml-6.1.3-cp315-cp315t-win32.whl", hash = "sha256:ace1d2c83b2bd24db5940600541140e87a325e119cb32d5fa9ad720d7e76648e"},
     {file = "lxml-6.1.3-cp315-cp315t-win_amd64.whl", hash = "sha256:b49638355ea3bebba70da783ccbc630fd72afa16bc46c54474bfa1f9a915bbc6"},
     {file = "lxml-6.1.3-cp315-cp315t-win_arm64.whl", hash = "sha256:5a721a98c649855963811b59b55755b30566e7f7fc40bdc9803d66dee9f811cf"},
+    {file = "lxml-6.1.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:13a620a3fcc20023f9e6ed5c383e00e826f1c2d5db554df2f67240760f9118e8"},
+    {file = "lxml-6.1.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fbfb70ba01355251faf6b293171df49f73a88a1b6494db109ffea85442574458"},
+    {file = "lxml-6.1.3-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:302f72413251c03f671e063c9414bed5dc8c927069e5abb69245521e51a4e81b"},
+    {file = "lxml-6.1.3-cp38-cp38-manylinux_2_28_i686.whl", hash = "sha256:ce1f220114959941170e22b8ad44279f6dee2dcef7591814d01ae805dc058889"},
+    {file = "lxml-6.1.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:170773d8a3cdc76259065523ddd978c44f9806e28605f08812e8f86783e44ac6"},
+    {file = "lxml-6.1.3-cp38-cp38-win32.whl", hash = "sha256:92d96586376fb79a33474797186bf993250152ee5c32650b67db78d54b92e6f3"},
+    {file = "lxml-6.1.3-cp38-cp38-win_amd64.whl", hash = "sha256:d44442effeb8781f392340c5dc8c6716fba41dbeacb82fd4c0f09026fb5ff682"},
     {file = "lxml-6.1.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:869dfcd4d381cb0ea87085cc4f011b9171b494ef21e76ad8665f6d5e2d1dc8a1"},
     {file = "lxml-6.1.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6ba4fe5bfbef6811a8e49b3719cde373ad399006c0c1ac184b7297116ecbba5d"},
     {file = "lxml-6.1.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:61116cec57ed69aebc70f37a545eec095339bb829efbdabcfb97c51e9536e158"},
@@ -6082,30 +6089,30 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruff"
-version = "0.16.5"
+version = "0.16.6"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b"},
-    {file = "ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3"},
-    {file = "ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb"},
-    {file = "ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025"},
-    {file = "ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9"},
-    {file = "ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7"},
-    {file = "ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde"},
-    {file = "ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea"},
-    {file = "ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105"},
-    {file = "ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29"},
-    {file = "ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf"},
-    {file = "ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91"},
-    {file = "ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a"},
-    {file = "ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef"},
-    {file = "ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26"},
-    {file = "ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f"},
-    {file = "ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e"},
-    {file = "ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b"},
+    {file = "ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8"},
+    {file = "ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32"},
+    {file = "ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c"},
+    {file = "ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876"},
+    {file = "ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d"},
+    {file = "ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1"},
+    {file = "ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70"},
+    {file = "ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3"},
+    {file = "ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757"},
+    {file = "ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e"},
+    {file = "ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4"},
+    {file = "ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88"},
+    {file = "ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953"},
+    {file = "ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718"},
+    {file = "ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25"},
+    {file = "ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39"},
+    {file = "ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5"},
+    {file = "ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050"},
 ]
 
 [[package]]

--- a/src/lang/zh_hans/jrrp.yaml
+++ b/src/lang/zh_hans/jrrp.yaml
@@ -49,3 +49,7 @@ reroll:
   success: |
     今日已重算: {}/{} 次
     本次消耗: {} vi
+button:
+  lucky_star: 幸运星
+  unlucky_one: 倒霉蛋
+  reroll: 重新抽取

--- a/src/plugins/nonebot_plugin_jrrp/__main__.py
+++ b/src/plugins/nonebot_plugin_jrrp/__main__.py
@@ -6,13 +6,15 @@ from statistics import mean
 from logging import getLogger
 
 from nonebot.adapters import Bot, Event
+from nonebot.adapters.qq import Bot as QQBot
 from nonebot_plugin_larkuser import get_user
 from nonebot_plugin_larkutils import get_user_id
+from nonebot_plugin_larkutils.command import get_command_prefix
 from nonebot_plugin_larkutils.group import get_group_id
 from nonebot_plugin_schedule.utils import complete_schedule
 from nonebot_plugin_chat.core.session import post_group_event
 from nonebot_plugin_larkuser.utils.nickname import get_nickname
-from nonebot_plugin_alconna import Args, Alconna, Subcommand, UniMessage, on_alconna
+from nonebot_plugin_alconna import Args, Alconna, Button, Subcommand, UniMessage, on_alconna
 from nonebot_plugin_larkutils.jrrp import get_luck_value, reroll_luck_value, get_luck_value_with_reroll_count
 
 from .lang import lang
@@ -42,6 +44,27 @@ def _extract_msg_id(result: Any) -> str | None:
     return getattr(result, "message_id", None)
 
 
+async def build_jrrp_message(bot: Bot, user_id: str) -> str | UniMessage:
+    """构建 jrrp 回复消息。
+
+    QQ 官方机器人: 保持原有文本不变，在最前面附加 @ (qqbot-at-user)，
+    并附带 幸运星/倒霉蛋/重新抽取 键盘按钮；
+    其余平台: 返回原有纯文本, 由 at_sender=True 附加 @。
+    """
+    if not isinstance(bot, QQBot):
+        return await get_luck_message(user_id)
+    prefix = get_command_prefix()
+    return (
+        UniMessage()
+        .style(f'<qqbot-at-user id="{user_id}" />{await get_luck_message(user_id)}', "markdown")
+        .keyboard(
+            Button("enter", await lang.text("button.lucky_star", user_id), text=f"{prefix}jrrp r"),
+            Button("enter", await lang.text("button.unlucky_one", user_id), text=f"{prefix}jrrp rr"),
+            Button("enter", await lang.text("button.reroll", user_id), text=f"{prefix}jrrp reroll"),
+        )
+    )
+
+
 async def process_jrrp_command(group_id: str, user_id: str, bot: Bot, event: Event) -> None:
     luck_value = await get_luck_value(user_id)
 
@@ -51,7 +74,11 @@ async def process_jrrp_command(group_id: str, user_id: str, bot: Bot, event: Eve
 
     event_text = await lang.text("chat_event", user_id, await get_nickname(user_id, bot, event), luck_value)
 
-    result = await jrrp.send(await get_luck_message(user_id), at_sender=True)
+    message = await build_jrrp_message(bot, user_id)
+    if isinstance(message, UniMessage):
+        result = await jrrp.send(message)
+    else:
+        result = await jrrp.send(message, at_sender=True)
     msg_id = _extract_msg_id(result)
 
     if msg_id:

--- a/src/plugins/nonebot_plugin_jrrp/__main__.py
+++ b/src/plugins/nonebot_plugin_jrrp/__main__.py
@@ -44,25 +44,26 @@ def _extract_msg_id(result: Any) -> str | None:
     return getattr(result, "message_id", None)
 
 
-async def build_jrrp_message(bot: Bot, user_id: str) -> UniMessage:
+async def build_jrrp_message(bot: Bot, user_id: str) -> str | UniMessage:
     """构建 jrrp 回复消息。
 
     QQ 官方机器人: 保持原有文本不变，在最前面附加 @ (qqbot-at-user)，
-    并附带 幸运星/倒霉蛋/重新抽取 键盘按钮；
-    其余平台: 返回原有纯文本, 由 send(at_sender=True) 附加 @。
+    并附带 幸运星/倒霉蛋/重新抽取 键盘按钮。带 keyboard 的消息使用
+    UniMessage.send 发送，且需在末尾单独调用 matcher.finish 结束处理器；
+    其余平台: 返回原有纯文本, 由 matcher.send(at_sender=True) 附加 @。
     """
-    if isinstance(bot, QQBot):
-        prefix = get_command_prefix()
-        return (
-            UniMessage()
-            .style(f'<qqbot-at-user id="{user_id}" />{await get_luck_message(user_id)}', "markdown")
-            .keyboard(
-                Button("enter", await lang.text("button.lucky_star", user_id), text=f"{prefix}jrrp r"),
-                Button("enter", await lang.text("button.unlucky_one", user_id), text=f"{prefix}jrrp rr"),
-                Button("enter", await lang.text("button.reroll", user_id), text=f"{prefix}jrrp reroll"),
-            )
+    if not isinstance(bot, QQBot):
+        return await get_luck_message(user_id)
+    prefix = get_command_prefix()
+    return (
+        UniMessage()
+        .style(f'<qqbot-at-user id="{user_id}" />{await get_luck_message(user_id)}', "markdown")
+        .keyboard(
+            Button("enter", await lang.text("button.lucky_star", user_id), text=f"{prefix}jrrp r"),
+            Button("enter", await lang.text("button.unlucky_one", user_id), text=f"{prefix}jrrp rr"),
+            Button("enter", await lang.text("button.reroll", user_id), text=f"{prefix}jrrp reroll"),
         )
-    return UniMessage().text(await get_luck_message(user_id))
+    )
 
 
 async def process_jrrp_command(group_id: str, user_id: str, bot: Bot, event: Event) -> None:
@@ -75,12 +76,12 @@ async def process_jrrp_command(group_id: str, user_id: str, bot: Bot, event: Eve
     event_text = await lang.text("chat_event", user_id, await get_nickname(user_id, bot, event), luck_value)
 
     message = await build_jrrp_message(bot, user_id)
-    receipt = await message.send(
-        target=event,
-        bot=bot,
-        at_sender=not isinstance(bot, QQBot),
-    )
-    msg_id = _extract_msg_id(receipt.msg_ids)
+    if isinstance(message, UniMessage):
+        # 带 keyboard 的消息使用 UniMessage.send 发送，结束后单独调用 matcher.finish
+        receipt = await message.send(target=event, bot=bot)
+        msg_id = _extract_msg_id(receipt.msg_ids)
+    else:
+        msg_id = _extract_msg_id(await jrrp.send(message, at_sender=True))
 
     if msg_id:
         event_text += f"\n[供回复的消息ID：{msg_id}]"

--- a/src/plugins/nonebot_plugin_jrrp/__main__.py
+++ b/src/plugins/nonebot_plugin_jrrp/__main__.py
@@ -44,25 +44,25 @@ def _extract_msg_id(result: Any) -> str | None:
     return getattr(result, "message_id", None)
 
 
-async def build_jrrp_message(bot: Bot, user_id: str) -> str | UniMessage:
+async def build_jrrp_message(bot: Bot, user_id: str) -> UniMessage:
     """构建 jrrp 回复消息。
 
     QQ 官方机器人: 保持原有文本不变，在最前面附加 @ (qqbot-at-user)，
     并附带 幸运星/倒霉蛋/重新抽取 键盘按钮；
-    其余平台: 返回原有纯文本, 由 at_sender=True 附加 @。
+    其余平台: 返回原有纯文本, 由 send(at_sender=True) 附加 @。
     """
-    if not isinstance(bot, QQBot):
-        return await get_luck_message(user_id)
-    prefix = get_command_prefix()
-    return (
-        UniMessage()
-        .style(f'<qqbot-at-user id="{user_id}" />{await get_luck_message(user_id)}', "markdown")
-        .keyboard(
-            Button("enter", await lang.text("button.lucky_star", user_id), text=f"{prefix}jrrp r"),
-            Button("enter", await lang.text("button.unlucky_one", user_id), text=f"{prefix}jrrp rr"),
-            Button("enter", await lang.text("button.reroll", user_id), text=f"{prefix}jrrp reroll"),
+    if isinstance(bot, QQBot):
+        prefix = get_command_prefix()
+        return (
+            UniMessage()
+            .style(f'<qqbot-at-user id="{user_id}" />{await get_luck_message(user_id)}', "markdown")
+            .keyboard(
+                Button("enter", await lang.text("button.lucky_star", user_id), text=f"{prefix}jrrp r"),
+                Button("enter", await lang.text("button.unlucky_one", user_id), text=f"{prefix}jrrp rr"),
+                Button("enter", await lang.text("button.reroll", user_id), text=f"{prefix}jrrp reroll"),
+            )
         )
-    )
+    return UniMessage().text(await get_luck_message(user_id))
 
 
 async def process_jrrp_command(group_id: str, user_id: str, bot: Bot, event: Event) -> None:
@@ -75,11 +75,12 @@ async def process_jrrp_command(group_id: str, user_id: str, bot: Bot, event: Eve
     event_text = await lang.text("chat_event", user_id, await get_nickname(user_id, bot, event), luck_value)
 
     message = await build_jrrp_message(bot, user_id)
-    if isinstance(message, UniMessage):
-        result = await jrrp.send(message)
-    else:
-        result = await jrrp.send(message, at_sender=True)
-    msg_id = _extract_msg_id(result)
+    receipt = await message.send(
+        target=event,
+        bot=bot,
+        at_sender=not isinstance(bot, QQBot),
+    )
+    msg_id = _extract_msg_id(receipt.msg_ids)
 
     if msg_id:
         event_text += f"\n[供回复的消息ID：{msg_id}]"

--- a/tests/test_jrrp_qq_buttons.py
+++ b/tests/test_jrrp_qq_buttons.py
@@ -48,16 +48,11 @@ async def test_build_jrrp_message_qq_prepends_at_and_adds_buttons(monkeypatch: p
 
 @pytest.mark.asyncio
 async def test_build_jrrp_message_plain_text_on_other_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
-    """非 QQ 平台应保持原有纯文本消息（由 send(at_sender=True) 附加 @）"""
-    from nonebot_plugin_alconna import Keyboard, Text, UniMessage
+    """非 QQ 平台应保持原有纯文本消息（由 matcher.send(at_sender=True) 附加 @）"""
     from nonebot_plugin_jrrp.__main__ import build_jrrp_message
 
     monkeypatch.setattr("nonebot_plugin_jrrp.__main__.get_luck_message", AsyncMock(return_value="你今天的人品值是: 66"))
 
     message = await build_jrrp_message(bot=MagicMock(), user_id="10")
 
-    assert isinstance(message, UniMessage)
-    text = next(seg for seg in message if isinstance(seg, Text))
-    assert text.text == "你今天的人品值是: 66"
-    # 非 QQ 平台不附带键盘按钮
-    assert not any(isinstance(seg, Keyboard) for seg in message)
+    assert message == "你今天的人品值是: 66"

--- a/tests/test_jrrp_qq_buttons.py
+++ b/tests/test_jrrp_qq_buttons.py
@@ -1,0 +1,58 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def patched_lang(monkeypatch: pytest.MonkeyPatch) -> None:
+    """替换 jrrp 插件的 LangHelper.text，避免依赖数据库读取语言文本
+
+    注意：插件导入必须在函数/fixture 内部进行（collection 阶段 nonebot 插件尚未加载）。
+    """
+    from nonebot_plugin_jrrp.lang import lang
+
+    async def fake_text(key: str, _user_id: str, *_args: object, **_kwargs: object) -> str:
+        return f"text::{key}"
+
+    monkeypatch.setattr(lang, "text", fake_text)
+
+
+@pytest.mark.asyncio
+async def test_build_jrrp_message_qq_prepends_at_and_adds_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
+    """QQ 官方机器人 jrrp 回复应保持原有文本并在最前面附加 @，同时附带三个键盘按钮"""
+    from nonebot.adapters.qq import Bot as QQBot
+    from nonebot_plugin_alconna import Keyboard, Text, UniMessage
+    from nonebot_plugin_jrrp.__main__ import build_jrrp_message
+    from nonebot_plugin_larkutils.command import config
+
+    monkeypatch.setattr("nonebot_plugin_jrrp.__main__.get_luck_message", AsyncMock(return_value="你今天的人品值是: 66"))
+    monkeypatch.setattr(config, "command_start", ["/"])
+
+    message = await build_jrrp_message(bot=MagicMock(spec=QQBot), user_id="10")
+
+    assert isinstance(message, UniMessage)
+    # 文本保持原有内容，且最前面附加 @ (qqbot-at-user)
+    text = next(seg for seg in message if isinstance(seg, Text))
+    assert text.text == '<qqbot-at-user id="10" />你今天的人品值是: 66'
+    assert any("markdown" in styles for styles in text.styles.values())
+    # 键盘包含 幸运星/倒霉蛋/重新抽取 三个 enter 按钮
+    keyboard = next(seg for seg in message if isinstance(seg, Keyboard))
+    buttons = list(keyboard.children)
+    assert [button.text for button in buttons] == ["/jrrp r", "/jrrp rr", "/jrrp reroll"]
+    assert [str(button.label) for button in buttons] == [
+        "text::button.lucky_star",
+        "text::button.unlucky_one",
+        "text::button.reroll",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_jrrp_message_plain_text_on_other_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
+    """非 QQ 平台应保持原有纯文本消息"""
+    from nonebot_plugin_jrrp.__main__ import build_jrrp_message
+
+    monkeypatch.setattr("nonebot_plugin_jrrp.__main__.get_luck_message", AsyncMock(return_value="你今天的人品值是: 66"))
+
+    message = await build_jrrp_message(bot=MagicMock(), user_id="10")
+
+    assert message == "你今天的人品值是: 66"

--- a/tests/test_jrrp_qq_buttons.py
+++ b/tests/test_jrrp_qq_buttons.py
@@ -48,11 +48,16 @@ async def test_build_jrrp_message_qq_prepends_at_and_adds_buttons(monkeypatch: p
 
 @pytest.mark.asyncio
 async def test_build_jrrp_message_plain_text_on_other_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
-    """非 QQ 平台应保持原有纯文本消息"""
+    """非 QQ 平台应保持原有纯文本消息（由 send(at_sender=True) 附加 @）"""
+    from nonebot_plugin_alconna import Keyboard, Text, UniMessage
     from nonebot_plugin_jrrp.__main__ import build_jrrp_message
 
     monkeypatch.setattr("nonebot_plugin_jrrp.__main__.get_luck_message", AsyncMock(return_value="你今天的人品值是: 66"))
 
     message = await build_jrrp_message(bot=MagicMock(), user_id="10")
 
-    assert message == "你今天的人品值是: 66"
+    assert isinstance(message, UniMessage)
+    text = next(seg for seg in message if isinstance(seg, Text))
+    assert text.text == "你今天的人品值是: 66"
+    # 非 QQ 平台不附带键盘按钮
+    assert not any(isinstance(seg, Keyboard) for seg in message)


### PR DESCRIPTION
## 变更内容

在 QQ 官方机器人（`nonebot.adapters.qq`）适配器下，为 `/jrrp` 命令的回复消息新增键盘按钮，并保证原有的文本展示与最前面的 @ 不变：

- **新增按钮**（点击后同等于发送对应指令）：
  - 幸运星 → `/jrrp r`（今日人品排行）
  - 倒霉蛋 → `/jrrp rr`（今日人品倒序排行）
  - 重新抽取 → `/jrrp reroll`（重新计算今日人品值）
- **@ 前置**：QQ 回复使用 `<qqbot-at-user id="..." />` Markdown 元素，在消息最前面 @ 发送者，jrrp 文本内容保持不变。
- **其他平台行为不变**：仍为纯文本 + `at_sender=True`。

## 实现说明

- 新增 `build_jrrp_message(bot, user_id)` 帮助函数，仅对 `QQBot` 构建 Markdown + 键盘消息，其余平台返回原有纯文本。
- 新增翻译键 `button.lucky_star` / `button.unlucky_one` / `button.reroll`（zh_hans 源语言，en_us/zh_tw 由 Crowdin 同步）。
- 新增 `tests/test_jrrp_qq_buttons.py`，覆盖 QQ 消息的 @ 前置、文本不变与三个按钮，以及非 QQ 平台纯文本回退。

## 测试

- `ruff check` / `ruff format` 通过（仅存在 main 分支已有的 TCH 提示，与本次改动无关）。
- 本地环境无 nonebot 依赖，pytest 由 CI 运行。
