### PR TITLE
feat(md): 新增 /md 指令用于测试 QQ 官方机器人 Markdown 渲染

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -416,6 +416,11 @@ Moonlark 投票
 - `/bcsu clear (清除广播内容)`
 - `/bcsu preview (预览广播内容)`
 - `/bcsu submit (提交并发送广播)`
+## `md`: Markdown 渲染测试
+
+将参数中的 Markdown 原样发送到当前群聊，用于测试 QQ 官方机器人的 Markdown 渲染效果（仅超管可用）
+> 此指令仅 Moonlark 管理员可用。
+- `/md <Markdown内容> (将 Markdown 原样发送到当前群聊测试渲染效果)`
 ## `model`: 模型管理
 
 管理 OpenAI 模型配置（仅限超级用户）

--- a/poetry.lock
+++ b/poetry.lock
@@ -6250,14 +6250,14 @@ test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6
 
 [[package]]
 name = "sentry-sdk"
-version = "2.68.1"
+version = "2.69.0"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "sentry_sdk-2.68.1-py3-none-any.whl", hash = "sha256:775b78871783a0ffd758276ad01b3bb2b1ebcdad8f9d2f0a7723f76b73c99b65"},
-    {file = "sentry_sdk-2.68.1.tar.gz", hash = "sha256:6a97895230b04bc35d4d8d2e51e3b9e21902dfb0086ccf1f131a80c15c7b997a"},
+    {file = "sentry_sdk-2.69.0-py3-none-any.whl", hash = "sha256:3b92738027322061fbab34199102fcc0459ff9a5bf373ccca7091af9a5f07530"},
+    {file = "sentry_sdk-2.69.0.tar.gz", hash = "sha256:0cf7d29419145ab0250ea51363ad79fb7509996aaa35c5d5d2c3ed85b3b80a7d"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ plugins = [
     "nonebot_plugin_auto_bind",
     "nonebot_plugin_eggstrike",
     "nonebot_plugin_shengcao",
+    "nonebot_plugin_md",
 ]
 plugin_dirs = []
 builtin_plugins = []

--- a/src/lang/zh_hans/md.yaml
+++ b/src/lang/zh_hans/md.yaml
@@ -1,0 +1,6 @@
+empty: 请输入要测试渲染的 Markdown 内容~
+unsupported_platform: 该指令仅支持 QQ 官方机器人使用~
+help:
+  description: Markdown 渲染测试
+  details: 将参数中的 Markdown 原样发送到当前群聊，用于测试 QQ 官方机器人的 Markdown 渲染效果（仅超管可用）
+  usage1: md <Markdown内容> (将 Markdown 原样发送到当前群聊测试渲染效果)

--- a/src/plugins/nonebot_plugin_md/__init__.py
+++ b/src/plugins/nonebot_plugin_md/__init__.py
@@ -1,0 +1,31 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from nonebot import require
+from nonebot.plugin import PluginMetadata
+
+__plugin_meta__ = PluginMetadata(
+    name="nonebot-plugin-md",
+    description="QQ 官方机器人 Markdown 渲染测试（仅超管可用）",
+    usage="/md <Markdown内容>",
+)
+
+require("nonebot_plugin_larkutils")
+require("nonebot_plugin_larklang")
+require("nonebot_plugin_alconna")
+
+from . import __main__ as __main__

--- a/src/plugins/nonebot_plugin_md/__main__.py
+++ b/src/plugins/nonebot_plugin_md/__main__.py
@@ -20,14 +20,14 @@ from nonebot.adapters import Bot, Event, Message
 from nonebot.adapters.qq import Bot as QQBot
 from nonebot.matcher import Matcher
 from nonebot.params import CommandArg
-from nonebot.permission import SUPERUSER
 from nonebot_plugin_alconna import UniMessage
 from nonebot_plugin_larklang import LangHelper
 from nonebot_plugin_larkutils import get_user_id
+from nonebot_plugin_larkutils.superuser import is_superuser
 
 lang = LangHelper()
 
-md_cmd = on_command("md", permission=SUPERUSER)
+md_cmd = on_command("md", permission=is_superuser)
 
 
 @md_cmd.handle()

--- a/src/plugins/nonebot_plugin_md/__main__.py
+++ b/src/plugins/nonebot_plugin_md/__main__.py
@@ -1,0 +1,51 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from nonebot import on_command
+from nonebot.adapters import Bot, Event, Message
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot.matcher import Matcher
+from nonebot.params import CommandArg
+from nonebot.permission import SUPERUSER
+from nonebot_plugin_alconna import UniMessage
+from nonebot_plugin_larklang import LangHelper
+from nonebot_plugin_larkutils import get_user_id
+
+lang = LangHelper()
+
+md_cmd = on_command("md", permission=SUPERUSER)
+
+
+@md_cmd.handle()
+async def _handle_md(
+    bot: Bot,
+    event: Event,
+    user_id: str = get_user_id(),
+    message: Message = CommandArg(),
+) -> None:
+    """将参数中的 Markdown 原样发送到当前会话，用于测试 QQ 官方机器人的 Markdown 渲染效果。"""
+    await _process_md(md_cmd, bot, event, user_id, message.extract_plain_text().strip())
+
+
+async def _process_md(matcher: Matcher, bot: Bot, event: Event, user_id: str, content: str) -> None:
+    """/md 命令核心逻辑：仅支持 QQ 官方机器人，其余平台与空参数直接提示。"""
+    if not isinstance(bot, QQBot):
+        await lang.finish("unsupported_platform", user_id)
+    if not content.strip():
+        await lang.finish("empty", user_id)
+    await UniMessage().style(content, "markdown").send(target=event, bot=bot)
+    await matcher.finish()

--- a/src/plugins/nonebot_plugin_md/help.yaml
+++ b/src/plugins/nonebot_plugin_md/help.yaml
@@ -1,0 +1,3 @@
+plugin: md
+commands:
+  md: help;1;superuser

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -130,6 +130,7 @@ packages = [
     { include = "nonebot_plugin_auto_bind", from = "./plugins" },
     { include = "nonebot_plugin_eggstrike", from = "./plugins" },
     { include = "nonebot_plugin_shengcao", from = "./plugins" },
+    { include = "nonebot_plugin_md", from = "./plugins" },
 ]
 
 

--- a/tests/test_md_command.py
+++ b/tests/test_md_command.py
@@ -1,0 +1,132 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from nonebot.exception import FinishedException
+
+
+@pytest.fixture(autouse=True)
+def patched_lang(monkeypatch: pytest.MonkeyPatch) -> None:
+    """替换 md 插件的 LangHelper.text，避免依赖数据库读取语言文本
+
+    注意：插件导入必须在函数/fixture 内部进行（collection 阶段 nonebot 插件尚未加载）。
+    """
+    from nonebot_plugin_md.__main__ import lang
+
+    async def fake_text(key: str, _user_id: str, *_args: object, **_kwargs: object) -> str:
+        return f"text::{key}"
+
+    monkeypatch.setattr(lang, "text", fake_text)
+
+
+def _raising_finish() -> AsyncMock:
+    """模拟真实 LangHelper.finish：调用后抛出 FinishedException 以终止处理器流程"""
+    return AsyncMock(side_effect=FinishedException())
+
+
+def test_md_command_registered_with_superuser_permission() -> None:
+    """/md 指令应存在，且权限包含 NoneBot 标准 SUPERUSER 检查"""
+    from nonebot.permission import Permission
+    from nonebot_plugin_md.__main__ import md_cmd
+
+    assert md_cmd
+    permission = md_cmd.permission
+    assert isinstance(permission, Permission)
+    # 权限检查器应包含 Superuser()（即 nonebot.permission.SUPERUSER）
+    assert any("Superuser" in str(checker) for checker in permission.checkers)
+
+
+@pytest.mark.asyncio
+async def test_process_md_non_qq_platform_rejects(monkeypatch: pytest.MonkeyPatch) -> None:
+    """非 QQ 官方机器人（如 OneBot V11）使用 /md 应提示 unsupported_platform 且不发送消息"""
+    from unittest.mock import MagicMock
+
+    from nonebot_plugin_md.__main__ import _process_md, lang
+
+    finish = _raising_finish()
+    monkeypatch.setattr(lang, "finish", finish)
+
+    matcher = MagicMock()
+    # MagicMock 不是 nonebot.adapters.qq.Bot 的实例，应走到 unsupported_platform 分支
+    with pytest.raises(FinishedException):
+        await _process_md(matcher, MagicMock(), MagicMock(), "10", "## 标题")
+
+    assert finish.call_args.args == ("unsupported_platform", "10")
+    matcher.finish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_md_empty_content_prompts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """空参数应提示 empty，且不发送任何 markdown 消息"""
+    from unittest.mock import MagicMock
+
+    from nonebot_plugin_md.__main__ import _process_md, lang
+
+    class FakeQQBot:
+        """模拟 QQ 官方机器人 Bot 实例"""
+
+    finish = _raising_finish()
+    monkeypatch.setattr(lang, "finish", finish)
+    # 将模块内的 QQBot 指向假类，使 isinstance 检查通过
+    monkeypatch.setattr("nonebot_plugin_md.__main__.QQBot", FakeQQBot)
+    # 使用假的 UniMessage 观察 style/send 调用
+    sent: list[tuple] = []
+
+    class FakeUniMessage:
+        def style(self, content: str, style: str) -> "FakeUniMessage":
+            self.content = content
+            self.style = style
+            return self
+
+        async def send(self, target: object = None, bot: object = None) -> None:
+            sent.append((self.content, self.style, target, bot))
+
+    monkeypatch.setattr("nonebot_plugin_md.__main__.UniMessage", FakeUniMessage)
+
+    event = MagicMock()
+    matcher = MagicMock()
+    with pytest.raises(FinishedException):
+        await _process_md(matcher, FakeQQBot(), event, "10", "   ")
+
+    assert finish.call_args.args == ("empty", "10")
+    assert sent == []
+    matcher.finish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_md_qq_sends_raw_markdown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """QQ 官方机器人下应将参数中的 Markdown 原样以 markdown 样式发送到当前会话并结束处理器"""
+    from unittest.mock import MagicMock
+
+    from nonebot_plugin_md.__main__ import _process_md, lang
+
+    class FakeQQBot:
+        """模拟 QQ 官方机器人 Bot 实例"""
+
+    finish = AsyncMock()
+    monkeypatch.setattr(lang, "finish", finish)
+    monkeypatch.setattr("nonebot_plugin_md.__main__.QQBot", FakeQQBot)
+
+    sent: list[tuple] = []
+
+    class FakeUniMessage:
+        def style(self, content: str, style: str) -> "FakeUniMessage":
+            self.content = content
+            self.style = style
+            return self
+
+        async def send(self, target: object = None, bot: object = None) -> None:
+            sent.append((self.content, self.style, target, bot))
+
+    monkeypatch.setattr("nonebot_plugin_md.__main__.UniMessage", FakeUniMessage)
+
+    matcher = MagicMock()
+    matcher.finish = AsyncMock()
+    event = MagicMock()
+    bot = FakeQQBot()
+    content = "## 标题\n\n**加粗** [链接](https://example.com) `代码`"
+    await _process_md(matcher, bot, event, "10", content)
+
+    # Markdown 原样发送，不转义不加工
+    assert sent == [(content, "markdown", event, bot)]
+    finish.assert_not_called()
+    matcher.finish.assert_awaited_once()

--- a/tests/test_md_command.py
+++ b/tests/test_md_command.py
@@ -23,16 +23,17 @@ def _raising_finish() -> AsyncMock:
     return AsyncMock(side_effect=FinishedException())
 
 
-def test_md_command_registered_with_superuser_permission() -> None:
-    """/md 指令应存在，且权限包含 NoneBot 标准 SUPERUSER 检查"""
+def test_md_command_registered_with_larkutils_superuser_permission() -> None:
+    """/md 指令应存在，且使用 larkutils 的 is_superuser 校验超管（先映射主账号再比对 SUPERUSERS）"""
     from nonebot.permission import Permission
+    from nonebot_plugin_larkutils.superuser import is_superuser
     from nonebot_plugin_md.__main__ import md_cmd
 
     assert md_cmd
     permission = md_cmd.permission
     assert isinstance(permission, Permission)
-    # 权限检查器应包含 Superuser()（即 nonebot.permission.SUPERUSER）
-    assert any("Superuser" in str(checker) for checker in permission.checkers)
+    # 权限检查器应包含 larkutils 的 is_superuser
+    assert any(checker.call is is_superuser for checker in permission.checkers)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 简介

新增一个仅超管可用的 /md 指令，用于将参数中的 Markdown **原样**发送到当前 QQ 群聊，方便测试 QQ 官方机器人的 Markdown 渲染效果。

## 变更内容

- 新增插件 nonebot_plugin_md：
  - __main__.py：使用 on_command("md", permission=is_superuser) 注册指令（larkutils 超管判断，先映射主账号再比对 SUPERUSERS），处理器通过 CommandArg 获取参数
  - 仅支持 QQ 官方适配器（nonebot.adapters.qq）：其余平台提示「该指令仅支持 QQ 官方机器人使用」
  - 空参数提示用法；有内容时以 UniMessage().style(content, "markdown") 发送到当前会话
- 本地化：新增 src/lang/zh_hans/md.yaml（空参数 / 平台限制提示与帮助文案）
- 帮助文档：新增 help.yaml（分类 superuser），并重新生成 COMMANDS.md
- 注册插件：更新根 pyproject.toml 的 [tool.nonebot] plugins 与 src/pyproject.toml 的 packages
- 测试：新增 tests/test_md_command.py（larkutils 超管权限、非 QQ 平台拒绝、空参数提示、QQ 下原样发送 Markdown）

## 验证

- 本地 pytest tests/：全部通过
- nb larkhelp-generate zh_hans COMMANDS.md 重新生成指令列表，仅新增 md 条目