### PR TITLE
fix: C2C 私聊下 jrrp/sign/shengcao 的 markdown 卡片附加 qqbot-at-user 报 ActionFailed

### DIFF
--- a/src/plugins/nonebot_plugin_jrrp/__main__.py
+++ b/src/plugins/nonebot_plugin_jrrp/__main__.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 from datetime import date
 from statistics import mean
 from logging import getLogger
 
 from nonebot.adapters import Bot, Event
 from nonebot.adapters.qq import Bot as QQBot
+from nonebot.adapters.qq.event import C2CMessageCreateEvent
 from nonebot_plugin_larkuser import get_user
 from nonebot_plugin_larkutils import get_user_id
 from nonebot_plugin_larkutils.command import get_command_prefix
@@ -44,7 +45,7 @@ def _extract_msg_id(result: Any) -> str | None:
     return getattr(result, "message_id", None)
 
 
-async def build_jrrp_message(bot: Bot, user_id: str) -> str | UniMessage:
+async def build_jrrp_message(bot: Bot, user_id: str, event: Optional[Event] = None) -> str | UniMessage:
     """构建 jrrp 回复消息。
 
     QQ 官方机器人: 保持原有文本不变，在最前面附加 @ (qqbot-at-user)，
@@ -55,9 +56,10 @@ async def build_jrrp_message(bot: Bot, user_id: str) -> str | UniMessage:
     if not isinstance(bot, QQBot):
         return await get_luck_message(user_id)
     prefix = get_command_prefix()
+    at_user = "" if isinstance(event, C2CMessageCreateEvent) else f'<qqbot-at-user id="{user_id}" />'
     return (
         UniMessage()
-        .style(f'<qqbot-at-user id="{user_id}" />{await get_luck_message(user_id)}', "markdown")
+        .style(f"{at_user}{await get_luck_message(user_id)}", "markdown")
         .keyboard(
             Button("enter", await lang.text("button.lucky_star", user_id), text=f"{prefix}jrrp r"),
             Button("enter", await lang.text("button.unlucky_one", user_id), text=f"{prefix}jrrp rr"),
@@ -75,7 +77,7 @@ async def process_jrrp_command(group_id: str, user_id: str, bot: Bot, event: Eve
 
     event_text = await lang.text("chat_event", user_id, await get_nickname(user_id, bot, event), luck_value)
 
-    message = await build_jrrp_message(bot, user_id)
+    message = await build_jrrp_message(bot, user_id, event)
     if isinstance(message, UniMessage):
         # 带 keyboard 的消息使用 UniMessage.send 发送，结束后单独调用 matcher.finish
         receipt = await message.send(target=event, bot=bot)

--- a/src/plugins/nonebot_plugin_shengcao/main.py
+++ b/src/plugins/nonebot_plugin_shengcao/main.py
@@ -1,12 +1,13 @@
 import json
 import random
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
 import jieba
 from nonebot import on_command
 from nonebot.adapters import Bot, Event, Message
 from nonebot.adapters.qq import Bot as QQBot
+from nonebot.adapters.qq.event import C2CMessageCreateEvent
 from nonebot.matcher import Matcher
 from nonebot.params import CommandArg
 from nonebot_plugin_alconna import Button, UniMessage
@@ -112,20 +113,28 @@ def fury_text(text: str) -> str:
     return "".join(result)
 
 
-async def _build_qq_message(user_id: str, output_text: str, original_text: str, mode: GrassMode) -> UniMessage:
+async def _build_qq_message(
+    user_id: str,
+    output_text: str,
+    original_text: str,
+    mode: GrassMode,
+    event: Optional[Event] = None,
+) -> UniMessage:
     """构建 QQ 官方机器人的 markdown + 键盘消息。
 
     - 生草结果以 markdown 渲染，需先转义特殊字符
     - 按钮 "再试一次" 重新生草，按钮 "狂怒模式" 切换到全量替换
     - 福瑞彩蛋下按钮文案替换为 UwU / OwO，再试一次切回 grass-furry
+    - C2C 单聊消息不支持 <qqbot-at-user> 提及语法，跳过 @ 前缀
     """
     prefix = get_command_prefix()
     retry_label = "UwU" if mode == "furry" else await lang.text("button.retry", user_id)
     fury_label = "OwO" if mode == "furry" else await lang.text("button.fury", user_id)
     retry_command = "grass-furry" if mode == "furry" else "grass"
+    at_user = "" if isinstance(event, C2CMessageCreateEvent) else f'<qqbot-at-user id="{user_id}" />'
     return (
         UniMessage()
-        .style(f'<qqbot-at-user id="{user_id}" />{escape_markdown(output_text)}', "markdown")
+        .style(f"{at_user}{escape_markdown(output_text)}", "markdown")
         .keyboard(
             Button("enter", retry_label, text=f"{prefix}{retry_command} {original_text}"),
             Button("enter", fury_label, text=f"{prefix}grass-fury {original_text}"),
@@ -143,7 +152,7 @@ async def _finish_result(
     mode: GrassMode,
 ) -> None:
     if isinstance(bot, QQBot):
-        message = await _build_qq_message(user_id, output_text, original_text, mode)
+        message = await _build_qq_message(user_id, output_text, original_text, mode, event)
         await message.send(target=event, bot=bot)
         await matcher.finish()
         return

--- a/src/plugins/nonebot_plugin_sign/__main__.py
+++ b/src/plugins/nonebot_plugin_sign/__main__.py
@@ -9,7 +9,7 @@ import httpx
 from nonebot import logger, on_type
 from nonebot.adapters import Bot, Event
 from nonebot.adapters.qq.bot import Bot as QQBot
-from nonebot.adapters.qq.event import InteractionCreateEvent
+from nonebot.adapters.qq.event import C2CMessageCreateEvent, InteractionCreateEvent
 from nonebot.adapters.qq.message import Message
 from nonebot.exception import FinishedException
 from nonebot.matcher import Matcher
@@ -418,11 +418,14 @@ class SignHandler:
     async def format_markdown(self, image_raw: bytes) -> None:
         if self._result is None:
             await lang.finish("sign.signed", self.user_id)
+        at_user = (
+            ""
+            if isinstance(self.event, C2CMessageCreateEvent)
+            else f'<qqbot-at-user id="{self.event.get_user_id()}" />'
+        )
         await (
             UniMessage()
-            .style(
-                f'<qqbot-at-user id="{self.event.get_user_id()}" />{await create_image_markdown(image_raw)}', "markdown"
-            )
+            .style(f"{at_user}{await create_image_markdown(image_raw)}", "markdown")
             .keyboard(*await self.build_button())
             .send()
         )

--- a/tests/test_grass_qq_buttons.py
+++ b/tests/test_grass_qq_buttons.py
@@ -61,6 +61,26 @@ async def test_build_qq_message_furry_uses_uwu_and_owo_labels(monkeypatch: pytes
 
 
 @pytest.mark.asyncio
+async def test_build_qq_message_c2c_skips_at_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """C2C 单聊消息不支持 qqbot-at-user 提及，应跳过 @ 前缀"""
+    from unittest.mock import MagicMock
+
+    from nonebot.adapters.qq.event import C2CMessageCreateEvent
+    from nonebot_plugin_alconna import Text, UniMessage
+    from nonebot_plugin_larkutils.command import config
+    from nonebot_plugin_shengcao.main import _build_qq_message
+
+    monkeypatch.setattr(config, "command_start", ["/"])
+
+    message = await _build_qq_message("10", "草*草", "原始文本", "grass", MagicMock(spec=C2CMessageCreateEvent))
+
+    assert isinstance(message, UniMessage)
+    text = next(seg for seg in message if isinstance(seg, Text))
+    assert text.text == "草\\*草"
+    assert any("markdown" in styles for styles in text.styles.values())
+
+
+@pytest.mark.asyncio
 async def test_fury_text_replaces_all_with_uniform_random_pool() -> None:
     """狂怒模式：命中词典的词必须全部被替换；合并释义池等概率随机选取（同义/近义均可能出现）"""
     from nonebot_plugin_shengcao.main import _dict_data, fury_text

--- a/tests/test_jrrp_qq_buttons.py
+++ b/tests/test_jrrp_qq_buttons.py
@@ -47,6 +47,29 @@ async def test_build_jrrp_message_qq_prepends_at_and_adds_buttons(monkeypatch: p
 
 
 @pytest.mark.asyncio
+async def test_build_jrrp_message_c2c_skips_at_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """C2C 单聊消息不支持 qqbot-at-user 提及，QQ 官方机器人下应跳过 @ 前缀"""
+    from nonebot.adapters.qq import Bot as QQBot
+    from nonebot.adapters.qq.event import C2CMessageCreateEvent
+    from nonebot_plugin_alconna import Text, UniMessage
+    from nonebot_plugin_jrrp.__main__ import build_jrrp_message
+    from nonebot_plugin_larkutils.command import config
+
+    monkeypatch.setattr("nonebot_plugin_jrrp.__main__.get_luck_message", AsyncMock(return_value="你今天的人品值是: 66"))
+    monkeypatch.setattr(config, "command_start", ["/"])
+
+    message = await build_jrrp_message(
+        bot=MagicMock(spec=QQBot),
+        user_id="10",
+        event=MagicMock(spec=C2CMessageCreateEvent),
+    )
+
+    assert isinstance(message, UniMessage)
+    text = next(seg for seg in message if isinstance(seg, Text))
+    assert text.text == "你今天的人品值是: 66"
+
+
+@pytest.mark.asyncio
 async def test_build_jrrp_message_plain_text_on_other_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
     """非 QQ 平台应保持原有纯文本消息（由 matcher.send(at_sender=True) 附加 @）"""
     from nonebot_plugin_jrrp.__main__ import build_jrrp_message

--- a/tests/test_sign_resign_prompt.py
+++ b/tests/test_sign_resign_prompt.py
@@ -83,3 +83,58 @@ async def test_build_button_adds_email_when_unread(monkeypatch: pytest.MonkeyPat
     assert len(buttons) == 3
     assert str(buttons[-1].label) == "text::button.email"
     assert buttons[-1].text == "/email"
+
+
+def _make_markdown_handler(monkeypatch: pytest.MonkeyPatch, event: MagicMock) -> tuple[object, list]:
+    """构造可调用 format_markdown 的 SignHandler，隔离图片生成/邮件查询/消息发送"""
+    from nonebot_plugin_alconna import UniMessage
+
+    from nonebot_plugin_sign.__main__ import SignHandler
+
+    monkeypatch.setattr("nonebot_plugin_sign.__main__.create_image_markdown", AsyncMock(return_value="![签到卡片]"))
+    monkeypatch.setattr("nonebot_plugin_sign.__main__.get_unread_email_count", AsyncMock(return_value=0))
+
+    sent: list[UniMessage] = []
+
+    async def fake_send(self: UniMessage, *_args: object, **_kwargs: object) -> None:
+        sent.append(self)
+
+    monkeypatch.setattr(UniMessage, "send", fake_send)
+
+    matcher = MagicMock()
+    matcher.finish = AsyncMock()
+    handler = SignHandler(user_id="10", bot=MagicMock(), event=event, matcher=matcher)
+    handler._result = {"sign_days": 1}  # ruff: ignore[private-member-access]
+    return handler, sent
+
+
+@pytest.mark.asyncio
+async def test_format_markdown_c2c_skips_at_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """C2C 单聊消息不支持 qqbot-at-user 提及，签到卡片应跳过 @ 前缀"""
+    from nonebot.adapters.qq.event import C2CMessageCreateEvent
+    from nonebot_plugin_alconna import Text
+
+    handler, sent = _make_markdown_handler(monkeypatch, event=MagicMock(spec=C2CMessageCreateEvent))
+
+    await handler.format_markdown(b"image")
+
+    text = next(seg for seg in sent[0] if isinstance(seg, Text))
+    assert text.text == "![签到卡片]"
+    handler.matcher.finish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_format_markdown_group_chat_prepends_at_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """群聊消息应保留 qqbot-at-user @ 前缀"""
+    from nonebot.adapters.qq.event import GroupAtMessageCreateEvent
+    from nonebot_plugin_alconna import Text
+
+    event = MagicMock(spec=GroupAtMessageCreateEvent)
+    event.get_user_id.return_value = "member_openid_1"
+    handler, sent = _make_markdown_handler(monkeypatch, event=event)
+
+    await handler.format_markdown(b"image")
+
+    text = next(seg for seg in sent[0] if isinstance(seg, Text))
+    assert text.text == '<qqbot-at-user id="member_openid_1" />![签到卡片]'
+    handler.matcher.finish.assert_awaited_once()


### PR DESCRIPTION
## 问题描述

延续 #1410（quick math）中发现的同类问题：其余三个插件在 QQ 官方机器人下构建 markdown 卡片时也会附加 `<qqbot-at-user id="..." />`，在 **C2C 单聊**（私聊）场景下发送同样会报：

```
ActionFailed: C2C消息不支持qqbot-at-user
```

涉及位置（此前已在 #1410 中标注为后续跟进）：
- `nonebot_plugin_jrrp` — 人品卡片（`build_jrrp_message`）
- `nonebot_plugin_sign` — 签到卡片（`SignHandler.format_markdown`）
- `nonebot_plugin_shengcao` — 生草/狂怒/福瑞结果卡片（`_build_qq_message`）

## 修复方案

与 #1410 相同的思路：构建 markdown 卡片时，若事件为 `C2CMessageCreateEvent` 则跳过 `qqbot-at-user` 前缀（C2C 单聊为单人会话，无需 @ 用户）：

```python
at_user = "" if isinstance(event, C2CMessageCreateEvent) else f'<qqbot-at-user id="{user_id}" />'
```

- jrrp / shengcao：`build_jrrp_message`、`_build_qq_message` 新增可选 `event` 参数，由调用方（handler 已有 event）传入；
- sign：直接使用 handler 持有的 `self.event` 判断。

群聊行为完全不变（仍保留 @ 前缀），markdown 卡片与键盘按钮在 C2C 下依旧正常发送。

## 测试

三个测试文件各自新增 C2C 回归用例（群聊保留 @ / C2C 跳过 @）：

- `tests/test_jrrp_qq_buttons.py`：+1
- `tests/test_grass_qq_buttons.py`：+1
- `tests/test_sign_resign_prompt.py`：+2

本地验证：`pytest tests/test_jrrp_qq_buttons.py tests/test_grass_qq_buttons.py tests/test_sign_resign_prompt.py` — **16 passed**。