### PR TITLE
fix(chat): 修复回复过期重试后 receipt 未赋值导致的 UnboundLocalError

### DIFF
--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -530,9 +530,8 @@ class MessageProcessor:
             # 回复消息 msg_id 已过期等错误：去掉 reply 后重试
             # 注意：code 仅 QQ 适配器提供，其他适配器没有该字段
             if reply_message_id is not None and getattr(e, "code", None) == 40034005:
-                await self.send_message(message_content, None)
-            else:
-                raise
+                return await self.send_message(message_content, None)
+            raise
         # 记录回应用时（使用 reply_message_id 查找对应的原消息）
         self._record_reply_timing(reply_message_id)
 


### PR DESCRIPTION
## 问题

`nonebot_plugin_chat/core/processor.py` 的 `send_message` 在 QQ 官方机器人适配器返回错误码 `40034005`（`reply_message_id` 已过期）时，会递归调用 `self.send_message(message_content, None)` 去掉 reply 重试，但**没有接收递归调用的返回值**，外层调用继续执行 `receipt.msg_ids[0]`，此时 `receipt` 尚未赋值，抛出 `UnboundLocalError`：

```
UnboundLocalError: cannot access local variable 'receipt' where it is not associated with a value
  File "nonebot_plugin_openai/utils/chat.py", line 209, in call_function
    result = await self.func_index[name]["func"](**params)
  File "nonebot_plugin_chat/core/processor.py", line 540, in send_message
    msg_first = receipt.msg_ids[0]
```

该错误会在 AI 工具调用中发送消息时触发，导致整个工具调用失败。

## 修复

重试分支直接 `return await self.send_message(message_content, None)`，将递归重试的完整结果（消息发送成功文案等）返回给调用方，避免落入未赋值的 `receipt`；同时移除多余的 `else`，逻辑保持不变。

```python
except ActionFailed as e:
    # 回复消息 msg_id 已过期等错误：去掉 reply 后重试
    if reply_message_id is not None and getattr(e, "code", None) == 40034005:
        return await self.send_message(message_content, None)
    raise
```

重试的递归调用使用 `reply_message_id=None`，不会再进入该重试分支，正常完成后由递归调用自身完成计时、缓存、token 扣除等收尾工作。

## 验证

- `ruff format --check` 通过
- `ruff check` 相比 main 未引入新的告警（文件原有告警数由 36 降为 35）