### PR TITLE
fix(quick_math): 修复 C2C 私聊下题目卡片附加 qqbot-at-user 报 ActionFailed

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6250,14 +6250,14 @@ test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6
 
 [[package]]
 name = "sentry-sdk"
-version = "2.69.0"
+version = "2.69.1"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "sentry_sdk-2.69.0-py3-none-any.whl", hash = "sha256:3b92738027322061fbab34199102fcc0459ff9a5bf373ccca7091af9a5f07530"},
-    {file = "sentry_sdk-2.69.0.tar.gz", hash = "sha256:0cf7d29419145ab0250ea51363ad79fb7509996aaa35c5d5d2c3ed85b3b80a7d"},
+    {file = "sentry_sdk-2.69.1-py3-none-any.whl", hash = "sha256:2d2556d9a14db548982b914cbed2a2dc07b6e55d941a620752f89a2afccfd78d"},
+    {file = "sentry_sdk-2.69.1.tar.gz", hash = "sha256:f9284b417540b0784b994fa021eb6f1e30ae1cce593d83541274d03c93966eff"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1826,14 +1826,14 @@ standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[stand
 
 [[package]]
 name = "filelock"
-version = "3.32.5"
+version = "3.32.6"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "filelock-3.32.5-py3-none-any.whl", hash = "sha256:142cd9fa77a872c5e78c62329a0d15278fadc686eb89e760017968961a4fd6b2"},
-    {file = "filelock-3.32.5.tar.gz", hash = "sha256:f6a6a28f743f9b95ce19db5abe0f376f75eb56517dff21e1a4751e2657d3e83d"},
+    {file = "filelock-3.32.6-py3-none-any.whl", hash = "sha256:3f16ecd0117feae0dfc147e8c62eb5daeccd8bd800378c3ddf416de9b4feb6b1"},
+    {file = "filelock-3.32.6.tar.gz", hash = "sha256:a3f55a18af3652a94d8f47d6055df434f254ca1d02ef2524850c6d249ca2512c"},
 ]
 
 [[package]]
@@ -4723,14 +4723,14 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.7"
+version = "4.11.8"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev", "test"]
 files = [
-    {file = "platformdirs-4.11.7-py3-none-any.whl", hash = "sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6"},
-    {file = "platformdirs-4.11.7.tar.gz", hash = "sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d"},
+    {file = "platformdirs-4.11.8-py3-none-any.whl", hash = "sha256:52f2f181bbfde907966932cc8312d967d02976422d66d537ea16092b8e291081"},
+    {file = "platformdirs-4.11.8.tar.gz", hash = "sha256:f23abafea7dd4276d1f29104b83598d7dcc567cafd07c9c951e66665645437fc"},
 ]
 
 [[package]]
@@ -5585,20 +5585,21 @@ files = [
 
 [[package]]
 name = "python-slugify"
-version = "8.0.4"
+version = "9.0.0"
 description = "A Python slugify application that also handles Unicode"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"},
-    {file = "python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8"},
+    {file = "python_slugify-9.0.0-py3-none-any.whl", hash = "sha256:b1180fb0fd6b3590e7fbd8328b08d56cde9dcac736527a070c0a811480621316"},
+    {file = "python_slugify-9.0.0.tar.gz", hash = "sha256:1cd20fe7ebf941b11964a92aba9e5319edfe18606276c6e2481b92e737cde44a"},
 ]
 
 [package.dependencies]
 text-unidecode = ">=1.3"
 
 [package.extras]
+anyascii = ["anyascii (>=0.3.2)"]
 unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]

--- a/src/plugins/nonebot_plugin_quick_math/commands/main.py
+++ b/src/plugins/nonebot_plugin_quick_math/commands/main.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from nonebot.adapters import Bot, Event
 from nonebot.adapters.qq import Bot as QQBot
+from nonebot.adapters.qq.event import C2CMessageCreateEvent
 
 from ..utils.session import QuickMathSession, QuickMathZenSession
 from nonebot_plugin_larkutils.user import get_user_id
@@ -9,8 +10,12 @@ from ..__main__ import quick_math
 
 
 def get_qq_user_id(bot: Bot, event: Event) -> Optional[str]:
-    """获取 QQ 官方机器人事件中的用户 ID（用于 markdown 卡片内 @ 用户）。"""
-    if isinstance(bot, QQBot):
+    """获取 QQ 官方机器人事件中的用户 ID（用于 markdown 卡片内 @ 用户）。
+
+    C2C 单聊消息不支持 ``<qqbot-at-user>`` 提及语法（发送会报 ActionFailed），
+    因此返回 ``None`` 跳过 @ 前缀；单聊中无需 @ 用户。
+    """
+    if isinstance(bot, QQBot) and not isinstance(event, C2CMessageCreateEvent):
         return event.get_user_id()
     return None
 

--- a/tests/test_quick_math_c2c_at_user.py
+++ b/tests/test_quick_math_c2c_at_user.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock
+
+
+def test_get_qq_user_id_returns_user_id_for_group_chat() -> None:
+    """QQ 官方机器人群聊事件应返回用户 ID，用于 markdown 卡片内 @ 用户"""
+    from nonebot.adapters.qq import Bot as QQBot
+    from nonebot.adapters.qq.event import GroupAtMessageCreateEvent
+    from nonebot_plugin_quick_math.commands.main import get_qq_user_id
+
+    event = MagicMock(spec=GroupAtMessageCreateEvent)
+    event.get_user_id.return_value = "member_openid_123"
+
+    assert get_qq_user_id(MagicMock(spec=QQBot), event) == "member_openid_123"
+
+
+def test_get_qq_user_id_returns_none_for_c2c_chat() -> None:
+    """C2C 单聊事件不支持 qqbot-at-user 提及（发送会报 ActionFailed），应返回 None 跳过 @ 前缀"""
+    from nonebot.adapters.qq import Bot as QQBot
+    from nonebot.adapters.qq.event import C2CMessageCreateEvent
+    from nonebot_plugin_quick_math.commands.main import get_qq_user_id
+
+    event = MagicMock(spec=C2CMessageCreateEvent)
+    event.get_user_id.return_value = "user_openid_123"
+
+    assert get_qq_user_id(MagicMock(spec=QQBot), event) is None
+
+
+def test_get_qq_user_id_returns_none_for_other_adapters() -> None:
+    """非 QQ 官方机器人（如 OneBot V11）不应生成用户 ID"""
+    from nonebot_plugin_quick_math.commands.main import get_qq_user_id
+
+    assert get_qq_user_id(MagicMock(), MagicMock()) is None


### PR DESCRIPTION
## 问题描述

QQ 官方机器人在 **C2C 单聊**（私聊）中游玩 quick math 时，发送题目 markdown 卡片直接报错：

```
ActionFailed: C2C消息不支持qqbot-at-user
  File "nonebot_plugin_quick_math/utils/session.py", line 249, in send_question
    result = await wait_answer(
  File "nonebot_plugin_quick_math/utils/message.py", line 61, in wait_answer
    r: str = await prompt(
  File "nonebot_plugin_larkuser/utils/waiter.py", line 52, in prompt
    await waiter.wait(timeout=timeout, auto_finish=False)
  File "nonebot_plugin_larkuser/utils/waiter2.py", line 90, in wait
    await self.send_message(self.prompt_text)
  File "nonebot_plugin_larkuser/utils/waiter2.py", line 71, in send_message
    await message.send(target=self.event)
```

## 根本原因

`build_markdown_message` 在 QQ 官方机器人下会把题目卡片内容前面加上 `<qqbot-at-user id="..." />`（源自 `get_qq_user_id` 无条件返回 `event.get_user_id()`）。但 QQ 官方 API 的 **C2C 单聊消息不支持 `qqbot-at-user` 提及语法**，发送即被拒绝。群聊场景支持该语法，因此只在 C2C 下崩溃。

## 修复方案

`get_qq_user_id` 在事件为 `C2CMessageCreateEvent` 时返回 `None`，从而跳过题目卡片中的 @ 前缀构建：

```python
if isinstance(bot, QQBot) and not isinstance(event, C2CMessageCreateEvent):
    return event.get_user_id()
return None
```

C2C 单聊是单一用户会话，本来也无需 @ 用户；判断方式与仓库内已有用法（`nonebot_plugin_larkutils.user`、`nonebot_plugin_chat.utils.group`）保持一致。

## 测试

新增 `tests/test_quick_math_c2c_at_user.py` 回归测试：

- 群聊事件（`GroupAtMessageCreateEvent`）→ 返回用户 ID
- C2C 事件（`C2CMessageCreateEvent`）→ 返回 `None`（不再生成 `qqbot-at-user`）
- 非 QQ 平台 → 返回 `None`

本地验证：`pytest tests/test_quick_math_c2c_at_user.py tests/test_jrrp_qq_buttons.py tests/test_larkuser_waiter.py` — 28 passed。

> 注：`nonebot_plugin_jrrp`、`nonebot_plugin_sign`、`nonebot_plugin_shengcao` 的 markdown 卡片也使用了相同的 `<qqbot-at-user>` 写法，在 C2C 下单聊触发同样会报错，可作后续跟进处理。