### PR TITLE
fix(larkhelp): 转义用法中的方括号，修复 QQ 上 [可选参数] (说明) 被渲染成链接导致显示丢失

### DIFF
--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -40,6 +40,27 @@ def urlencode_cmd(text: str) -> str:
     return re.sub(r"[<>&\"'%]", lambda m: f"%{ord(m.group()):02X}", text)
 
 
+def strip_usage_explanation(text: str) -> str:
+    """移除用法字符串末尾的 (说明) 部分，用于生成指令组件的 text 属性。
+
+    仅删除结尾的解释括号组，避免旧的 `\(.*?\)` 实现把参数占位符内的括号注解
+    （如 `[-l|--last <持续(小时)>]` 中的 `(小时)`）一并删掉。
+    """
+    return re.sub(r"\s*\([^)]*\)\s*$", "", text).strip()
+
+
+def escape_show_brackets(text: str) -> str:
+    """转义用法中的方括号，避免 QQ 平台解析 `<qqbot-cmd-input>` 标签时把属性内容当 markdown 链接处理。
+
+    QQ 平台在解析标签属性时会按 markdown 处理其中的文本。当 show 值形如
+    `quick-math [--level <开始的等级>] (开始挑战)` 时，`[...]` 后紧跟 `(...)` 会被
+    识别成链接 `[label](dest)`，导致该标签无法被解析成指令组件，整段
+    `<qqbot-cmd-input ... />` 原文直接显示在消息里。转义为 `\[` `\]` 后不再构成
+    链接，标签正常解析，方括号与说明文字按字面展示。
+    """
+    return text.replace("[", r"\[").replace("]", r"\]")
+
+
 help_list = {}
 
 
@@ -77,10 +98,8 @@ async def help_command_handler(bot: Bot, command: str, user_id: str = get_user_i
                         await lang.text(
                             "command.usage_item",
                             user_id,
-                            urlencode_cmd(
-                                re.sub(r"\(.*?\)", "", usage_str := await helper.text(usage, user_id)).strip()
-                            ),
-                            urlencode_cmd(usage_str),
+                            urlencode_cmd(strip_usage_explanation(usage_str := await helper.text(usage, user_id))),
+                            urlencode_cmd(escape_show_brackets(usage_str)),
                         )
                         for usage in data.usages
                     ]

--- a/tests/test_larkhelp_qq_cmd_input.py
+++ b/tests/test_larkhelp_qq_cmd_input.py
@@ -1,18 +1,24 @@
-"""nonebot_plugin_larkhelp 的 QQ 指令组件（<qqbot-cmd-input>）属性值 urlencode 回归测试
+"""nonebot_plugin_larkhelp 的 QQ 指令组件（<qqbot-cmd-input>）属性值回归测试
 
-QQ 官方要求 <qqbot-cmd-input> 的 text/show 属性值需 urlencode 后传递，否则当用法
-包含尖括号占位符（如 `shop buy <编号> [数量]`）时平台返回
-"qqbot-cmd-input参数解析失败"（ActionFailed），即 /help shop 的线上报错。
+1. urlencode：QQ 官方要求 <qqbot-cmd-input> 的 text/show 属性值需 urlencode 后传递，
+   否则当用法包含尖括号占位符（如 `shop buy <编号> [数量]`）时平台返回
+   "qqbot-cmd-input参数解析失败"（ActionFailed），即 /help shop 的线上报错。
+2. 标签解析：平台解析标签属性时会按 markdown 处理其中文本，用法中 `[可选参数]`
+   后紧跟 `(说明)`（如 `quick-math [--level <开始的等级>] (开始挑战)`）会被识别成
+   链接导致整个标签无法解析、原文直接显示，因此 show 中的方括号需转义，
+   text 只移除用法末尾的 (说明)。
 """
 
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock
+import re
 
 import pytest
 
 _SHOP_TEXT = {
     "help.usage1": "shop (查看商品列表)",
     "help.usage2": "shop buy <编号> [数量] (购买商品)",
+    "help.usage3": "shop rank [--total] (积分排行榜)",
     "help.description": "商店与商品",
     "help.details": "查看商品并购买",
 }
@@ -54,7 +60,7 @@ def larkhelp_env(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, list[tuple[str, 
             plugin="shop",
             description="help.description",
             details="help.details",
-            usages=["help.usage1", "help.usage2"],
+            usages=["help.usage1", "help.usage2", "help.usage3"],
             category="community",
         ),
     }
@@ -98,6 +104,33 @@ def test_urlencode_cmd_encodes_tag_breaking_chars_only() -> None:
     assert urlencode_cmd("line1\nline2\r\nline3") == "line1 line2 line3"
 
 
+def test_escape_show_brackets_escapes_square_brackets_only() -> None:
+    """show 中的方括号需转义，避免 `[...]` 与 `(...)` 组成链接导致标签无法解析、原文显示"""
+    from nonebot_plugin_larkhelp.__main__ import escape_show_brackets
+
+    assert escape_show_brackets("quick-math [--level <开始的等级>] (开始挑战)") == (
+        r"quick-math \[--level <开始的等级>\] (开始挑战)"
+    )
+    assert escape_show_brackets("quick-math rank [--total] (积分排行榜)") == (
+        r"quick-math rank \[--total\] (积分排行榜)"
+    )
+    assert escape_show_brackets("quick-math points (查看总分详情)") == "quick-math points (查看总分详情)"
+    assert escape_show_brackets("quick-math zen <等级> (禅模式)") == "quick-math zen <等级> (禅模式)"
+
+
+def test_strip_usage_explanation_only_strips_trailing_parens() -> None:
+    """text 属性只移除用法末尾的 (说明)，保留占位符内的括号注解（如 <持续(小时)>）"""
+    from nonebot_plugin_larkhelp.__main__ import strip_usage_explanation
+
+    assert strip_usage_explanation("quick-math [--level <开始的等级>] (开始挑战)") == (
+        "quick-math [--level <开始的等级>]"
+    )
+    assert strip_usage_explanation("shop (查看商品列表)") == "shop"
+    assert strip_usage_explanation("vote create [-g|--global] [-l|--last <持续(小时)>] [标题] (创建投票)") == (
+        "vote create [-g|--global] [-l|--last <持续(小时)>] [标题]"
+    )
+
+
 def _assert_no_raw_breaking_chars(args: tuple[object, ...]) -> None:
     for value in args:
         assert not any(ch in str(value) for ch in _TAG_BREAKING_CHARS), args
@@ -114,7 +147,8 @@ async def test_help_shop_qq_usage_item_is_urlencoded(larkhelp_env: object) -> No
     usage_items = [args for key, args in lang_calls if key == "command.usage_item"]
     assert usage_items == [
         ("shop", "shop (查看商品列表)"),
-        ("shop buy %3C编号%3E [数量]", "shop buy %3C编号%3E [数量] (购买商品)"),
+        ("shop buy %3C编号%3E [数量]", "shop buy %3C编号%3E \\[数量\\] (购买商品)"),
+        ("shop rank [--total]", "shop rank \\[--total\\] (积分排行榜)"),
     ]
     for item in usage_items:
         _assert_no_raw_breaking_chars(item)
@@ -123,11 +157,13 @@ async def test_help_shop_qq_usage_item_is_urlencoded(larkhelp_env: object) -> No
     markdown = module.UniMessage.sent[0]
     assert (
         '<qqbot-cmd-input text="/shop buy %3C编号%3E [数量]" '
-        'show="/shop buy %3C编号%3E [数量] (购买商品)" reference="false" />' in markdown
+        'show="/shop buy %3C编号%3E \\[数量\\] (购买商品)" reference="false" />' in markdown
     )
     assert '<qqbot-cmd-input text="/shop" show="/shop (查看商品列表)" reference="false" />' in markdown
     # 属性值内不允许出现未编码的尖括号
     assert 'text="/shop buy <编号>' not in markdown
+    # 标签属性内不允许出现未被转义的 [可选参数] 后跟 (说明)（会被平台当作链接解析导致标签无法解析）
+    assert not re.search(r"(?<!\\)\[[^\n\]]*\]\s*\(", markdown), markdown
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

QQ 官方机器人上执行 `/help quick-math` 时，带可选参数的用法显示错误：带 `[--level]` 的用法与 `rank` 的用法，整个 `<qqbot-cmd-input ... />` **没有被解析成可点击的指令组件，标签原文直接显示**在消息里（`text` 属性里仍是未解码的 `%3C`）。不带 `[可选参数]` 的用法（`points`、`zen`）正常。

## 根因

QQ 平台在解析 `<qqbot-cmd-input>` 标签属性时会按 markdown 处理其中的文本。当 show 值形如 `quick-math [--level <开始的等级>] (开始挑战)` 时，`[...]` 后紧跟 `(...)` 被识别为链接 `[label](dest)`，导致整个标签无法被解析成指令组件，标签原文直接显示在消息里。

## 影响范围（类似问题）

这是 larkhelp 层的通用问题，所有“可选参数后跟说明”的用法在 QQ 帮助里都会以同样方式显示错：`bingo`、`ct`、`chat`、`eggstrike`、`bag`、`ghot`、`linuxman`、`preview`、`shop`、`summary`、`tol`、`vote`、`quick-math` 等（zh_hans/zh_tw/en_us 共 79 处命中同一模式，代码层修复对所有语言同时生效）。

## 修复

`src/plugins/nonebot_plugin_larkhelp/__main__.py`：

1. **show 中的方括号转义**：新增 `escape_show_brackets()`，将 `[`/`]` 转义为 `\[`/`\]`。转义后不再构成链接，标签可正常解析，方括号与说明文字按字面展示。
2. **text 的说明剥离只作用于末尾**：新增 `strip_usage_explanation()`，`re.sub(r"\s*\([^)]*\)\s*$", "", ...)` 仅删除用法**末尾**的 `(说明)`，避免旧实现 `re.sub(r"\(.*?\)", ...)` 误删参数占位符内的括号注解（如 `vote create [-l|--last <持续(小时)>]` 中的 `(小时)`，此前点击该指令会得到残缺的 `[-l|--last <持续>]`）。

## 测试

- 更新 `tests/test_larkhelp_qq_cmd_input.py`：断言 show 中 `[数量]`/`[--total]` 已转义、text 保持原始方括号；
- 新增发送 markdown 级断言：其中**不存在未转义的 `[可选参数] (说明)` 序列**（即平台解析失败的直接诱因）；
- 新增 `escape_show_brackets` 与 `strip_usage_explanation` 单元测试（覆盖报告中的 quick-math 四条用法与 vote 的内嵌注解场景）。
- `tests/test_larkhelp_qq_cmd_input.py` 全部 6 项通过；两文件通过 black（pre-commit 固定 26.5.1）检查。
