### PR TITLE
fix(larkhelp): 将用法说明移出 <qqbot-cmd-input> 标签，修复 QQ 上 [可选参数] (说明) 被渲染成链接导致显示丢失

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1826,14 +1826,14 @@ standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[stand
 
 [[package]]
 name = "filelock"
-version = "3.32.5"
+version = "3.32.6"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "filelock-3.32.5-py3-none-any.whl", hash = "sha256:142cd9fa77a872c5e78c62329a0d15278fadc686eb89e760017968961a4fd6b2"},
-    {file = "filelock-3.32.5.tar.gz", hash = "sha256:f6a6a28f743f9b95ce19db5abe0f376f75eb56517dff21e1a4751e2657d3e83d"},
+    {file = "filelock-3.32.6-py3-none-any.whl", hash = "sha256:3f16ecd0117feae0dfc147e8c62eb5daeccd8bd800378c3ddf416de9b4feb6b1"},
+    {file = "filelock-3.32.6.tar.gz", hash = "sha256:a3f55a18af3652a94d8f47d6055df434f254ca1d02ef2524850c6d249ca2512c"},
 ]
 
 [[package]]
@@ -4723,14 +4723,14 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.7"
+version = "4.11.8"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev", "test"]
 files = [
-    {file = "platformdirs-4.11.7-py3-none-any.whl", hash = "sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6"},
-    {file = "platformdirs-4.11.7.tar.gz", hash = "sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d"},
+    {file = "platformdirs-4.11.8-py3-none-any.whl", hash = "sha256:52f2f181bbfde907966932cc8312d967d02976422d66d537ea16092b8e291081"},
+    {file = "platformdirs-4.11.8.tar.gz", hash = "sha256:f23abafea7dd4276d1f29104b83598d7dcc567cafd07c9c951e66665645437fc"},
 ]
 
 [[package]]
@@ -5585,20 +5585,21 @@ files = [
 
 [[package]]
 name = "python-slugify"
-version = "8.0.4"
+version = "9.0.0"
 description = "A Python slugify application that also handles Unicode"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"},
-    {file = "python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8"},
+    {file = "python_slugify-9.0.0-py3-none-any.whl", hash = "sha256:b1180fb0fd6b3590e7fbd8328b08d56cde9dcac736527a070c0a811480621316"},
+    {file = "python_slugify-9.0.0.tar.gz", hash = "sha256:1cd20fe7ebf941b11964a92aba9e5319edfe18606276c6e2481b92e737cde44a"},
 ]
 
 [package.dependencies]
 text-unidecode = ">=1.3"
 
 [package.extras]
+anyascii = ["anyascii (>=0.3.2)"]
 unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
@@ -6250,14 +6251,14 @@ test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6
 
 [[package]]
 name = "sentry-sdk"
-version = "2.69.0"
+version = "2.69.1"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "sentry_sdk-2.69.0-py3-none-any.whl", hash = "sha256:3b92738027322061fbab34199102fcc0459ff9a5bf373ccca7091af9a5f07530"},
-    {file = "sentry_sdk-2.69.0.tar.gz", hash = "sha256:0cf7d29419145ab0250ea51363ad79fb7509996aaa35c5d5d2c3ed85b3b80a7d"},
+    {file = "sentry_sdk-2.69.1-py3-none-any.whl", hash = "sha256:2d2556d9a14db548982b914cbed2a2dc07b6e55d941a620752f89a2afccfd78d"},
+    {file = "sentry_sdk-2.69.1.tar.gz", hash = "sha256:f9284b417540b0784b994fa021eb6f1e30ae1cce593d83541274d03c93966eff"},
 ]
 
 [package.dependencies]

--- a/src/lang/zh_hans/larkhelp.yaml
+++ b/src/lang/zh_hans/larkhelp.yaml
@@ -29,7 +29,7 @@ command:
     **用法**({}):
     {}
   usage_item: |
-    <qqbot-cmd-input text="{__prefix__}{}" show="{__prefix__}{}" reference="false" />
+    <qqbot-cmd-input text="{__prefix__}{}" show="{__prefix__}{}" reference="false" /> {}
   usage: '{__prefix__}{}'
   not_found:
     - 命令 {} 不存在，或无可用的帮助信息

--- a/src/plugins/nonebot_plugin_larkhelp/__main__.py
+++ b/src/plugins/nonebot_plugin_larkhelp/__main__.py
@@ -41,7 +41,7 @@ def urlencode_cmd(text: str) -> str:
 
 
 def strip_usage_explanation(text: str) -> str:
-    """移除用法字符串末尾的 (说明) 部分，用于生成指令组件的 text 属性。
+    """移除用法字符串末尾的 (说明) 部分，用于生成指令组件的 text/show 属性。
 
     仅删除结尾的解释括号组，避免旧的 `\(.*?\)` 实现把参数占位符内的括号注解
     （如 `[-l|--last <持续(小时)>]` 中的 `(小时)`）一并删掉。
@@ -49,16 +49,18 @@ def strip_usage_explanation(text: str) -> str:
     return re.sub(r"\s*\([^)]*\)\s*$", "", text).strip()
 
 
-def escape_show_brackets(text: str) -> str:
-    """转义用法中的方括号，避免 QQ 平台解析 `<qqbot-cmd-input>` 标签时把属性内容当 markdown 链接处理。
+def split_usage_explanation(text: str) -> tuple[str, str]:
+    """将用法拆分为指令本体与末尾的 (说明)，供 `<qqbot-cmd-input>` 标签及标签外文本使用。
 
-    QQ 平台在解析标签属性时会按 markdown 处理其中的文本。当 show 值形如
-    `quick-math [--level <开始的等级>] (开始挑战)` 时，`[...]` 后紧跟 `(...)` 会被
-    识别成链接 `[label](dest)`，导致该标签无法被解析成指令组件，整段
-    `<qqbot-cmd-input ... />` 原文直接显示在消息里。转义为 `\[` `\]` 后不再构成
-    链接，标签正常解析，方括号与说明文字按字面展示。
+    用法形如 `shop buy <编号> [数量] (购买商品)`。指令组件的 text/show 属性只
+    携带指令本体，说明文字渲染在标签外部：若把 `[可选参数] (说明)` 一并放进属性，
+    QQ 平台解析标签属性时会按 markdown 处理其中文本，把 `[...]` 后紧跟的 `(...)`
+    识别成链接 `[label](dest)`，导致整个标签无法解析、原文直接显示。
     """
-    return text.replace("[", r"\[").replace("]", r"\]")
+    match = re.search(r"\s*\([^)]*\)\s*$", text)
+    if match is None:
+        return text.strip(), ""
+    return text[: match.start()].strip(), match.group().strip()
 
 
 help_list = {}
@@ -98,10 +100,14 @@ async def help_command_handler(bot: Bot, command: str, user_id: str = get_user_i
                         await lang.text(
                             "command.usage_item",
                             user_id,
-                            urlencode_cmd(strip_usage_explanation(usage_str := await helper.text(usage, user_id))),
-                            urlencode_cmd(escape_show_brackets(usage_str)),
+                            urlencode_cmd(cmd_text),
+                            urlencode_cmd(cmd_text),
+                            explanation,
                         )
                         for usage in data.usages
+                        for cmd_text, explanation in [
+                            split_usage_explanation(await helper.text(usage, user_id)),
+                        ]
                     ]
                 ),
             ),

--- a/tests/test_larkhelp_qq_cmd_input.py
+++ b/tests/test_larkhelp_qq_cmd_input.py
@@ -5,8 +5,8 @@
    "qqbot-cmd-input参数解析失败"（ActionFailed），即 /help shop 的线上报错。
 2. 标签解析：平台解析标签属性时会按 markdown 处理其中文本，用法中 `[可选参数]`
    后紧跟 `(说明)`（如 `quick-math [--level <开始的等级>] (开始挑战)`）会被识别成
-   链接导致整个标签无法解析、原文直接显示，因此 show 中的方括号需转义，
-   text 只移除用法末尾的 (说明)。
+   链接导致整个标签无法解析、原文直接显示，因此把 (说明) 用法说明直接渲染在
+   `<qqbot-cmd-input>` 标签外部，text/show 属性只携带指令本体。
 """
 
 from typing import Any, ClassVar
@@ -73,7 +73,7 @@ def larkhelp_env(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, list[tuple[str, 
         if self.plugin_name == "shop":
             return _SHOP_TEXT.get(key, f"shop::{key}")
         if key == "command.usage_item":
-            return '<qqbot-cmd-input text="/{}" show="/{}" reference="false" />'.format(*args)
+            return '<qqbot-cmd-input text="/{}" show="/{}" reference="false" /> {}'.format(*args)
         if key == "command.info_md":
             return "{} **{}**\n{}\n\n**用法**({}):\n{}".format(*args)
         if key == "menu_cat.item":
@@ -104,22 +104,25 @@ def test_urlencode_cmd_encodes_tag_breaking_chars_only() -> None:
     assert urlencode_cmd("line1\nline2\r\nline3") == "line1 line2 line3"
 
 
-def test_escape_show_brackets_escapes_square_brackets_only() -> None:
-    """show 中的方括号需转义，避免 `[...]` 与 `(...)` 组成链接导致标签无法解析、原文显示"""
-    from nonebot_plugin_larkhelp.__main__ import escape_show_brackets
+def test_split_usage_explanation_returns_command_and_explanation() -> None:
+    """用法拆分为指令本体与末尾的 (说明)：说明文字渲染在标签外部"""
+    from nonebot_plugin_larkhelp.__main__ import split_usage_explanation
 
-    assert escape_show_brackets("quick-math [--level <开始的等级>] (开始挑战)") == (
-        r"quick-math \[--level <开始的等级>\] (开始挑战)"
+    assert split_usage_explanation("quick-math [--level <开始的等级>] (开始挑战)") == (
+        "quick-math [--level <开始的等级>]",
+        "(开始挑战)",
     )
-    assert escape_show_brackets("quick-math rank [--total] (积分排行榜)") == (
-        r"quick-math rank \[--total\] (积分排行榜)"
+    assert split_usage_explanation("shop (查看商品列表)") == ("shop", "(查看商品列表)")
+    assert split_usage_explanation("vote create [-g|--global] [-l|--last <持续(小时)>] [标题] (创建投票)") == (
+        "vote create [-g|--global] [-l|--last <持续(小时)>] [标题]",
+        "(创建投票)",
     )
-    assert escape_show_brackets("quick-math points (查看总分详情)") == "quick-math points (查看总分详情)"
-    assert escape_show_brackets("quick-math zen <等级> (禅模式)") == "quick-math zen <等级> (禅模式)"
+    assert split_usage_explanation("help") == ("help", "")
+    assert split_usage_explanation("  shop  (查看商品列表)  ") == ("shop", "(查看商品列表)")
 
 
 def test_strip_usage_explanation_only_strips_trailing_parens() -> None:
-    """text 属性只移除用法末尾的 (说明)，保留占位符内的括号注解（如 <持续(小时)>）"""
+    """text/show 属性只移除用法末尾的 (说明)，保留占位符内的括号注解（如 <持续(小时)>）"""
     from nonebot_plugin_larkhelp.__main__ import strip_usage_explanation
 
     assert strip_usage_explanation("quick-math [--level <开始的等级>] (开始挑战)") == (
@@ -138,7 +141,7 @@ def _assert_no_raw_breaking_chars(args: tuple[object, ...]) -> None:
 
 @pytest.mark.asyncio
 async def test_help_shop_qq_usage_item_is_urlencoded(larkhelp_env: object) -> None:
-    """QQ 平台 /help shop：含尖括号占位符的用法在 <qqbot-cmd-input> 中必须被 urlencode"""
+    """QQ 平台 /help shop：含尖括号占位符的用法在 <qqbot-cmd-input> 中必须被 urlencode，说明在标签外"""
     from nonebot.adapters.qq import Bot as QQBot
 
     module, lang_calls = larkhelp_env
@@ -146,9 +149,9 @@ async def test_help_shop_qq_usage_item_is_urlencoded(larkhelp_env: object) -> No
 
     usage_items = [args for key, args in lang_calls if key == "command.usage_item"]
     assert usage_items == [
-        ("shop", "shop (查看商品列表)"),
-        ("shop buy %3C编号%3E [数量]", "shop buy %3C编号%3E \\[数量\\] (购买商品)"),
-        ("shop rank [--total]", "shop rank \\[--total\\] (积分排行榜)"),
+        ("shop", "shop", "(查看商品列表)"),
+        ("shop buy %3C编号%3E [数量]", "shop buy %3C编号%3E [数量]", "(购买商品)"),
+        ("shop rank [--total]", "shop rank [--total]", "(积分排行榜)"),
     ]
     for item in usage_items:
         _assert_no_raw_breaking_chars(item)
@@ -157,13 +160,14 @@ async def test_help_shop_qq_usage_item_is_urlencoded(larkhelp_env: object) -> No
     markdown = module.UniMessage.sent[0]
     assert (
         '<qqbot-cmd-input text="/shop buy %3C编号%3E [数量]" '
-        'show="/shop buy %3C编号%3E \\[数量\\] (购买商品)" reference="false" />' in markdown
+        'show="/shop buy %3C编号%3E [数量]" reference="false" /> (购买商品)' in markdown
     )
-    assert '<qqbot-cmd-input text="/shop" show="/shop (查看商品列表)" reference="false" />' in markdown
+    assert '<qqbot-cmd-input text="/shop" show="/shop" reference="false" /> (查看商品列表)' in markdown
     # 属性值内不允许出现未编码的尖括号
     assert 'text="/shop buy <编号>' not in markdown
-    # 标签属性内不允许出现未被转义的 [可选参数] 后跟 (说明)（会被平台当作链接解析导致标签无法解析）
-    assert not re.search(r"(?<!\\)\[[^\n\]]*\]\s*\(", markdown), markdown
+    # 标签属性内不允许出现 [可选参数] 后跟 (说明)（会被平台当作链接解析导致标签无法解析），
+    # 说明文字已移到标签外部，因此属性内 [XXX] 之后不再紧跟 (XXX)
+    assert not re.search(r"<qqbot-cmd-input[^>]*\[[^\n\]]*\]\s*\(", markdown), markdown
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题背景

QQ 平台解析 `<qqbot-cmd-input>` 标签属性时会按 markdown 处理其中文本。当 `show` 值形如 `quick-math [--level <开始的等级>] (开始挑战)` 时，`[...]` 后紧跟 `(...)` 会被识别成链接 `[label](dest)`，整个标签无法被解析成指令组件，`<qqbot-cmd-input ... />` 原文直接显示在消息里（quick-math 的 rank / 带 `--level` 的用法、bingo / chat / eggstrike / shop / vote 等全部含 `[可选参数] (说明)` 用法的指令均受影响）。

上一版修复（#1412）通过在属性内把方括号转义为 `\[` `\]` 来规避链接解析。本 PR 基于最新 main 重新实现该修复：**直接把 `(说明)` 用法说明移出 `<qqbot-cmd-input>` 标签**，不再依赖转义。

## 改动

- `text` / `show` 属性只携带指令本体（去除末尾 `(说明)` 后的用法），点击组件仍会输入完整指令
- `(说明)` 作为标签外的普通 markdown 文本展示，属性内不再出现 `[可选参数]` 紧跟 `(说明)` 的序列，标签必然可被平台正常解析
- 移除不再需要的 `escape_show_brackets`，新增 `split_usage_explanation` 拆分指令本体与说明文字
- 更新回归测试：断言最终 markdown 的属性内不存在 `[XXX]` 紧跟 `(XXX)` 的序列，说明文字渲染在标签外

渲染效果示例：

```markdown
**用法**(3):
<qqbot-cmd-input text="/shop" show="/shop" reference="false" /> (查看商品列表)
<qqbot-cmd-input text="/shop buy <编号> [数量]" show="/shop buy <编号> [数量]" reference="false" /> (购买商品)
<qqbot-cmd-input text="/shop rank [--total]" show="/shop rank [--total]" reference="false" /> (积分排行榜)
```

## 验证

- `tests/test_larkhelp_qq_cmd_input.py` 全部通过，完整 `tests/` 179 项通过
- `urlencode_cmd` 的尖括号编码逻辑保持不变，`/help shop` 等含 `<编号>` 占位符的指令仍能正常解析
