### PR TITLE
feat(quick_math): 主界面重构、新增 PvP 对战模式并扩展微积分类题目

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -57,10 +57,15 @@
 ## `quick-math`: 快速数学
 
 以计算为核心的玩法。找到问题的答案，并在排行榜中获取更高的积分。（指令别名：qm）
-- `/quick-math [--level <开始的等级>] (开始挑战)`
+- `/quick-math (查看主界面（玩法介绍、周积分排行、模式介绍）)`
+- `/quick-math start [--level <等级>] (开始普通挑战)`
+- `/quick-math pvp create [最大人数] (创建对战房间)`
+- `/quick-math pvp join <房间码> (加入对战房间)`
+- `/quick-math pvp start (开始对战（仅房主）)`
+- `/quick-math pvp quit (退出对战房间)`
+- `/quick-math zen <等级> (禅模式)`
 - `/quick-math rank [--total] (积分排行榜)`
 - `/quick-math points (查看总分详情)`
-- `/quick-math zen <等级> (禅模式)`
 ## `roll`: 掷骰子
 
 消耗背包中的二十面骰子进行掷骰，点数越高奖励越多，掷出 1 还会倒扣 vi！

--- a/migrations/versions/9f4e8c2a61b3d5f7_add_quick_math_week_table.py
+++ b/migrations/versions/9f4e8c2a61b3d5f7_add_quick_math_week_table.py
@@ -1,0 +1,60 @@
+"""add quick math weekly score table
+
+迁移 ID: 9f4e8c2a61b3d5f7
+父迁移: cdf298a5eb8b
+创建时间: 2026-09-08 12:00:00.000000
+
+为 Quick Math 主界面周积分排行榜新增按 ISO 周累计的积分表。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "9f4e8c2a61b3d5f7"
+down_revision: str | Sequence[str] | None = "cdf298a5eb8b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+TABLE_NAME = "nonebot_plugin_quick_math_quickmathweek"
+
+
+def upgrade(name: str = "") -> None:
+    if name:
+        return
+
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect == "mysql":
+        table_check = sa.text("SHOW TABLES LIKE :table_name")
+    else:
+        table_check = sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:table_name")
+    result = bind.execute(table_check, {"table_name": TABLE_NAME}).fetchall()
+    if result:
+        return
+
+    op.create_table(
+        TABLE_NAME,
+        sa.Column("user_id", sa.String(length=128), nullable=False),
+        sa.Column("week", sa.String(length=16), nullable=False),
+        sa.Column("points", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("user_id", "week", name=op.f("pk_nonebot_plugin_quick_math_quickmathweek")),
+        info={"bind_key": "nonebot_plugin_quick_math"},
+    )
+    op.create_index(
+        op.f("ix_nonebot_plugin_quick_math_quickmathweek_week"),
+        TABLE_NAME,
+        ["week"],
+        unique=False,
+        info={"bind_key": "nonebot_plugin_quick_math"},
+    )
+
+
+def downgrade(name: str = "") -> None:
+    if name:
+        return
+    op.drop_index(op.f("ix_nonebot_plugin_quick_math_quickmathweek_week"), table_name=TABLE_NAME)
+    op.drop_table(TABLE_NAME)

--- a/src/lang/zh_hans/quick_math.yaml
+++ b/src/lang/zh_hans/quick_math.yaml
@@ -31,7 +31,7 @@ main:
     | 已答题目 | 本题限时 | 本题难度 | 当前积分 | 跳过   |
     |---------|--------|---------|---------|---------|
     | {1}     | {2}s   | L{3}    | {4}     | {5}/{6} |
-  
+
     ## 题目信息
 
     {0}
@@ -40,6 +40,34 @@ main:
 
     {}
   choice_item: '{}. {}'
+
+menu:
+  intro: |
+    # ⚡ Quick Math
+
+    快速数学挑战！在限时内回答数学题获取积分，答得越快得分越高。挑战结束后积分会计入周积分排行榜，冲击更高的记录！
+
+  weekly: |
+    ## 📊 本周积分排行
+  weekly_item: '{}. **{}** — {} 分'
+  weekly_empty: 本周还没有人参与挑战，快来争当第一名吧！
+  weekly_me: 我的本周积分：{} 分
+  modes: |
+    ## 🎮 模式介绍
+
+    - **普通模式**：连续答题，答对会逐渐提升难度，答错或超时即结束
+    - **禅模式**：指定难度不限时挑战，输入 leave 可随时退出
+    - **PvP 对战**：在群聊中创建房间，多名玩家轮流答题，坚持到最后的人获胜
+    - **排行榜**：查看历史最高与总积分排行
+    - **积分**：查看自己的积分详情
+  commands: |
+    ## ⌨️ 快速指令
+
+    - `{0}qm start` 开始普通挑战
+    - `{0}qm zen <等级>` 进入禅模式
+    - `{0}qm rank` 查看排行榜
+    - `{0}qm points` 查看积分
+    - `{0}qm pvp create [人数]` 创建 PvP 对战房间
 
 question:
   l1-1: '$${} + {} = ?$$'
@@ -90,6 +118,67 @@ button:
   restart: 再来一局
   rank-record: 记录排行
   rank-total: 总分排行
+  start: 开始挑战
+  zen: 禅模式
+  rank: 排行榜
+  points: 积分
+  pvp-create: 创建对战
+  pvp-start: 开始
+  pvp-join: 加入
+  pvp-quit: 退出
+pvp:
+  only_group: 请在群聊中创建或加入 PvP 对战！
+  already_in: 您已经在某个 PvP 房间中了！
+  already_in_room: 您已经在该房间中了！
+  not_found: 房间不存在或不在本群！
+  full: 房间已满，无法加入！
+  playing: 游戏已经开始，无法加入！
+  not_in_room: 您不在任何房间中！
+  not_owner: 只有房主可以开始对战！
+  need_more_players: 至少需要 2 名玩家才能开始对战！
+  help: |
+    # ⚔️ Quick Math PvP
+
+    群内多人在线对战！互相轮流答题，坚持到最后的人获胜。
+
+    - `{0}` 创建房间
+    - `{1}` 加入房间
+    - `{2}` 退出房间
+    - `{3}` 开始对战（仅房主）
+  create: |
+    # ⚔️ Quick Math PvP
+
+    房间已创建（{2} 人房）！
+    房间码：`{0}`
+
+    其他玩家输入 `{1}` 加入房间
+  create_md: |
+    # ⚔️ Quick Math PvP
+
+    房间已创建（{} 人房），快点击下方按钮加入吧！
+  room_title: |
+    ## ⚔️ PvP 房间 {0}
+
+    玩家（{1}/{2}）
+  room_player: '{}. {}'
+  owner_suffix: ' （房主）'
+  join_hint: 其他玩家输入 `{0}` 加入房间
+  started: |
+    # ⚔️ 对战开始！
+
+    答题顺序：{0}
+
+    {1} 名玩家已就绪，坚持到最后的人获胜！
+  eliminated: '💥 {} 已被淘汰！最终得分：{}'
+  player_quited: '{} 退出了房间'
+  disband: 房间已解散
+  winner: '🏆 获胜者：{}，得分 {}！'
+  result_title: |
+    # ⚔️ PvP 结算
+
+    | 排名 | 玩家 | 积分 | 答对 | 正确率 | 跳过 |
+    |:---:|:---|:---:|:---:|:---:|:---:|
+  result_row: '| {} | {} | {} | {} | {} | {} |'
 rank:
   title-1:  QuickMath 记录排行
   title-2:  QuickMath 总分排行
@@ -110,10 +199,15 @@ achievements:
 help:
   desc: 快速数学
   details: 以计算为核心的玩法。找到问题的答案，并在排行榜中获取更高的积分。（指令别名：qm）
-  u1: quick-math [--level <开始的等级>] (开始挑战)
-  u2: quick-math rank [--total] (积分排行榜)
+  u1: quick-math (查看主界面（玩法介绍、周积分排行、模式介绍）)
+  u2: quick-math start [--level <等级>] (开始普通挑战)
   u3: quick-math zen <等级> (禅模式)
-  u4: quick-math points (查看总分详情)
+  u4: quick-math rank [--total] (积分排行榜)
+  u5: quick-math points (查看总分详情)
+  u6: quick-math pvp create [最大人数] (创建对战房间)
+  u7: quick-math pvp join <房间码> (加入对战房间)
+  u8: quick-math pvp quit (退出对战房间)
+  u9: quick-math pvp start (开始对战（仅房主）)
 award:
   info: |
     # 奖励详情

--- a/src/lang/zh_hans/quick_math.yaml
+++ b/src/lang/zh_hans/quick_math.yaml
@@ -63,11 +63,11 @@ menu:
   commands: |
     ## ⌨️ 快速指令
 
-    - `{0}qm start` 开始普通挑战
-    - `{0}qm zen <等级>` 进入禅模式
-    - `{0}qm rank` 查看排行榜
-    - `{0}qm points` 查看积分
-    - `{0}qm pvp create [人数]` 创建 PvP 对战房间
+    - `{__prefix__}qm start` 开始普通挑战
+    - `{__prefix__}qm zen <等级>` 进入禅模式
+    - `{__prefix__}qm rank` 查看排行榜
+    - `{__prefix__}qm points` 查看积分
+    - `{__prefix__}qm pvp create [人数]` 创建 PvP 对战房间
 
 question:
   l1-1: '$${} + {} = ?$$'
@@ -141,17 +141,15 @@ pvp:
 
     群内多人在线对战！互相轮流答题，坚持到最后的人获胜。
 
-    - `{0}` 创建房间
-    - `{1}` 加入房间
-    - `{2}` 退出房间
-    - `{3}` 开始对战（仅房主）
+    - `{__prefix__}qm pvp create [最大人数]` 创建房间
+    - `{__prefix__}qm pvp join <房间码>` 加入房间
+    - `{__prefix__}qm pvp quit` 退出房间
+    - `{__prefix__}qm pvp start` 开始对战（仅房主）
   create: |
-    # ⚔️ Quick Math PvP
-
     房间已创建（{2} 人房）！
-    房间码：`{0}`
+    房间码：{0}
 
-    其他玩家输入 `{1}` 加入房间
+    其他玩家输入 {1} 加入房间
   create_md: |
     # ⚔️ Quick Math PvP
 
@@ -162,7 +160,7 @@ pvp:
     玩家（{1}/{2}）
   room_player: '{}. {}'
   owner_suffix: ' （房主）'
-  join_hint: 其他玩家输入 `{0}` 加入房间
+  join_hint: 其他玩家输入 {0} 加入房间
   started: |
     # ⚔️ 对战开始！
 

--- a/src/plugins/nonebot_plugin_quick_math/__init__.py
+++ b/src/plugins/nonebot_plugin_quick_math/__init__.py
@@ -21,4 +21,4 @@ require("nonebot_plugin_larkuser")
 require("nonebot_plugin_alconna")
 require("nonebot_plugin_apscheduler")
 
-from .commands import main, rank, points
+from .commands import main, menu, pvp, rank, points

--- a/src/plugins/nonebot_plugin_quick_math/__main__.py
+++ b/src/plugins/nonebot_plugin_quick_math/__main__.py
@@ -1,5 +1,4 @@
-from typing import Literal
-from nonebot_plugin_alconna import Alconna, Args, Subcommand, on_alconna, Option
+from nonebot_plugin_alconna import Alconna, Args, Option, Subcommand, on_alconna
 
 from nonebot_plugin_larkuser.utils.matcher import patch_matcher
 from nonebot_plugin_larklang import LangHelper
@@ -7,10 +6,17 @@ from nonebot_plugin_larklang import LangHelper
 quick_math = on_alconna(
     Alconna(
         "quick-math",
+        Subcommand("start", Option("--level", Args["max_level", int])),
         Subcommand("rank", Option("-t|--total")),
         Subcommand("points"),
-        Subcommand("--level", Args["max_level", int]),
         Subcommand("zen", Args["zen_level", int]),
+        Subcommand(
+            "pvp",
+            Subcommand("create", Args["max_players", int, 5]),
+            Subcommand("join", Args["room_id", str]),
+            Subcommand("quit"),
+            Subcommand("start"),
+        ),
     ),
     aliases={"qm"},
 )

--- a/src/plugins/nonebot_plugin_quick_math/commands/main.py
+++ b/src/plugins/nonebot_plugin_quick_math/commands/main.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from nonebot.adapters import Bot, Event
 from nonebot.adapters.qq import Bot as QQBot
+from nonebot_plugin_alconna import Match
 
 from ..utils.session import QuickMathSession, QuickMathZenSession
 from nonebot_plugin_larkutils.user import get_user_id
@@ -15,19 +16,15 @@ def get_qq_user_id(bot: Bot, event: Event) -> Optional[str]:
     return None
 
 
-@quick_math.assign("max_level")
-async def max_level_handler(bot: Bot, event: Event, max_level: int, user_id: str = get_user_id()) -> None:
-    await handle(bot, event, max_level, user_id)
+@quick_math.assign("start")
+async def start_handler(bot: Bot, event: Event, max_level: Match[int], user_id: str = get_user_id()) -> None:
+    session = QuickMathSession(user_id, bot, get_qq_user_id(bot, event), event)
+    if max_level.available:
+        session.set_max_level(max_level.result)
+    await session.loop()
 
 
 @quick_math.assign("zen")
 async def zen_handler(bot: Bot, event: Event, zen_level: int, user_id: str = get_user_id()) -> None:
     session = QuickMathZenSession(user_id, zen_level, bot, get_qq_user_id(bot, event), event)
-    await session.loop()
-
-
-@quick_math.assign("$main")
-async def handle(bot: Bot, event: Event, max_level: int = 1, user_id: str = get_user_id()) -> None:
-    session = QuickMathSession(user_id, bot, get_qq_user_id(bot, event), event)
-    session.set_max_level(max_level)
     await session.loop()

--- a/src/plugins/nonebot_plugin_quick_math/commands/menu.py
+++ b/src/plugins/nonebot_plugin_quick_math/commands/menu.py
@@ -1,0 +1,55 @@
+from nonebot.adapters import Bot, Event
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot_plugin_alconna import Button, UniMessage
+from nonebot_plugin_htmlrender import md_to_pic
+from nonebot_plugin_larkuser import get_user
+from nonebot_plugin_larkutils import get_user_id
+from nonebot_plugin_larkutils.command import get_command_prefix
+
+from ..__main__ import lang, quick_math
+from ..utils.ranking import get_weekly_user_list
+
+
+async def get_menu_markdown(user_id: str, append_commands: bool) -> str:
+    """生成 /qm 主界面 markdown：玩法介绍 + 周积分排行榜 + 模式介绍。
+
+    :param append_commands: 非 QQ 适配器（无按钮）时在末尾追加全部模式的指令说明。
+    """
+    intro = await lang.text("menu.intro", user_id)
+    weekly, my_points = await get_weekly_user_list(user_id)
+    weekly_lines = [await lang.text("menu.weekly", user_id)]
+    if weekly:
+        for index, data in enumerate(weekly, start=1):
+            user = await get_user(data.user_id)
+            nickname = user.get_nickname() if user.has_nickname() else await lang.text("rank.default_nickname", user_id)
+            weekly_lines.append(await lang.text("menu.weekly_item", user_id, index, nickname, data.points))
+    else:
+        weekly_lines.append(await lang.text("menu.weekly_empty", user_id))
+    if my_points > 0:
+        weekly_lines.append(await lang.text("menu.weekly_me", user_id, my_points))
+    parts = [intro, "\n".join(weekly_lines), await lang.text("menu.modes", user_id)]
+    if append_commands:
+        parts.append(await lang.text("menu.commands", user_id, get_command_prefix()))
+    return "\n\n".join(parts)
+
+
+@quick_math.assign("$main")
+async def menu_handler(bot: Bot, event: Event, user_id: str = get_user_id()) -> None:
+    if isinstance(bot, QQBot):
+        prefix = get_command_prefix()
+        await (
+            UniMessage()
+            .style(await get_menu_markdown(user_id, append_commands=False), "markdown")
+            .keyboard(
+                Button("enter", await lang.text("button.start", user_id), text=f"{prefix}qm start"),
+                Button("enter", await lang.text("button.zen", user_id), text=f"{prefix}qm zen 5"),
+                Button("enter", await lang.text("button.rank", user_id), text=f"{prefix}qm rank"),
+                Button("enter", await lang.text("button.points", user_id), text=f"{prefix}qm points"),
+                Button("enter", await lang.text("button.pvp-create", user_id), text=f"{prefix}qm pvp create"),
+            )
+            .send(target=event, bot=bot)
+        )
+        await quick_math.finish()
+    else:
+        image = await md_to_pic(await get_menu_markdown(user_id, append_commands=True))
+        await quick_math.finish(UniMessage().image(raw=image))

--- a/src/plugins/nonebot_plugin_quick_math/commands/menu.py
+++ b/src/plugins/nonebot_plugin_quick_math/commands/menu.py
@@ -29,7 +29,7 @@ async def get_menu_markdown(user_id: str, append_commands: bool) -> str:
         weekly_lines.append(await lang.text("menu.weekly_me", user_id, my_points))
     parts = [intro, "\n".join(weekly_lines), await lang.text("menu.modes", user_id)]
     if append_commands:
-        parts.append(await lang.text("menu.commands", user_id, get_command_prefix()))
+        parts.append(await lang.text("menu.commands", user_id))
     return "\n\n".join(parts)
 
 

--- a/src/plugins/nonebot_plugin_quick_math/commands/pvp.py
+++ b/src/plugins/nonebot_plugin_quick_math/commands/pvp.py
@@ -12,15 +12,7 @@ from ..utils.pvp import QuickMathRoom, QuickMathRoomPlayer, find_room_of_user, g
 
 @quick_math.assign("pvp")
 async def pvp_help_handler(user_id: str = get_user_id()) -> None:
-    prefix = config.command_start[0]
-    await lang.finish(
-        "pvp.help",
-        user_id,
-        f"{prefix}qm pvp create [最大人数]",
-        f"{prefix}qm pvp join <房间码>",
-        f"{prefix}qm pvp quit",
-        f"{prefix}qm pvp start",
-    )
+    await lang.finish("pvp.help", user_id)
 
 
 @quick_math.assign("pvp.create")

--- a/src/plugins/nonebot_plugin_quick_math/commands/pvp.py
+++ b/src/plugins/nonebot_plugin_quick_math/commands/pvp.py
@@ -1,0 +1,129 @@
+from nonebot.adapters import Bot, Event
+from nonebot_plugin_alconna import Match
+
+from nonebot_plugin_larkutils import get_group_id, get_user_id
+from nonebot_plugin_larkutils.user import is_private_message
+
+from ..__main__ import lang, quick_math
+from ..config import config
+from ..commands.main import get_qq_user_id
+from ..utils.pvp import QuickMathRoom, QuickMathRoomPlayer, find_room_of_user, generate_room_code, rooms
+
+
+@quick_math.assign("pvp")
+async def pvp_help_handler(user_id: str = get_user_id()) -> None:
+    prefix = config.command_start[0]
+    await lang.finish(
+        "pvp.help",
+        user_id,
+        f"{prefix}qm pvp create [最大人数]",
+        f"{prefix}qm pvp join <房间码>",
+        f"{prefix}qm pvp quit",
+        f"{prefix}qm pvp start",
+    )
+
+
+@quick_math.assign("pvp.create")
+async def create_handler(
+    bot: Bot,
+    event: Event,
+    max_players: Match[int],
+    user_id: str = get_user_id(),
+    group_id: str = get_group_id(),
+    private: bool = is_private_message(),
+) -> None:
+    if private:
+        await lang.finish("pvp.only_group", user_id)
+    if find_room_of_user(user_id) is not None:
+        await lang.finish("pvp.already_in", user_id)
+    count = max_players.result if max_players.available else config.qm_pvp_default_max_players
+    count = min(max(count, 2), config.qm_pvp_max_players)
+    room = QuickMathRoom(generate_room_code(), group_id, user_id, count, bot, event)
+    rooms[room.room_id] = room
+    room.players.append(QuickMathRoomPlayer(user_id, get_qq_user_id(bot, event), event))
+    message = await room.build_create_message(user_id)
+    await message.send(target=event, bot=bot)
+    await quick_math.finish()
+
+
+@quick_math.assign("pvp.join")
+async def join_handler(
+    bot: Bot,
+    event: Event,
+    room_id: str,
+    user_id: str = get_user_id(),
+    group_id: str = get_group_id(),
+    private: bool = is_private_message(),
+) -> None:
+    if private:
+        await lang.finish("pvp.only_group", user_id)
+    room = rooms.get(room_id.strip().upper())
+    if room is None or room.group_id != group_id:
+        await lang.finish("pvp.not_found", user_id)
+    if room.status != "waiting":
+        await lang.finish("pvp.playing", user_id)
+    if room.get_player(user_id) is not None:
+        await lang.finish("pvp.already_in_room", user_id)
+    if room.is_full:
+        await lang.finish("pvp.full", user_id)
+    if (current := find_room_of_user(user_id)) is not None and current is not room:
+        await lang.finish("pvp.already_in", user_id)
+    room.players.append(QuickMathRoomPlayer(user_id, get_qq_user_id(bot, event), event))
+    room.last_event = event
+    message = await room.build_player_list_message(user_id)
+    await message.send(target=event, bot=bot)
+    await quick_math.finish()
+
+
+@quick_math.assign("pvp.quit")
+async def quit_handler(
+    event: Event,
+    user_id: str = get_user_id(),
+    group_id: str = get_group_id(),
+    private: bool = is_private_message(),
+) -> None:
+    if private:
+        await lang.finish("pvp.only_group", user_id)
+    room = find_room_of_user(user_id)
+    if room is None or room.group_id != group_id:
+        await lang.finish("pvp.not_in_room", user_id)
+    room.last_event = event
+    player = room.get_player(user_id)
+    if player is None:
+        await quick_math.finish()
+    if room.owner == user_id:
+        # 房主退出直接解散房间
+        room.status = "ended"
+        rooms.pop(room.room_id, None)
+        await room.broadcast_lang("pvp.disband", user_id)
+    elif room.status == "playing":
+        # 对局中退出视为淘汰，保存当前成绩
+        room.players.remove(player)
+        await room.eliminate(player, quit_game=True)
+    else:
+        room.players.remove(player)
+        await room.broadcast_lang("pvp.player_quited", user_id, await room.get_nickname(user_id))
+    await quick_math.finish()
+
+
+@quick_math.assign("pvp.start")
+async def start_handler(
+    event: Event,
+    user_id: str = get_user_id(),
+    group_id: str = get_group_id(),
+    private: bool = is_private_message(),
+) -> None:
+    if private:
+        await lang.finish("pvp.only_group", user_id)
+    room = find_room_of_user(user_id)
+    if room is None or room.group_id != group_id:
+        await lang.finish("pvp.not_in_room", user_id)
+    if room.status != "waiting":
+        await lang.finish("pvp.playing", user_id)
+    if room.owner != user_id:
+        await lang.finish("pvp.not_owner", user_id)
+    if len(room.players) < 2:
+        await lang.finish("pvp.need_more_players", user_id)
+    room.last_event = event
+    await room.start()
+    await quick_math.finish()

--- a/src/plugins/nonebot_plugin_quick_math/config.py
+++ b/src/plugins/nonebot_plugin_quick_math/config.py
@@ -8,7 +8,7 @@ class Config(BaseModel):
     qm_wait_time: int = 3
     qm_min_limit: int = 3
     qm_retry_count: int = 1
-    qm_change_max_level_count: int = 7
+    qm_change_max_level_count: int = 5
     qm_gpt_max_retry: int = 5
     qm_choice_options: int = 3
     qm_pvp_default_max_players: int = 5

--- a/src/plugins/nonebot_plugin_quick_math/config.py
+++ b/src/plugins/nonebot_plugin_quick_math/config.py
@@ -13,7 +13,6 @@ class Config(BaseModel):
     qm_choice_options: int = 3
     qm_pvp_default_max_players: int = 5
     qm_pvp_max_players: int = 10
-    qm_pvp_change_max_level_count: int = 21
     command_start: list[str]
 
 

--- a/src/plugins/nonebot_plugin_quick_math/config.py
+++ b/src/plugins/nonebot_plugin_quick_math/config.py
@@ -11,6 +11,9 @@ class Config(BaseModel):
     qm_change_max_level_count: int = 7
     qm_gpt_max_retry: int = 5
     qm_choice_options: int = 3
+    qm_pvp_default_max_players: int = 5
+    qm_pvp_max_players: int = 10
+    qm_pvp_change_max_level_count: int = 21
     command_start: list[str]
 
 

--- a/src/plugins/nonebot_plugin_quick_math/help.yaml
+++ b/src/plugins/nonebot_plugin_quick_math/help.yaml
@@ -6,6 +6,11 @@ commands:
     usages:
       - help.u1
       - help.u2
-      - help.u4
+      - help.u6
+      - help.u7
+      - help.u9
+      - help.u8
       - help.u3
+      - help.u4
+      - help.u5
     category: game

--- a/src/plugins/nonebot_plugin_quick_math/models.py
+++ b/src/plugins/nonebot_plugin_quick_math/models.py
@@ -10,3 +10,11 @@ class QuickMathUser(Model):
     max_point: Mapped[int] = mapped_column(default=0)
     last_use: Mapped[datetime]
     exchanged: Mapped[int] = mapped_column(default=0)
+
+
+class QuickMathWeek(Model):
+    """按 ISO 周累计的 Quick Math 积分，用于主界面的周积分排行榜。"""
+
+    user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    week: Mapped[str] = mapped_column(String(16), primary_key=True)
+    points: Mapped[int] = mapped_column(default=0)

--- a/src/plugins/nonebot_plugin_quick_math/models.py
+++ b/src/plugins/nonebot_plugin_quick_math/models.py
@@ -16,5 +16,5 @@ class QuickMathWeek(Model):
     """按 ISO 周累计的 Quick Math 积分，用于主界面的周积分排行榜。"""
 
     user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
-    week: Mapped[str] = mapped_column(String(16), primary_key=True)
+    week: Mapped[str] = mapped_column(String(16), primary_key=True, index=True)
     points: Mapped[int] = mapped_column(default=0)

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l7.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l7.py
@@ -1,7 +1,7 @@
-from nonebot.log import logger
-from random import randint, choice
+import random
 from typing import Any
-from sympy import Symbol, diff, limit, latex
+
+from sympy import Symbol, diff, exp, latex, limit, log
 
 from .options import build_options
 from .utils import get_verify_function
@@ -9,17 +9,149 @@ from ....types import Question
 from ....__main__ import lang
 
 
-def _diff_text(expr: Any, x: Symbol, order: int = 1) -> str:
+def _diff_latex(expr: Any, x: Symbol, order: int = 1) -> str:
     result = expr
     for _ in range(order):
         result = diff(result, x)
-    return str(result).replace(" ", "")
+    return latex(result).replace(" ", "")
+
+
+def _ln(x: Symbol) -> Any:
+    return log(x)
+
+
+def _coeff(min_: int, max_: int) -> int:
+    return random.choice([i for i in range(min_, max_ + 1) if i != 0])
+
+
+def _display_sign(index: int, negative: bool, content: str) -> str:
+    """生成带正负号的单项显示：首项负号输出 `-...`，其余项输出 `+ ...` / `- ...`。"""
+    if index == 0:
+        return f"- {content}" if negative else content
+    return f"- {content}" if negative else f"+ {content}"
+
+
+def _generate_simple_terms(x: Symbol, count: int, require_nonlinear: bool = False) -> list[tuple[Any, str]]:
+    """按函数模型池随机生成 count 个单一模型项（可重复），保证至少一个非常数项。
+
+    :param require_nonlinear: 二阶求导等场景下要求至少出现一个非线性项，
+        避免线性/常数项求导后恒为 0 导致题目退化。
+    """
+    models: list[tuple[Any, str]] = []
+    has_nonlinear = False
+    while len(models) < count:
+        model = random.choice(
+            [
+                "const",
+                "linear",
+                "quadratic",
+                "power",
+                "exp",
+                "a_pow",
+                "ln",
+                "log_base",
+            ],
+        )
+        match model:
+            case "const":
+                # 常数项：符号表达式为 1（由系数决定具体数值），显示也由系数决定
+                expr, display = 1, None
+            case "linear":
+                expr, display = x, "x"
+            case "quadratic":
+                expr, display = x**2, "x^{2}"
+                has_nonlinear = True
+            case "power":
+                n = random.randint(3, 8)
+                expr, display = x**n, f"x^{{{n}}}"
+                has_nonlinear = True
+            case "exp":
+                expr, display = exp(x), latex(exp(x))
+                has_nonlinear = True
+            case "a_pow":
+                base = random.randint(2, 9)
+                expr, display = base**x, f"{base}^{{x}}"
+                has_nonlinear = True
+            case "ln":
+                expr, display = _ln(x), r"\ln{\left(x \right)}"
+                has_nonlinear = True
+            case "log_base":
+                base = random.randint(2, 9)
+                expr, display = log(x, base), rf"\log_{{{base}}}{{\left(x \right)}}"
+                has_nonlinear = True
+        models.append((expr, display))
+    if require_nonlinear and not has_nonlinear:
+        # 将最后一项替换为非线性项，保证二阶导数非零
+        n = random.randint(3, 8)
+        models[-1] = (x**n, f"x^{{{n}}}")
+    elif not has_nonlinear:  # 理论极端：全部抽到常数项，替换最后一项为非常数项
+        models[-1] = (x, "x")
+    return models
+
+
+def _generate_compound_term(x: Symbol) -> tuple[Any, str]:
+    """生成一个由两个函数乘除组成的组合项（整个题目最多出现一个）。"""
+    n = random.randint(2, 6)
+    base = random.randint(2, 9)
+    kind = random.randint(1, 6)
+    match kind:
+        case 1:
+            expr = x**n * _ln(x)
+            display = rf"x^{{{n}}} \ln{{\left(x \right)}}"
+        case 2:
+            expr = x**n * log(x, base)
+            display = rf"x^{{{n}}} \log_{{{base}}}{{\left(x \right)}}"
+        case 3:
+            m = random.randint(1, 3)
+            expr = base**x * x**m
+            display = rf"{base}^{{x}} x^{{{m}}}"
+        case 4:
+            m = random.randint(1, 3)
+            expr = x**m * exp(x)
+            display = rf"x^{{{m}}} e^{{x}}"
+        case 5:
+            expr = _ln(x) / x**n
+            display = rf"\frac{{\ln{{\left(x \right)}}}}{{x^{{{n}}}}}"
+        case 6:
+            expr = log(x, base) / x**n
+            display = rf"\frac{{\log_{{{base}}}{{\left(x \right)}}}}{{x^{{{n}}}}}"
+    return expr, display
+
+
+def _generate_terms(x: Symbol, count: int, require_nonlinear: bool = False) -> tuple[list[tuple[Any, str]], list[int]]:
+    """生成 count 个求和项（含至多一个乘除组合项），返回 (项列表, 系数列表)。"""
+    terms = _generate_simple_terms(x, count, require_nonlinear)
+    if random.random() < 0.5:  # 约一半题目包含一个乘除组合项
+        index = random.randrange(count)
+        terms[index] = _generate_compound_term(x)
+    coefficients = [_coeff(1, 9) for _ in range(count)]
+    return terms, coefficients
+
+
+def _build_function(terms: list[tuple[Any, str]], coefficients: list[int]) -> tuple[Any, str]:
+    """将带系数的项列表组装为符号表达式与显示用 LaTeX。"""
+    expr = sum(c * term for c, (term, _) in zip(coefficients, terms))
+    display_parts = []
+    for index, (coefficient, (_, term_display)) in enumerate(zip(coefficients, terms)):
+        negative = coefficient < 0
+        absolute = abs(coefficient)
+        if term_display is None:  # 常数项
+            content = str(absolute)
+        elif absolute == 1:
+            content = term_display
+        elif term_display[0].isdigit():
+            # 系数与以数字开头的函数（如 a^{x}）之间必须显式用乘号，避免连写歧义
+            content = f"{absolute} \\cdot {term_display}"
+        else:
+            content = f"{absolute}{term_display}"
+        display_parts.append(_display_sign(index, negative, content))
+    return expr, " ".join(display_parts)
 
 
 async def generate_limit_question(user_id: str) -> tuple[str, str, list[str]]:
     x = Symbol("x")
-    f = choice([x**2 + 3 * x - 2, x**3 - 2 * x + 1, x**4 - 4 * x**3 + 5 * x**2 + 2 * x - 1])
-    a = randint(-10, 10)
+    f = random.choice([x**2 + 3 * x - 2, x**3 - 2 * x + 1, x**4 - 4 * x**3 + 5 * x**2 + 2 * x - 1])
+    a = random.randint(-10, 10)
     _limit = limit(f, x, a)
     question = await lang.text("question.l7-limit", user_id, a, latex(f))
     answer = latex(_limit)
@@ -27,31 +159,31 @@ async def generate_limit_question(user_id: str) -> tuple[str, str, list[str]]:
     return question, answer, variants
 
 
-async def generate_question(user_id: str) -> Question:
+async def generate_derivative_question(user_id: str, order: int = 1) -> tuple[str, str, list[str]]:
     x = Symbol("x")
-    a = randint(1, 10)
-    b = randint(1, 10)
-    c = randint(1, 10)
-    d = randint(1, 10)
-    match randint(1, 4):
-        case 1:
-            f = a * x**3 + b * x**2 + c * x + d
-            answer = _diff_text(f, x)
-            question = await lang.text("question.l7-diff", user_id, latex(f))
-            variants = [_diff_text((a + k) * x**3 + (b - k) * x**2 + c * x + d, x) for k in range(1, 7)]
-        case 2:
-            f = a * x**3 + b * x**2 + c * x + d
-            answer = _diff_text(f, x, 2)
-            question = await lang.text("question.l7-diff-diff", user_id, latex(f))
-            variants = [_diff_text((a + k) * x**3 + (b - k) * x**2 + c * x + d, x, 2) for k in range(1, 7)]
-        case 3:
-            f = a * x**2 + b * x + c
-            answer = _diff_text(f, x)
-            question = await lang.text("question.l7-diff", user_id, latex(f))
-            variants = [_diff_text((a + k) * x**2 + (b - k) * x + c, x) for k in range(1, 7)]
-        case _:
-            question, answer, variants = await generate_limit_question(user_id)
-    logger.debug(answer)
+    count = random.randint(3, 5)
+    terms, coefficients = _generate_terms(x, count, require_nonlinear=order > 1)
+    f, display = _build_function(terms, coefficients)
+    answer = _diff_latex(f, x, order)
+    key = "question.l7-diff-diff" if order == 2 else "question.l7-diff"
+    question = await lang.text(key, user_id, display)
+    variants: list[str] = []
+    for k in range(1, 7):
+        # 所有系数同向扰动，避免相邻同类项在 ±k 交替扰动下相互抵消导致干扰项退化
+        perturbed = [c + k for c in coefficients]
+        f_k, _ = _build_function(terms, perturbed)
+        variants.append(_diff_latex(f_k, x, order))
+    return question, answer, variants
+
+
+async def generate_question(user_id: str) -> Question:
+    case = random.randint(1, 5)
+    if case in (1, 2, 3):
+        question, answer, variants = await generate_derivative_question(user_id)
+    elif case == 4:
+        question, answer, variants = await generate_derivative_question(user_id, 2)
+    else:
+        question, answer, variants = await generate_limit_question(user_id)
     return {
         "question": question,
         "answer": get_verify_function(answer, user_id),

--- a/src/plugins/nonebot_plugin_quick_math/utils/message.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/message.py
@@ -54,6 +54,8 @@ async def wait_answer(
     user_id: str,
     events: Optional[list[Event]] = None,
     enable_leave_command: bool = False,
+    allow_quit: bool = True,
+    ignore_error_details: bool = True,
 ) -> ReplyType | ExtendReplyType:
     message = image
     for i in range(config.qm_retry_count + 1):
@@ -64,6 +66,8 @@ async def wait_answer(
                 timeout=question["limit_in_sec"],
                 event=events[-1] if events else None,
                 events=events,
+                allow_quit=allow_quit,
+                ignore_error_details=ignore_error_details,
             )
         except PromptTimeout:
             return ReplyType.TIMEOUT

--- a/src/plugins/nonebot_plugin_quick_math/utils/pvp.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/pvp.py
@@ -1,0 +1,235 @@
+import operator
+import random
+from datetime import datetime
+from typing import Optional
+
+from nonebot.adapters import Bot, Event
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot_plugin_alconna import Button, UniMessage
+from nonebot_plugin_htmlrender import md_to_pic
+from nonebot_plugin_larkuser import get_user
+from nonebot_plugin_larkutils.command import get_command_prefix
+
+from ..__main__ import lang
+from ..types import ExtendReplyType, ReplyType
+from ..utils.message import wait_answer
+from ..utils.session import QuickMathPvpSession
+from ..utils.user import update_user_data
+
+# 房间码字符集：去除 0/O/1/I 等易混淆字符
+ROOM_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+ROOM_CODE_LENGTH = 5
+
+rooms: dict[str, "QuickMathRoom"] = {}
+
+
+def generate_room_code() -> str:
+    while True:
+        code = "".join(random.choice(ROOM_CODE_ALPHABET) for _ in range(ROOM_CODE_LENGTH))
+        if code not in rooms:
+            return code
+
+
+def find_room_of_user(user_id: str) -> Optional["QuickMathRoom"]:
+    """查找用户当前所在的房间（全局唯一，一个用户同时只能在一个房间中）。"""
+    return next((room for room in rooms.values() if room.get_player(user_id) is not None), None)
+
+
+class QuickMathRoomPlayer:
+    def __init__(self, user_id: str, qq_user_id: Optional[str], event: Event) -> None:
+        self.user_id = user_id
+        self.qq_user_id = qq_user_id
+        # 加入房间时的事件，作为该玩家第一题的回复目标，避免所有首题都回复同一条消息
+        self.event = event
+        self.session: Optional[QuickMathPvpSession] = None
+        self.saved = False
+        self.final_point = 0
+
+
+class QuickMathRoom:
+    def __init__(self, room_id: str, group_id: str, owner: str, max_players: int, bot: Bot, event: Event) -> None:
+        self.room_id = room_id
+        self.group_id = group_id
+        self.owner = owner
+        self.max_players = max_players
+        self.bot = bot
+        # 房间内最新的事件，用于群内广播（QQ 被动回复需始终针对最新事件）
+        self.last_event = event
+        self.players: list[QuickMathRoomPlayer] = []
+        self.status = "waiting"  # waiting | playing | ended
+        self.order: list[QuickMathRoomPlayer] = []
+        self.seat = 0
+
+    def get_player(self, user_id: str) -> Optional[QuickMathRoomPlayer]:
+        return next((player for player in self.players if player.user_id == user_id), None)
+
+    @property
+    def is_full(self) -> bool:
+        return len(self.players) >= self.max_players
+
+    async def get_nickname(self, user_id: str) -> str:
+        user = await get_user(user_id)
+        return user.get_nickname() if user.has_nickname() else await lang.text("rank.default_nickname", user_id)
+
+    async def broadcast_lang(self, key: str, user_id: str, *args: object) -> None:
+        """向房间广播本地化文本（QQ 下针对房间的最新事件被动回复）。"""
+        await UniMessage(await lang.text(key, user_id, *args)).send(target=self.last_event, bot=self.bot)
+
+    # ---------- 房间消息 ----------
+
+    async def build_create_message(self, user_id: str) -> UniMessage:
+        prefix = get_command_prefix()
+        join_command = f"{prefix}qm pvp join {self.room_id}"
+        if isinstance(self.bot, QQBot):
+            return (
+                UniMessage()
+                .style(await lang.text("pvp.create_md", user_id, self.max_players), "markdown")
+                .keyboard(Button("enter", await lang.text("button.pvp-join", user_id), text=join_command))
+            )
+        return UniMessage(await lang.text("pvp.create", user_id, self.room_id, join_command, self.max_players))
+
+    async def build_player_list_message(self, user_id: str) -> UniMessage:
+        lines = [await lang.text("pvp.room_title", user_id, self.room_id, len(self.players), self.max_players)]
+        for index, player in enumerate(self.players, start=1):
+            nickname = await self.get_nickname(player.user_id)
+            if player.user_id == self.owner:
+                nickname += await lang.text("pvp.owner_suffix", user_id)
+            lines.append(await lang.text("pvp.room_player", user_id, index, nickname))
+        if isinstance(self.bot, QQBot):
+            prefix = get_command_prefix()
+            buttons = [Button("enter", await lang.text("button.pvp-start", user_id), text=f"{prefix}qm pvp start")]
+            if not self.is_full:
+                buttons.append(
+                    Button(
+                        "enter",
+                        await lang.text("button.pvp-join", user_id),
+                        text=f"{prefix}qm pvp join {self.room_id}",
+                    ),
+                )
+            buttons.append(Button("enter", await lang.text("button.pvp-quit", user_id), text=f"{prefix}qm pvp quit"))
+            return UniMessage().style("\n".join(lines), "markdown").keyboard(*buttons)
+        lines.append(await lang.text("pvp.join_hint", user_id, f"{get_command_prefix()}qm pvp join {self.room_id}"))
+        return UniMessage("\n".join(lines))
+
+    # ---------- 对战流程 ----------
+
+    async def start(self) -> None:
+        """开始对战：打乱并固定参与顺序，依次轮流向玩家发题。"""
+        self.status = "playing"
+        random.shuffle(self.players)
+        self.order = self.players[:]
+        self.seat = 0
+        for player in self.players:
+            player.session = QuickMathPvpSession(player.user_id, self.bot, player.qq_user_id, player.event)
+            # 预置玩家加入时的事件，使首题回复针对该玩家的消息而非统一回复同一事件
+            player.session.events = [player.event]
+        order_text = " → ".join([await self.get_nickname(player.user_id) for player in self.order])
+        await self.broadcast_lang("pvp.started", self.owner, order_text, len(self.order))
+        while self.status == "playing" and len(self.players) > 1:
+            next_player = self.order[self.seat % len(self.order)]
+            while self.players and next_player not in self.players:
+                self.seat += 1
+                next_player = self.order[self.seat % len(self.order)]
+            if not self.players:
+                break
+            self.seat += 1
+            if await self.play_turn(next_player) and next_player in self.players:
+                self.players.remove(next_player)
+        if self.status == "playing":
+            await self.finish()
+
+    async def play_turn(self, player: QuickMathRoomPlayer) -> bool:
+        """向单个玩家发送题目并处理回答；返回玩家是否被淘汰。"""
+        session = player.session
+        if session is None:
+            return True
+        image, question = await session.get_question()
+        send_time = datetime.now()
+        result = await wait_answer(
+            question,
+            image,
+            player.user_id,
+            session.events,
+            allow_quit=False,
+            # 超时以 PromptTimeout 返回 ReplyType.TIMEOUT，避免 FinishedException 中断整个对战
+            ignore_error_details=False,
+        )
+        if session.events:
+            session.event = session.events[-1]
+            self.last_event = session.event
+        if player.saved:
+            # 等待期间玩家已通过 /qm pvp quit 退出或房间已被解散
+            return True
+        session.total_answered += 1
+        if result in (ReplyType.TIMEOUT, ReplyType.WRONG, ExtendReplyType.LEAVE):
+            await self.eliminate(player)
+            return True
+        if result == ReplyType.SKIP and session.available_skip_count > session.skipped_question:
+            await session.on_skip(question, send_time)
+        elif result == ReplyType.RIGHT:
+            await session.on_right_answer(question, send_time)
+        await session.on_question_finished()
+        return False
+
+    async def eliminate(self, player: QuickMathRoomPlayer, quit_game: bool = False) -> None:
+        """保存成绩并广播淘汰/退出消息。"""
+        if player.saved:
+            return
+        player.saved = True
+        session = player.session
+        player.final_point = session.point if session is not None else 0
+        if session is not None and session.passed > 0:
+            await update_user_data(player.user_id, session.point)
+            await session.update_achievement()
+        nickname = await self.get_nickname(player.user_id)
+        if quit_game:
+            await self.broadcast_lang("pvp.player_quited", self.owner, nickname)
+        else:
+            await self.broadcast_lang("pvp.eliminated", self.owner, nickname, player.final_point)
+
+    async def finish(self) -> None:
+        """仅剩一人时结算：保存成绩并发送得分排行表格（md_to_pic）。"""
+        winner = self.players[0] if self.players else None
+        if winner is not None and winner.session is not None and winner.session.passed > 0:
+            await update_user_data(winner.user_id, winner.session.point)
+            await winner.session.update_achievement()
+        if winner is not None:
+            winner_nickname = await self.get_nickname(winner.user_id)
+            await self.broadcast_lang("pvp.winner", self.owner, winner_nickname, winner.session.point)
+        image = await md_to_pic(await self.build_result_markdown())
+        await UniMessage().image(raw=image).send(target=self.last_event, bot=self.bot)
+        self.status = "ended"
+        rooms.pop(self.room_id, None)
+
+    async def build_result_markdown(self) -> str:
+        """生成结算表格 markdown（按得分降序）。"""
+        records: list[dict] = []
+        for player in self.order:
+            session = player.session
+            records.append(
+                {
+                    "user_id": player.user_id,
+                    "point": player.final_point,
+                    "passed": session.passed if session is not None else 0,
+                    "total_answered": session.total_answered if session is not None else 0,
+                    "skipped": session.skipped_question if session is not None else 0,
+                },
+            )
+        records.sort(key=operator.itemgetter("point"), reverse=True)
+        lines = [await lang.text("pvp.result_title", self.owner)]
+        for index, record in enumerate(records, start=1):
+            nickname = await self.get_nickname(record["user_id"])
+            rate = record["passed"] / record["total_answered"] * 100 if record["total_answered"] else 0
+            lines.append(
+                await lang.text(
+                    "pvp.result_row",
+                    self.owner,
+                    index,
+                    nickname,
+                    record["point"],
+                    record["passed"],
+                    f"{rate:.0f}%",
+                    record["skipped"],
+                ),
+            )
+        return "\n".join(lines)

--- a/src/plugins/nonebot_plugin_quick_math/utils/pvp.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/pvp.py
@@ -11,6 +11,7 @@ from nonebot_plugin_larkuser import get_user
 from nonebot_plugin_larkutils.command import get_command_prefix
 
 from ..__main__ import lang
+from ..config import config
 from ..types import ExtendReplyType, ReplyType
 from ..utils.message import wait_answer
 from ..utils.session import QuickMathPvpSession
@@ -120,7 +121,14 @@ class QuickMathRoom:
         self.order = self.players[:]
         self.seat = 0
         for player in self.players:
-            player.session = QuickMathPvpSession(player.user_id, self.bot, player.qq_user_id, player.event)
+            # 升级周期按参与人数计算：人数 × 普通模式升级周期，开局人数固定后不再变化
+            player.session = QuickMathPvpSession(
+                player.user_id,
+                self.bot,
+                player.qq_user_id,
+                player.event,
+                cycle_count=len(self.players) * config.qm_change_max_level_count,
+            )
             # 预置玩家加入时的事件，使首题回复针对该玩家的消息而非统一回复同一事件
             player.session.events = [player.event]
         order_text = " → ".join([await self.get_nickname(player.user_id) for player in self.order])

--- a/src/plugins/nonebot_plugin_quick_math/utils/ranking.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/ranking.py
@@ -1,11 +1,13 @@
 from nonebot_plugin_ranking.web import WebRanking, register
 from nonebot_plugin_ranking.types import RankingData
-from ..models import QuickMathUser
+from ..models import QuickMathUser, QuickMathWeek
 from ..__main__ import lang
 
 from nonebot_plugin_orm import get_session
 from sqlalchemy import select
 from typing import Any, AsyncGenerator
+
+from .user import get_week_key
 
 
 async def get_user_list(order_by: Any = QuickMathUser.max_point) -> AsyncGenerator[QuickMathUser, None]:
@@ -15,8 +17,25 @@ async def get_user_list(order_by: Any = QuickMathUser.max_point) -> AsyncGenerat
             yield user
 
 
-class RecordRanking(WebRanking):
+async def get_weekly_user_list(user_id: str, limit: int = 5) -> tuple[list[QuickMathWeek], int]:
+    """获取本周积分排行前 ``limit`` 名，以及当前用户的本周积分。"""
+    week = get_week_key()
+    my_points = 0
+    async with get_session() as session:
+        data = await session.scalars(
+            select(QuickMathWeek)
+            .where(QuickMathWeek.week == week)
+            .order_by(QuickMathWeek.points.desc(), QuickMathWeek.user_id)
+            .limit(limit),
+        )
+        ranked = list(data)
+        mine = await session.get(QuickMathWeek, (user_id, week))
+        if mine is not None:
+            my_points = mine.points
+    return ranked, my_points
 
+
+class RecordRanking(WebRanking):
     async def get_sorted_data(self, user_id: str) -> list[RankingData]:
         return [
             {
@@ -29,7 +48,6 @@ class RecordRanking(WebRanking):
 
 
 class TotalRanking(WebRanking):
-
     async def get_sorted_data(self, user_id: str) -> list[RankingData]:
         return [
             {

--- a/src/plugins/nonebot_plugin_quick_math/utils/session.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/session.py
@@ -259,3 +259,42 @@ class QuickMathZenSession(QuickMathSession):
             self.point *= 0.75
             return False
         return await self.process_answer_result(result, send_time, question)
+
+
+class QuickMathPvpSession(QuickMathSession):
+    """PvP 对战模式下的单人会话。
+
+    与普通模式的区别：
+
+    - 题目开头会 @ 答题者（QQ markdown 使用 @ 标签，其他适配器前置 At 段）；
+    - 难度升级周期更长（见 ``config.qm_pvp_change_max_level_count``）；
+    - 答错/超时后不可复活，直接淘汰；
+    - 题目的等级、限时缩短与跳过次数均按玩家独立计算。
+    """
+
+    async def get_question(self, **kwargs) -> tuple[UniMessage, QuestionData]:
+        message, question = await super().get_question(**kwargs)
+        if not isinstance(self.bot, QQBot):
+            # 非 QQ 适配器：在题目最前面 @ 需要答题的玩家
+            message = UniMessage().at(self.user_id) + message
+        return message, question
+
+    async def send_lang(self, key: str, *args: object) -> None:
+        """针对玩家本人最新事件发送本地化文本（不经过 matcher，适配 PvP 群聊场景）。"""
+        text = await lang.text(key, self.user_id, *args)
+        await UniMessage(text).send(target=self.event, bot=self.bot)
+
+    async def on_wrong_answer(self) -> bool:
+        # PvP 模式不可复活：最终答错/超时即淘汰
+        self.end_time = datetime.now()
+        return False
+
+    async def on_question_finished(self) -> None:
+        if (
+            self.level[0] != "lock"
+            and self.passed % config.qm_pvp_change_max_level_count == 0
+            and self.level[1] != get_max_level()
+        ):
+            self.set_max_level(self.level[1] + 1)
+        if self.point >= 200 * self.available_skip_count:
+            self.available_skip_count += 1

--- a/src/plugins/nonebot_plugin_quick_math/utils/session.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/session.py
@@ -303,11 +303,7 @@ class QuickMathPvpSession(QuickMathSession):
         return False
 
     async def on_question_finished(self) -> None:
-        if (
-            self.level[0] != "lock"
-            and self.passed % self.cycle_count == 0
-            and self.level[1] != get_max_level()
-        ):
+        if self.level[0] != "lock" and self.passed % self.cycle_count == 0 and self.level[1] != get_max_level():
             self.set_max_level(self.level[1] + 1)
         if self.point >= 200 * self.available_skip_count:
             self.available_skip_count += 1

--- a/src/plugins/nonebot_plugin_quick_math/utils/session.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/session.py
@@ -267,10 +267,23 @@ class QuickMathPvpSession(QuickMathSession):
     与普通模式的区别：
 
     - 题目开头会 @ 答题者（QQ markdown 使用 @ 标签，其他适配器前置 At 段）；
-    - 难度升级周期更长（见 ``config.qm_pvp_change_max_level_count``）；
+    - 难度升级周期按参与人数计算（每名玩家答对 ``cycle_count`` 题后升级，
+      默认取房间人数 × 普通模式升级周期），而非写死的固定值；
     - 答错/超时后不可复活，直接淘汰；
     - 题目的等级、限时缩短与跳过次数均按玩家独立计算。
     """
+
+    def __init__(
+        self,
+        user_id: str,
+        bot: Bot,
+        qq_user_id: Optional[str] = None,
+        event: Optional[Event] = None,
+        cycle_count: Optional[int] = None,
+    ) -> None:
+        super().__init__(user_id, bot, qq_user_id, event)
+        # 升级周期按房间人数计算，由房间在开局时传入；未传入时退化为普通模式周期
+        self.cycle_count = cycle_count if cycle_count is not None else config.qm_change_max_level_count
 
     async def get_question(self, **kwargs) -> tuple[UniMessage, QuestionData]:
         message, question = await super().get_question(**kwargs)
@@ -292,7 +305,7 @@ class QuickMathPvpSession(QuickMathSession):
     async def on_question_finished(self) -> None:
         if (
             self.level[0] != "lock"
-            and self.passed % config.qm_pvp_change_max_level_count == 0
+            and self.passed % self.cycle_count == 0
             and self.level[1] != get_max_level()
         ):
             self.set_max_level(self.level[1] + 1)

--- a/src/plugins/nonebot_plugin_quick_math/utils/user.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/user.py
@@ -1,8 +1,15 @@
 import copy
 from datetime import datetime
-from nonebot_plugin_orm import get_session
+from nonebot_plugin_orm import AsyncSession, get_session
 
-from ..models import QuickMathUser
+from ..models import QuickMathUser, QuickMathWeek
+
+
+def get_week_key(now: datetime | None = None) -> str:
+    """返回当前时间的 ISO 周标识，如 ``2026-W35``。"""
+    now = now or datetime.now()
+    year, week, _ = now.isocalendar()
+    return f"{year}-W{week:02d}"
 
 
 async def update_user_data(user_id: str, point: int) -> tuple[int, int]:
@@ -15,7 +22,7 @@ async def update_user_data(user_id: str, point: int) -> tuple[int, int]:
             data.experience += point * (point / data.max_point)
             data.last_use = datetime.now()
             await session.commit()
-            return point - record, record
+            diff = point - record
         else:
             session.add(
                 QuickMathUser(
@@ -23,7 +30,20 @@ async def update_user_data(user_id: str, point: int) -> tuple[int, int]:
                     max_point=point,
                     experience=point,
                     last_use=datetime.now(),
-                )
+                ),
             )
             await session.commit()
-            return point, 0
+            diff, record = point, 0
+        await add_week_points(session, user_id, point)
+        return diff, record
+
+
+async def add_week_points(session: AsyncSession, user_id: str, point: int) -> None:
+    """将本次积分累计到当前 ISO 周。"""
+    week = get_week_key()
+    week_data = await session.get(QuickMathWeek, (user_id, week))
+    if week_data is None:
+        session.add(QuickMathWeek(user_id=user_id, week=week, points=point))
+    else:
+        week_data.points += point
+    await session.commit()


### PR DESCRIPTION
## 改动说明

对 `nonebot_plugin_quick_math` 插件做三项改动（基于最新 `main` 分支）。

### 1. 微积分类题目（L7 求导）扩展函数模型
- 函数模型池扩展为：`c`、`a·x`、`b·x²`、`x^a`、`e^x`、`a^x`、`ln x`、`log_a x`
- 每题由 3~5 个函数相加组成，不限制模型重复（可为三个相同的 `x^a`，也可全不相同）
- 至多一个项可包含两个函数的乘/除（如 `x^5·ln x`、`ln x / x³`），约一半题目会包含
- 二阶导数题目保证至少一个非线性项，避免求导退化为 0
- 干扰项改为所有系数同向扰动，避免相邻同类项在 ±k 交替扰动下相互抵消

### 2. `/qm` 改为主界面
- 原默认开始模式迁移到 `/qm start`（支持 `--level <等级>` 指定初始等级）
- `/qm` 显示：玩法介绍 + 本周积分排行榜（新增 `QuickMathWeek` 表按 ISO 周累计）+ 模式介绍
- QQ 官方适配器：末尾附全部模式按钮；其他适配器：内容用 `md_to_pic` 渲染成图片，markdown 末尾附加全部模式的指令以替代按钮

### 3. 新增 PvP 对战模式（仅群聊）
- `/qm pvp create [最大人数]`：创建房间并生成房间码；QQ 适配器显示「加入」按钮代替房间码
- `/qm pvp join <房间码>`：仅可加入同群房间；入房后发送玩家列表，QQ 适配器显示「开始 / 加入 / 退出」按钮（加入按钮仅在未满员时显示）
- `/qm pvp quit`：退出房间，房主退出直接解散房间
- `/qm pvp start`：仅房主可用；开始后打乱并固定答题顺序，按顺序轮流 @ 玩家发题
  - 与普通模式类似，但升级周期更长（`qm_pvp_change_max_level_count`，默认 21）、不可复活
  - 题目等级 / 限时缩短 / 跳过次数按玩家独立计算
  - 重试机会用完后超时或答错即淘汰，保存其成绩并退出队列
  - 仅剩最后一人时结束，用 `md_to_pic` 发送得分排行与每人数据表格

## 其他
- 新增数据库迁移 `9f4e8c2a61b3d5f7`（QuickMathWeek 表）
- 补充 `help.yaml` 与 `src/lang/zh_hans/quick_math.yaml` 本地化条目
- PvP 等待答案时超时以 `PromptTimeout` 正常返回（`wait_answer` 新增 `ignore_error_details` 参数），避免超时中断整局对战

> 说明：en_us / zh_tw 由 Crowdin 管理，未直接修改。
