### PR TITLE
feat(larkuser): 适配 QQ 官方 Bot 群信息与群成员列表接口

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -59,6 +59,17 @@ BOTS_LIST='{"main": "123456789", "secondary": "987654321"}'
 BOTS_APPID_MAP='{"102xxxxxx": "3889000000"}'
 # 群绑定验证码过期时间（秒）
 BOTS_BIND_GROUP_TIMEOUT=300
+# larkuser 插件：QQ 官方 Bot 群聊信息 / 群成员列表缓存
+# 是否启用群信息与群成员列表的周期性同步
+QQ_GROUP_SYNC_ENABLED=true
+# 周期性同步任务的执行间隔（秒），默认 30 分钟
+QQ_GROUP_SYNC_INTERVAL=1800
+# 群成员列表缓存有效期（秒），超过后由周期任务重新拉取，默认 1 小时
+QQ_GROUP_MEMBER_CACHE_TTL=3600
+# 群基本信息缓存有效期（秒），默认 6 小时
+QQ_GROUP_INFO_CACHE_TTL=21600
+# 单个群一次同步最多缓存的成员数，防止游标异常时无限翻页
+QQ_GROUP_MEMBER_MAX_COUNT=3000
 # menupanel 插件：QQ 自定义菜单「在线帮助」link 项跳转的前端帮助页地址
 # 超管使用 NoneBot 标准 SUPERUSERS 配置，无需单独设置
 MENUPANEL_FRONTEND_HELP_URL="https://moonlark.itcdt.top/#/help"

--- a/docs/plugins/larkuser.md
+++ b/docs/plugins/larkuser.md
@@ -198,3 +198,77 @@ Moonlark 用户操作基类，定义了用户相关的各种操作方法。
 - `has_vimcoin`: 检查用户是否有足够的 VimCoin。
 - `get_config_key`: 获取用户配置项。
 - `set_config_key`: 设置用户配置项。
+
+## QQ 官方 Bot 群聊信息与群成员缓存
+
+QQ 开放平台的[获取群基本信息](https://bot.q.qq.com/wiki/develop/api-v2/autogen/api/v2_groups_group_openid_info.get.html)
+与[获取群成员列表](https://bot.q.qq.com/wiki/develop/api-v2/autogen/api/v2_groups_group_openid_members.get.html)
+接口都只对白名单机器人开放，群成员列表还有分页（每页 30 条）与频率限制（60 QPM）。
+因此插件把接口结果缓存在数据库中，收到 QQ 群消息时登记该群并在后台同步一次，
+之后由周期任务按缓存有效期刷新，其余功能只读缓存。
+
+缓存同时会用群成员列表里的昵称补全没有昵称的用户：已注册用户（`UserData`）昵称为空时
+填入并标记来源为 `group_member`，未注册用户直接写入 `GuestUser`。
+
+相关配置见 `.env.template` 中的 `QQ_GROUP_*` 配置项。
+
+```python
+async def get_group_name(bot: QQBot, group_openid: str) -> Optional[str]:
+```
+
+获取群名称，缓存缺失或过期时调用接口刷新，接口不可用时返回 `None`。
+
+```python
+async def get_group_member(group_openid: str, member_openid: str) -> Optional[QQGroupMemberInfo]:
+```
+
+按成员 openid 读取缓存的群成员信息（昵称、群角色、入群时间等），未缓存时返回 `None`。
+
+```python
+async def get_cached_group_members(group_openid: str) -> list[QQGroupMemberInfo]:
+```
+
+读取缓存的群成员列表（不调用接口）。
+
+```python
+async def get_group_member_nickname_map(group_openid: str) -> dict[str, str]:
+```
+
+构造「昵称 -> 成员 openid」映射，昵称优先取 Moonlark 中的昵称，没有时退回到 QQ 昵称。
+Chat 会话解析 @ 时使用该映射。
+
+```python
+async def get_group_member_ids(bot: QQBot, group_openid: str) -> list[str]:
+```
+
+获取群成员 openid 列表，缓存尚未建立时同步一次。`everyday_wife` 插件用它抽取群成员。
+
+```python
+async def ensure_group_members(bot: QQBot, group_openid: str) -> list[QQGroupMemberInfo]:
+```
+
+确保群成员缓存可用，从未同步过或缓存为空时同步一次。
+
+```python
+async def refresh_group_members(bot: QQBot, group_openid: str) -> list[QQGroupMemberInfo]:
+```
+
+忽略缓存有效期，全量重新拉取群成员列表并刷新缓存（含分页、频率限制与昵称补全）。
+
+```python
+async def refresh_group_info(bot: QQBot, group_openid: str) -> Optional[QQGroupInfo]:
+```
+
+调用接口刷新群基本信息，失败时返回 `None` 并把错误记录到缓存表中。
+
+```python
+async def remember_group(group_openid: str, bot_id: str = "") -> None:
+```
+
+登记一个 QQ 群（不调用接口），已存在时只补全 `bot_id`。
+
+```python
+async def sync_all_groups() -> None:
+```
+
+周期任务调用的同步入口，按缓存有效期刷新所有已登记群的群信息与群成员列表。

--- a/migrations/versions/a7f3c9e21b64_add_qq_group_cache.py
+++ b/migrations/versions/a7f3c9e21b64_add_qq_group_cache.py
@@ -1,0 +1,76 @@
+"""add qq group info and member cache tables
+
+迁移 ID: a7f3c9e21b64
+父迁移: 9f4e8c2a61b3d5f7
+创建时间: 2026-09-11 11:20:00.000000
+
+为 larkuser 插件新增 QQ 官方 Bot 群聊信息与群成员列表缓存表：
+- nonebot_plugin_larkuser_qq_group_info：群基本信息与同步状态；
+- nonebot_plugin_larkuser_qq_group_member：群成员列表缓存。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "a7f3c9e21b64"
+down_revision: str | Sequence[str] | None = "9f4e8c2a61b3d5f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+INFO_TABLE = "nonebot_plugin_larkuser_qq_group_info"
+MEMBER_TABLE = "nonebot_plugin_larkuser_qq_group_member"
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    if bind.dialect.name == "mysql":
+        statement = sa.text("SHOW TABLES LIKE :table_name")
+    else:
+        statement = sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:table_name")
+    return bool(bind.execute(statement, {"table_name": table_name}).fetchall())
+
+
+def upgrade(name: str = "") -> None:
+    if name:
+        return
+
+    if not _table_exists(INFO_TABLE):
+        op.create_table(
+            INFO_TABLE,
+            sa.Column("group_openid", sa.String(length=128), nullable=False),
+            sa.Column("bot_id", sa.String(length=64), nullable=False),
+            sa.Column("group_name", sa.String(length=256), nullable=False),
+            sa.Column("description", sa.String(length=512), nullable=False),
+            sa.Column("member_count", sa.Integer(), nullable=False),
+            sa.Column("info_updated_at", sa.DateTime(), nullable=True),
+            sa.Column("members_synced_at", sa.DateTime(), nullable=True),
+            sa.Column("last_error", sa.String(length=512), nullable=False),
+            sa.PrimaryKeyConstraint("group_openid", name=op.f(f"pk_{INFO_TABLE}")),
+            info={"bind_key": "nonebot_plugin_larkuser"},
+        )
+
+    if not _table_exists(MEMBER_TABLE):
+        op.create_table(
+            MEMBER_TABLE,
+            sa.Column("group_openid", sa.String(length=128), nullable=False),
+            sa.Column("member_openid", sa.String(length=128), nullable=False),
+            sa.Column("nickname", sa.String(length=256), nullable=False),
+            sa.Column("role", sa.String(length=16), nullable=False),
+            sa.Column("is_bot", sa.Boolean(), nullable=False),
+            sa.Column("joined_at", sa.DateTime(), nullable=True),
+            sa.Column("union_openid", sa.String(length=128), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint("group_openid", "member_openid", name=op.f(f"pk_{MEMBER_TABLE}")),
+            info={"bind_key": "nonebot_plugin_larkuser"},
+        )
+
+
+def downgrade(name: str = "") -> None:
+    if name:
+        return
+    op.drop_table(MEMBER_TABLE)
+    op.drop_table(INFO_TABLE)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1838,78 +1838,78 @@ files = [
 
 [[package]]
 name = "fonttools"
-version = "4.64.0"
+version = "4.65.0"
 description = "Tools to manipulate font files"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fonttools-4.64.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:50e52b6f479ddb1fe32423c2ec860811f36584cf6eabf279fb9a4f98b859a8b4"},
-    {file = "fonttools-4.64.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:730eed859508cb7b0775ebe6bb39f18901f168eb989d8ee23a4fe082700e1e3f"},
-    {file = "fonttools-4.64.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6946c033a144086d5b98c976b72f476b70c93fbbedf914eee0e886f073a4e9fa"},
-    {file = "fonttools-4.64.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d16102cbcd4615b09c64e6022733faccc93200785f1ab0d4493afb8b0261edde"},
-    {file = "fonttools-4.64.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a3238a693e806a3158375c6403b8f6f71d86eb9c149b60c97f26dfd560c98ac8"},
-    {file = "fonttools-4.64.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:70fd99e5a09fb77f14b29d70879a4fce9529b2d2948b14c96708e0a61e001b98"},
-    {file = "fonttools-4.64.0-cp310-cp310-win32.whl", hash = "sha256:507c553cdb5abe2e951b5368423849fe29911a828c2135319c3e500e3bf25b32"},
-    {file = "fonttools-4.64.0-cp310-cp310-win_amd64.whl", hash = "sha256:e7b34209eef39462563c05ea9dcf51c272a2ded56f5753da925e66bca3baa484"},
-    {file = "fonttools-4.64.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dac25768be4c03a990c359f408cb7e8958ed0e93061e495b3642ce7909761205"},
-    {file = "fonttools-4.64.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d652592c71683941b768306fa1c7c6ce1bb9b072505043feafe86305d71030b7"},
-    {file = "fonttools-4.64.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:801fd04899d72eab34f02ab78d0451525621b3bd589da9d2d480dfffe951b643"},
-    {file = "fonttools-4.64.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff7aff4637fbf71394df139c63ccfe08a47aa4252d2f91224ddb3335c716c925"},
-    {file = "fonttools-4.64.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f521d79d6acda4923b264805541696f452079db0952a5bb96f9ff742f50629ec"},
-    {file = "fonttools-4.64.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a0afa8bac675445dc0e2ba2891ecbedd9be89cb437afa94c823e0290cc2c4bc5"},
-    {file = "fonttools-4.64.0-cp311-cp311-win32.whl", hash = "sha256:c3c1fb656063a2f762db5378ea8d38ad5f7836b4f3fb8c4652270ded43df2935"},
-    {file = "fonttools-4.64.0-cp311-cp311-win_amd64.whl", hash = "sha256:e63b63b8b5fdb8e29318dff2b15c5f852be46e972775b466f75b848f6eed4502"},
-    {file = "fonttools-4.64.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9ecb2b206b5b2386f6968721a0770226b66bdd54adc4279bfff3ddf62873eed8"},
-    {file = "fonttools-4.64.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8c631303bb1fd7be3067c47536a30ff1fcb4846d6008c112bc52a03f7cd6965"},
-    {file = "fonttools-4.64.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2763e452b025ee8e990f0462e76052de9bb094ebc21d296f62c6dfe958886b4"},
-    {file = "fonttools-4.64.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:66a83f93579fb3493e458c4449d1d566a7b2a1c7b19915cd0fa3c9b8b5a8540b"},
-    {file = "fonttools-4.64.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cf67f96dc0bfe9607f5f2b734cedfbe2f6f995231adee4ccefa12872044d452d"},
-    {file = "fonttools-4.64.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6786bed88581e19bc4f28ea7a64ad531e8f54acf50327fddca942688824a60bd"},
-    {file = "fonttools-4.64.0-cp312-cp312-win32.whl", hash = "sha256:da4c9bdeaf6b06c12d13d0addfc8ef15aa9695d26574a6dc10751258bef72f30"},
-    {file = "fonttools-4.64.0-cp312-cp312-win_amd64.whl", hash = "sha256:06b6409b868494556a831ae33b2d9a090476c37516b38d70f45a9720b460d423"},
-    {file = "fonttools-4.64.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9443eefff58aad558608f352092e1be6d278980e8c3b4e8621fcbfda97818500"},
-    {file = "fonttools-4.64.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:09657817b75575822bcd6098ef0ebf0386f34430839ee53109e70fd40a7f6539"},
-    {file = "fonttools-4.64.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d7995b906666037d7114c20a5566a372902747452af7d5bd4cd6bca8f1a2550"},
-    {file = "fonttools-4.64.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2c42237b7e8c6813643e57d3efed3be094d4c06339dc2166b626e2cc5c12ee93"},
-    {file = "fonttools-4.64.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:498f02ea92c9ca18c0f9c581ea93184a9d56c25b0af14189b0767adaf34235d8"},
-    {file = "fonttools-4.64.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8252f20108e557532f91d7d6dd9af87c16ed6fa930f65516aa480fa2cfed3363"},
-    {file = "fonttools-4.64.0-cp313-cp313-win32.whl", hash = "sha256:45e3ecc3888f1637094fd75cd8fc727f3a4b06d1ddf89181126c071e244fd2a5"},
-    {file = "fonttools-4.64.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4812f71c39d77ec5041348dafa400532adf7bf8f1fffa9aa6495fce5876d7b8"},
-    {file = "fonttools-4.64.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6f1ce9ef9a1b13098efdc2e43a2ed96d9851bbde7b31c652a87552c4efe9b422"},
-    {file = "fonttools-4.64.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:83cc48d1411d2ff388dab99973dca81172cc9ceae9c9799da9548d494cfb38cb"},
-    {file = "fonttools-4.64.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e412767d1c9765cf1b82f7b00f1686c6ca5809ebb77af363b3f9f2325a465c01"},
-    {file = "fonttools-4.64.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b4a7af455ffed980925bc0ebf5b8d6239e6c3e797d9d755b6db192fb3080d614"},
-    {file = "fonttools-4.64.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:398b14f89ca950b288bd290875f07e4e10685644fa4ac668546fb107b1ada4d4"},
-    {file = "fonttools-4.64.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dc96150f99e05a317cb1f042b92c4cf8bc93cdb1f9f85717322e202ecdf2e505"},
-    {file = "fonttools-4.64.0-cp314-cp314-win32.whl", hash = "sha256:1c3661324f3f0fa4539a32288a3e0711a5f3ccf020036e760bb558ae9811a16f"},
-    {file = "fonttools-4.64.0-cp314-cp314-win_amd64.whl", hash = "sha256:043f6c572bf236f2a76e762c25f841daea11e8fc03e78088d7be66e0c5b4e4c0"},
-    {file = "fonttools-4.64.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4691a122b8c1d0d82d6e7510ce59d5c42146518240274b53e912e255573924f7"},
-    {file = "fonttools-4.64.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:3200180abc69639483cf54a17cca2e13c31ede5f665979ea0a9c829d093f372f"},
-    {file = "fonttools-4.64.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53eee22af5b5a305c1ee2652955ed46b148e881456fcec1e7f0eb27f642f6bb4"},
-    {file = "fonttools-4.64.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08f172961e11f4eb4f80f2f20049e09b0ea8e044fa6d456fed8346eb8588f360"},
-    {file = "fonttools-4.64.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6eae4376adb104c2acfa76fd9ea0cb12b572ca1d70eceac709871f638ff76e93"},
-    {file = "fonttools-4.64.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2730946ca8f12c356bd98eb9b2b095c8e761ed05bed5afb0d5b380cebe4f6370"},
-    {file = "fonttools-4.64.0-cp314-cp314t-win32.whl", hash = "sha256:d30c966bea2deffa19c738c81776f7182da5ccabd97e666bae4f3d6ba87341d9"},
-    {file = "fonttools-4.64.0-cp314-cp314t-win_amd64.whl", hash = "sha256:917fd520bb60809d83c14d43cfe48d5ad2516abaf2c073d65a431800dade2d29"},
-    {file = "fonttools-4.64.0-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8dd18fdff0ac9759b8d67a714730abee07b2312e3656c20ba5affb0107094762"},
-    {file = "fonttools-4.64.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:5af87d1a6d247d7467ee082ae977a5443b2c45f8cd4d59375b6daa38d523c2de"},
-    {file = "fonttools-4.64.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:769fb64412ca237547ca73f111a64252d9e32c9d938bed51ed537bc9146a8f54"},
-    {file = "fonttools-4.64.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e662f874ab2c7da9861584db44a13573e0936df087215f63013138f6e5eba083"},
-    {file = "fonttools-4.64.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2524a26f8fdb9051b0d778d052f5d238285ca9f91a7dc004514c7d6cf38d35f4"},
-    {file = "fonttools-4.64.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:1e4e84b47839d35be24dbf476845a34f2ccf99707b66df125c1c414d3e86d25d"},
-    {file = "fonttools-4.64.0-cp315-cp315-win32.whl", hash = "sha256:be084d19a3ac0c8b2aba696680642d703118d3b1f18cf83f5b7dbaf0ffc62ab6"},
-    {file = "fonttools-4.64.0-cp315-cp315-win_amd64.whl", hash = "sha256:de8acaa5f4160f537a3cf41b031171d51004b9f4aebfa6c194f18dffa9533d03"},
-    {file = "fonttools-4.64.0-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5b90ad6637237b636d15c9ae8b7c4a7a1c194f33def378677e468c13fd4542f8"},
-    {file = "fonttools-4.64.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:fa75c7970bc6bca340cc6e20f20f069201bfcb50094c31a536fd99724d1d01ca"},
-    {file = "fonttools-4.64.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:236e59bc7e2a63557a4d7b013f9cb9e28d9aebc45bc09f85e545e6bf091db626"},
-    {file = "fonttools-4.64.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a515f664cad988f2295056833a59f62220bc3e46afdaffe389a29060f6712355"},
-    {file = "fonttools-4.64.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:5bfdaada437e7730c17d366bd7bb8c4a16639963ddbfc1b2f302a68a17a290e7"},
-    {file = "fonttools-4.64.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:c60be0aed97a32c6ba8cee21f0d0477136e495451bd97910f589ac892db120d4"},
-    {file = "fonttools-4.64.0-cp315-cp315t-win32.whl", hash = "sha256:f8669ce37851b597d3435b91fefa51139e58d506ca449ca0e5bb68c63b8b6d2b"},
-    {file = "fonttools-4.64.0-cp315-cp315t-win_amd64.whl", hash = "sha256:89356c0793b474af7e49ec90d39fb2363e2341516a90460e38231df5ebe8acd5"},
-    {file = "fonttools-4.64.0-py3-none-any.whl", hash = "sha256:4a05783ff54ce4c7a28f18e5772efdf63c219374bd9ffc55452182e1cef8be60"},
-    {file = "fonttools-4.64.0.tar.gz", hash = "sha256:ecb2e59a7bc692fee64dda6010deb66222335693b30046f15cccf81233aa715f"},
+    {file = "fonttools-4.65.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:93a73af2075036d36d7fbf856779c56a1b3b86ffcdae6abede7596604c42c156"},
+    {file = "fonttools-4.65.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c130be2232e3caf8d2b476854ea78421ec1642917ff5ab695284bac31bbb072b"},
+    {file = "fonttools-4.65.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e3944e0bdba42effb71959e43d91b599326b02b59c78310d5675e8a75525e7d8"},
+    {file = "fonttools-4.65.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fb53892b570f7f1f0055e75fc4de32673e32f749c4c8a606b63d5c436650e634"},
+    {file = "fonttools-4.65.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a6c8d184e523580a7c55d21cde37176a3c91cb539cf06c2aa36ffc634fd75296"},
+    {file = "fonttools-4.65.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e5ceccaf2e57d83b753a2b5db5d94aa0a8071886d4afebd2d520c9683e6bef0e"},
+    {file = "fonttools-4.65.0-cp310-cp310-win32.whl", hash = "sha256:aff640a4fcb021fa83f9879d5bfa115b6931522dae991a24faa75888bd6aeff6"},
+    {file = "fonttools-4.65.0-cp310-cp310-win_amd64.whl", hash = "sha256:5c1700a60e4ff23a0425d5a64abf43d092e6b55071354825781faf255904dcb4"},
+    {file = "fonttools-4.65.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:06273c71e692caf5989c0437ca50875a5e49e216ddf653228fe9bb35bdc82c0f"},
+    {file = "fonttools-4.65.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ca2b02d74e9ad7e21a1d11e4701425800a4b0c63cf90486e60258262feccbcbf"},
+    {file = "fonttools-4.65.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7830e9fa3bebc44dbc27ff44d8201def30ea5c48a773696d58e69e6bcd9cd5d4"},
+    {file = "fonttools-4.65.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a3991732c87b3f054a2a8cf86dd0d602833fa8cb37c911503173771646e1013d"},
+    {file = "fonttools-4.65.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6031e77b3fb8c765055ba2b8bd8dcb17030f3bf2484c448b472fdedf4460ba80"},
+    {file = "fonttools-4.65.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6813cc1e2e883bd6c15b3e04f72c78dc65fdc4ca861063adf5f341fbaec2ca62"},
+    {file = "fonttools-4.65.0-cp311-cp311-win32.whl", hash = "sha256:4a5db8442453da4b6f43ad325879381b726bf2238a2253efd9584be21a2cefc2"},
+    {file = "fonttools-4.65.0-cp311-cp311-win_amd64.whl", hash = "sha256:9f201796c8e24e657be77c16fa664e798a46122144217f90838982937a964f0a"},
+    {file = "fonttools-4.65.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e844a45c9e5ced6536f184cf1a65b5d65e8f7e711993b413e10500a8223622e5"},
+    {file = "fonttools-4.65.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b30e953de049bf43fc0a63c7d0c44d205c923e4bbf24716aae1518c0e65f977c"},
+    {file = "fonttools-4.65.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09c34bdeed8915bfb53bee0c8ed2254dbd8ec69c0014b7f3702f347c049bf358"},
+    {file = "fonttools-4.65.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:05595385ae99f4b9626cebb973bf171b8fe38a8f40708e6e42abba0ed7537778"},
+    {file = "fonttools-4.65.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d95b34dd68fbfc0e4a1740c421597656117f979ed8dc85de66e08f9f9981806e"},
+    {file = "fonttools-4.65.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:924d06e6130429168318db71c40174a765ad016fc4b56ca811287e3d7373b3a6"},
+    {file = "fonttools-4.65.0-cp312-cp312-win32.whl", hash = "sha256:04f73dd01005752a6e75cf4a8dc6b70dc724d1d4bc34cc89522153f4a2f07680"},
+    {file = "fonttools-4.65.0-cp312-cp312-win_amd64.whl", hash = "sha256:3b5d9ba89edf778b376e669b879ae33a198bf45cf5a23c3f6514f935cf9d0d9d"},
+    {file = "fonttools-4.65.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8b7bb52817a24731d2e4f4df0e71fdde05e6c806c8f8f1517b015d142fdacfa5"},
+    {file = "fonttools-4.65.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e2c21772fcf70325189707b19f346812690bb1b0bd7e207e6ac205244806b303"},
+    {file = "fonttools-4.65.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c9b26816415b5e3d899e9077109d327b22140fe3c4066644d8cdbad5bb1569"},
+    {file = "fonttools-4.65.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6dd6243f60e2d6160c2966e1e14020dc261ffd741b69a2e4ca8bfd051592e4b7"},
+    {file = "fonttools-4.65.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:834962fd7cf21c58e81ac50a59e6ed2306f9df5e3dd481dad1cd7d2c4c60b773"},
+    {file = "fonttools-4.65.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:580eb68ff7bd6954a7a76afddd864bfc66eaaf5f5c20dd6ead9186d0055a4ffe"},
+    {file = "fonttools-4.65.0-cp313-cp313-win32.whl", hash = "sha256:7a18b2ffd44249fe84289253197aa65ad4f2de554c0d381f18b1f5939bc6bc60"},
+    {file = "fonttools-4.65.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ae1846b0f192fd485d26a455af19b8f5cf05aff08f9836f533913d8fcea133c"},
+    {file = "fonttools-4.65.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:dc87a9f846bec83c3795804f62b4632716d46e3522869a3dd9cd44a5d245b006"},
+    {file = "fonttools-4.65.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aa50dd7b9baf75e2bbd43401fc0d237f7a94a8ad2e0c57ea97160fc631af5eb0"},
+    {file = "fonttools-4.65.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d2a9892fdb3b7e2d0f4174e3b907d226ff83698249762eeefce08ec5b2de1dd"},
+    {file = "fonttools-4.65.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6d815734e7fede0ad1f233f23f0f191cbe8fc64762ff041e589bc0f78e0b2397"},
+    {file = "fonttools-4.65.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:71e4c67b6196a2f447f46476fd2302604721617f5e0a21b0988bdd87b6bb9687"},
+    {file = "fonttools-4.65.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b11d8a4a0c3ca74bbd4c105b7ef82501945c939e6096d9934ec7d288cdf5aaa9"},
+    {file = "fonttools-4.65.0-cp314-cp314-win32.whl", hash = "sha256:8e44a34d91b3c793879767eb115867ced74d2eb94974e64e72fe9e2eea71cf1a"},
+    {file = "fonttools-4.65.0-cp314-cp314-win_amd64.whl", hash = "sha256:0aa8901db22875c831d6a91796549590d7e747da37438f38b69d771b668be445"},
+    {file = "fonttools-4.65.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2e4a380ca40d3a5372e31b340f0da0d53b4583aadbb8e41f6a516afa69c509a4"},
+    {file = "fonttools-4.65.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:661bd91c4be13721408b2d4b67a9b3fa7736713adc9a6c9780c9c60fc7959f90"},
+    {file = "fonttools-4.65.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:62c5e42c79449def957adf8a9a65a43018efa7e2a6bc6baa3afe955e0d5fb2ab"},
+    {file = "fonttools-4.65.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:36fca8efc46b5adfca327c666e739fc05b7a7a6ef17840230f81b22f53230f61"},
+    {file = "fonttools-4.65.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8aa1291e4c767abf1b0b79ca2d6895f7c0b661d9d95d03b5791c883a9d1e1f08"},
+    {file = "fonttools-4.65.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fcf39949f56911348514b466714efa9118bec3d2be249e1c487263f7cda6edab"},
+    {file = "fonttools-4.65.0-cp314-cp314t-win32.whl", hash = "sha256:ffc918702661f1d74d2fbb2f5551036b64f6d2d743139e105289b694bcd16f54"},
+    {file = "fonttools-4.65.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5a977e3645dbffaee924209828aa702a215f7ff68bc08010740c10c723787e62"},
+    {file = "fonttools-4.65.0-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:7aa0518b45ff5286ad56f063938db3add3816e899aab58d782b3f9a252523caa"},
+    {file = "fonttools-4.65.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:673e2b3ac4ac8e4f3607d390ecc5a606e5db5c4e88fb4cb2999593efb65afea2"},
+    {file = "fonttools-4.65.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a03cff943b204a90bf3d1c04c97b9509a8aa0ee99e2e544084ca43ad995975b"},
+    {file = "fonttools-4.65.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:41f684ee6212e411196ab054f8308faf6605f154950e6f4686fb8f2103d624b0"},
+    {file = "fonttools-4.65.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:52ea9d2a8385075770db74d5e5718fa80b2222bb4fc62856a377dd2865ca8848"},
+    {file = "fonttools-4.65.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:d0d25027ade65ec46b13c0436e51bcb7c5171a4ea255a5e7a8d0d1d3ab4cffd7"},
+    {file = "fonttools-4.65.0-cp315-cp315-win32.whl", hash = "sha256:22cb846d35d278235ef3b7e947c6040b2057d72e8305a314f21d5342eca49040"},
+    {file = "fonttools-4.65.0-cp315-cp315-win_amd64.whl", hash = "sha256:aecc899fdbf9ecbf728f8977977e2e1043ee4d70c257124c8fa4cbcf796fcd83"},
+    {file = "fonttools-4.65.0-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6275863dad195ee34b6e0ca3fc61c74096bc37e5d6fb8e049f4d68d65865a2b7"},
+    {file = "fonttools-4.65.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:d8ffd2f62b402180b0edae8f86a071f583970e2177143117db5cf4c52da60079"},
+    {file = "fonttools-4.65.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:830f91327ca83bfc1278e7060068a498938f84d05dc4869675486f84f55d4fe1"},
+    {file = "fonttools-4.65.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9db2cb95847c18eef74a4ef0fe257a893ae3f4b0395f4866e2f426ab07f3d804"},
+    {file = "fonttools-4.65.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:be9b9a95ed0af03375e99020e921c4bc6b41fad10e053dea7acad370521a3c46"},
+    {file = "fonttools-4.65.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:bbd9faf777a9deb6790df4f2b0be611857c45fe86605e840d7154a028d828af7"},
+    {file = "fonttools-4.65.0-cp315-cp315t-win32.whl", hash = "sha256:c779d838815b91889c95ed64c9be5950ad5a683279f91aeb23384cb757ddc6a3"},
+    {file = "fonttools-4.65.0-cp315-cp315t-win_amd64.whl", hash = "sha256:d9484b7ee1b49b6b8a0231c849f3983723dec29e3a7366d9b1b02f4036f71944"},
+    {file = "fonttools-4.65.0-py3-none-any.whl", hash = "sha256:3060b8c1fc2329fa20265b7c138614143ea7c1624e26c5c180c76aeb74deae6f"},
+    {file = "fonttools-4.65.0.tar.gz", hash = "sha256:762ba5431358d0dbd4a01982484a1d494fb267e91f974cdcf20b80eab8560f6f"},
 ]
 
 [package.extras]
@@ -5027,14 +5027,14 @@ wincertstore = "0.2"
 
 [[package]]
 name = "pure-eval"
-version = "0.2.3"
+version = "0.2.4"
 description = "Safely evaluate AST nodes without side effects"
 optional = false
 python-versions = "*"
 groups = ["dev"]
 files = [
-    {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
-    {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
+    {file = "pure_eval-0.2.4-py3-none-any.whl", hash = "sha256:96cae060a313cfaad51bb761278bfb0e62dc0248d9315a81173752dc546cd37a"},
+    {file = "pure_eval-0.2.4.tar.gz", hash = "sha256:260c2774686e651b79f8b8e7fc9d80b3599ea6a66334b47d5f4abb69fc2c0ea1"},
 ]
 
 [package.extras]
@@ -6119,30 +6119,30 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruff"
-version = "0.16.6"
+version = "0.16.7"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8"},
-    {file = "ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32"},
-    {file = "ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c"},
-    {file = "ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876"},
-    {file = "ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d"},
-    {file = "ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1"},
-    {file = "ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70"},
-    {file = "ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3"},
-    {file = "ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757"},
-    {file = "ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e"},
-    {file = "ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4"},
-    {file = "ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88"},
-    {file = "ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953"},
-    {file = "ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718"},
-    {file = "ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25"},
-    {file = "ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39"},
-    {file = "ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5"},
-    {file = "ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050"},
+    {file = "ruff-0.16.7-py3-none-linux_armv6l.whl", hash = "sha256:727307773e7c7f9181d3ed3a2484186e56c1fa1874255911c74585eb2c7c19f9"},
+    {file = "ruff-0.16.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9d61c258deabf58f34c67bd4bb4d939c7f2e6b5f0e59c1cdd1cf771b11cde929"},
+    {file = "ruff-0.16.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7ab81118df8945e0193d0240712aa4496573595b75185c3636ed825592a0f728"},
+    {file = "ruff-0.16.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c196c968874fc8019da8e7163de7a1a370f111e2309b4b7dfea0fce950198d0"},
+    {file = "ruff-0.16.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac8c3bd0a7e10ad31e6ce51e7a99f3cb772e69aecdd6b9ea7e99b362f62a62c0"},
+    {file = "ruff-0.16.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:398d3988edde000b5c75dc1b3f584708da9bc990de069c18909142580fec1af9"},
+    {file = "ruff-0.16.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce05b62b770a8217c4646a9c4139fca00efe8fe5d71f87df2b243ff20d4584d1"},
+    {file = "ruff-0.16.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:af1b576fddb9d9ef2ececfb5fadcd6a624b25070ed85e3cfcfe449fc3ff6a7b9"},
+    {file = "ruff-0.16.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ce7f8f22df67c93ed96c717f9128eadb797144ac2bad475cf536f31d6100c55"},
+    {file = "ruff-0.16.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:06d0e93d04f392996435ebd600c153f65b47d73fbec2415aa99c5ee5756b3a5f"},
+    {file = "ruff-0.16.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:142151a5e7b93c1b11111337142f89dd2fbfee92161225c99a97222f22e32656"},
+    {file = "ruff-0.16.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e6651f97a342d8b35d54d8991544ca22169b86dc54111cb604666940c431b750"},
+    {file = "ruff-0.16.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ef140c6eb935fa9a84c9c607dfb2cb1b85843c192e79265b0c54f35f557ea8e5"},
+    {file = "ruff-0.16.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:53e39506a730fadeee0d998ed5946f30671f0db240c6c7c73bdabbe33604bb6f"},
+    {file = "ruff-0.16.7-py3-none-win32.whl", hash = "sha256:2ea3470fcebcbc5df2fb0c6f3b90333fa9084c534e0111c038fa4a6ab9f1c4b7"},
+    {file = "ruff-0.16.7-py3-none-win_amd64.whl", hash = "sha256:7ac26aca826e9e21d0f1cb25b54ac660760a9fdd094d3e4df9848232be98cfc6"},
+    {file = "ruff-0.16.7-py3-none-win_arm64.whl", hash = "sha256:aab7f39e2c9df6c596216070f98eef1207b94f8516cca20c808826974971855b"},
+    {file = "ruff-0.16.7.tar.gz", hash = "sha256:5f71d004ac1263b22fa39462ac5ae618a4b77d58981af2cc79bf79a29c12b1a6"},
 ]
 
 [[package]]

--- a/src/plugins/nonebot_plugin_chat/core/session/group.py
+++ b/src/plugins/nonebot_plugin_chat/core/session/group.py
@@ -1,12 +1,19 @@
-from typing import Literal, Optional
+from typing import Literal, Optional, cast
 
 from nonebot.adapters import Bot
 from nonebot.adapters.onebot.v11 import Bot as OB11Bot
+from nonebot.adapters.qq import Bot as QQBot
 from nonebot_plugin_alconna import Target, UniMessage
 from nonebot_plugin_chat.config import config
 from nonebot_plugin_chat.types import AdapterUserInfo
 from nonebot_plugin_ghot.function import get_group_hot_score
-from nonebot_plugin_larkuser import get_user
+from nonebot_plugin_larkuser import (
+    ensure_group_members,
+    get_group_member,
+    get_group_member_nickname_map,
+    get_group_name,
+    get_user,
+)
 
 from .base import BaseSession
 
@@ -33,6 +40,17 @@ class GroupSession(BaseSession):
                 **member_info,
                 nickname=adapter_nickname if not user.has_nickname() else user.get_nickname(),
             )
+        if isinstance(self.bot, QQBot):
+            member = await get_group_member(self.adapter_group_id, user_id)
+            if member is not None:
+                user = await get_user(user_id)
+                return AdapterUserInfo(
+                    nickname=member.nickname if not user.has_nickname() else user.get_nickname(),
+                    sex="unknown",
+                    role=member.role if member.role in ("member", "admin", "owner") else "member",
+                    join_time=int(member.joined_at.timestamp()) if member.joined_at else 0,
+                    card=None,
+                )
         cached_users = await self.get_users()
         if user_id in cached_users.values():
             for nickname, uid in cached_users.items():
@@ -42,16 +60,35 @@ class GroupSession(BaseSession):
             nickname=(await get_user(user_id)).get_nickname(), sex="unknown", role="member", join_time=0, card=None
         )
 
+    async def _get_ob11_group_users(self) -> dict[str, str]:
+        """通过 OneBot 11 接口获取「昵称 -> 用户 ID」映射"""
+        bot = cast(OB11Bot, self.bot)
+        users: dict[str, str] = {}
+        for user in await bot.get_group_member_list(group_id=int(self.adapter_group_id)):
+            adapter_nickname = user["nickname"]
+            ml_user = await get_user(str(user["user_id"]))
+            nickname = adapter_nickname if not ml_user.has_nickname() else ml_user.get_nickname()
+            users[nickname] = str(user["user_id"])
+        return users
+
+    async def _get_qq_group_users(self) -> dict[str, str]:
+        """通过 QQ 官方 Bot 的群成员列表（缓存）获取「昵称 -> 成员 openid」映射"""
+        users = await get_group_member_nickname_map(self.adapter_group_id)
+        if users:
+            return users
+        # 缓存尚未建立时同步一次，失败则由调用方回退到消息缓存
+        await ensure_group_members(cast(QQBot, self.bot), self.adapter_group_id)
+        return await get_group_member_nickname_map(self.adapter_group_id)
+
     async def get_users(self) -> dict[str, str]:
         cached_users = await self._get_users_in_cached_message()
         if any([u not in self.group_users for u in cached_users.keys()]):
             if isinstance(self.bot, OB11Bot):
-                self.group_users.clear()
-                for user in await self.bot.get_group_member_list(group_id=int(self.adapter_group_id)):
-                    adapter_nickname = user["nickname"]
-                    ml_user = await get_user(str(user["user_id"]))
-                    nickname = adapter_nickname if not ml_user.has_nickname() else ml_user.get_nickname()
-                    self.group_users[nickname] = str(user["user_id"])
+                self.group_users = await self._get_ob11_group_users()
+            elif isinstance(self.bot, QQBot):
+                # 与 OneBot 11 一致，@ 解析以群成员列表为准，取不到时回退到消息缓存
+                qq_users = await self._get_qq_group_users()
+                self.group_users = qq_users if qq_users else {**self.group_users, **cached_users}
             else:
                 self.group_users = cached_users
         return self.group_users
@@ -84,12 +121,17 @@ class GroupSession(BaseSession):
     async def get_session_name(self) -> Optional[str]:
         if isinstance(self.bot, OB11Bot):
             return (await self.bot.get_group_info(group_id=int(self.adapter_group_id)))["group_name"]
+        if isinstance(self.bot, QQBot):
+            return await get_group_name(self.bot, self.adapter_group_id)
         return None
 
     async def format_message(self, origin_message: str) -> UniMessage:
         message = re.sub(r"\[\d\d:\d\d:\d\d]\[Moonlark]\(\d+\): ?", "", origin_message)
         message = message.strip()
         users = await self.get_users()
+        if not users:
+            # 没有任何已知成员时直接返回，避免空正则匹配到每个字符
+            return UniMessage().text(text=message)
         uni_msg = UniMessage()
         at_list = re.finditer("|".join([f"@{re.escape(user)}" for user in users.keys()]), message)
         cursor_index = 0

--- a/src/plugins/nonebot_plugin_everyday_wife/utils/init.py
+++ b/src/plugins/nonebot_plugin_everyday_wife/utils/init.py
@@ -28,7 +28,7 @@ from sqlalchemy import select
 from nonebot_plugin_everyday_wife.models import WifeData
 from nonebot_plugin_everyday_wife.utils.control import marry
 from nonebot_plugin_bots.config import config as bots_config
-from nonebot_plugin_larkuser import get_user
+from nonebot_plugin_larkuser import get_group_member_ids, get_user
 
 # 匹配 Moonlark 所需的最低好感度
 MOONLARK_MATCH_FAV_THRESHOLD = 0.150
@@ -178,6 +178,5 @@ async def get_members_onebot_v12(bot: OneBotV12Bot, group_id: str) -> list[str]:
 
 
 async def get_members_qq(bot: QQBot, group_id: str) -> list[str]:
-    """获取 QQ 群成员列表"""
-    members = await bot.post_group_members(group_id=group_id)
-    return [user.member_openid for user in members.members]
+    """获取 QQ 群成员列表（使用 larkuser 维护的群成员缓存）"""
+    return await get_group_member_ids(bot, group_id)

--- a/src/plugins/nonebot_plugin_larkuser/__init__.py
+++ b/src/plugins/nonebot_plugin_larkuser/__init__.py
@@ -15,6 +15,7 @@ require("nonebot_plugin_localstore")
 require("nonebot_plugin_render")
 require("nonebot_plugin_preview")
 require("nonebot_plugin_waiter")
+require("nonebot_plugin_apscheduler")
 
 
 from .matchers import recorder, panel, whoami, register, setnick, getid
@@ -25,3 +26,14 @@ from .utils.user import get_user, MoonlarkUser, get_registered_users, get_regist
 from .utils.waiter import prompt
 from .utils.nickname import get_nickname
 from .utils.waiter2 import Waiter, WaitUserInput
+from .group import (
+    QQGroupInfo,
+    QQGroupMemberInfo,
+    ensure_group_members,
+    get_cached_group_members,
+    get_group_member,
+    get_group_member_ids,
+    get_group_member_nickname_map,
+    get_group_name,
+    refresh_group_members,
+)

--- a/src/plugins/nonebot_plugin_larkuser/config.py
+++ b/src/plugins/nonebot_plugin_larkuser/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from nonebot import get_plugin_config
 
 
@@ -6,6 +6,18 @@ class Config(BaseModel):
     """Plugin Config Here"""
 
     user_registered_guest: bool = False
+
+    # ── QQ 官方 Bot 群聊缓存 ──
+    # 是否启用群信息 / 群成员列表的周期性同步
+    qq_group_sync_enabled: bool = True
+    # 周期性同步任务的执行间隔（秒），默认 30 分钟
+    qq_group_sync_interval: int = Field(default=1800, ge=60)
+    # 群成员列表缓存的有效期（秒），超过后由周期任务重新拉取，默认 1 小时
+    qq_group_member_cache_ttl: int = Field(default=3600, ge=60)
+    # 群基本信息缓存的有效期（秒），默认 6 小时
+    qq_group_info_cache_ttl: int = Field(default=21600, ge=60)
+    # 单个群一次同步最多缓存的成员数，防止游标异常时无限翻页
+    qq_group_member_max_count: int = Field(default=3000, ge=1)
 
 
 config = get_plugin_config(Config)

--- a/src/plugins/nonebot_plugin_larkuser/group/__init__.py
+++ b/src/plugins/nonebot_plugin_larkuser/group/__init__.py
@@ -1,0 +1,83 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+"""QQ 官方 Bot 群聊信息与群成员缓存。
+
+QQ 开放平台提供的群信息接口（``/v2/groups/{group_openid}/info``）与群成员列表
+接口（``/v2/groups/{group_openid}/members``）都只对白名单机器人开放，群成员列表
+还有分页与频率限制，所以这里统一维护一份数据库缓存，并对外提供只读查询接口。
+"""
+
+# 导入 sync 以注册群消息监听与周期性同步任务
+from . import sync as sync
+from .cache import (
+    NICK_SOURCE_GROUP_MEMBER,
+    NICK_SOURCE_KEY,
+    ensure_group_known,
+    ensure_group_members,
+    fill_user_nicknames,
+    get_cached_group_members,
+    get_group_member,
+    get_group_member_ids,
+    get_group_member_nickname_map,
+    get_group_name,
+    get_group_record,
+    get_qq_bot,
+    refresh_group_info,
+    refresh_group_members,
+    remember_group,
+    request_group_sync,
+    sync_all_groups,
+)
+from .client import (
+    QQGroupAPIError,
+    QQGroupPermissionError,
+    QQGroupRateLimitError,
+    fetch_all_group_members,
+    fetch_group_info,
+    fetch_group_members_page,
+)
+from .types import QQGroupInfo, QQGroupMemberInfo
+
+__all__ = [
+    "NICK_SOURCE_GROUP_MEMBER",
+    "NICK_SOURCE_KEY",
+    "QQGroupAPIError",
+    "QQGroupInfo",
+    "QQGroupMemberInfo",
+    "QQGroupPermissionError",
+    "QQGroupRateLimitError",
+    "ensure_group_known",
+    "ensure_group_members",
+    "fetch_all_group_members",
+    "fetch_group_info",
+    "fetch_group_members_page",
+    "fill_user_nicknames",
+    "get_cached_group_members",
+    "get_group_member",
+    "get_group_member_ids",
+    "get_group_member_nickname_map",
+    "get_group_name",
+    "get_group_record",
+    "get_qq_bot",
+    "refresh_group_info",
+    "refresh_group_members",
+    "remember_group",
+    "request_group_sync",
+    "sync",
+    "sync_all_groups",
+]

--- a/src/plugins/nonebot_plugin_larkuser/group/cache.py
+++ b/src/plugins/nonebot_plugin_larkuser/group/cache.py
@@ -1,0 +1,441 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+"""QQ 官方 Bot 群聊缓存。
+
+群成员列表接口存在分页与频率限制（60 QPM，每页最多 30 条），因此这里把接口
+结果落到数据库里做缓存，由 :mod:`nonebot_plugin_larkuser.group.sync` 周期性刷新，
+群聊相关功能只读缓存，避免每次都直接打接口。
+
+缓存同时承担两个额外职责：
+
+- 用群成员列表里的昵称补全没有昵称的用户（注册用户昵称为空时填入，
+  未注册用户写入 :class:`~nonebot_plugin_larkuser.models.GuestUser`）；
+- 提供「昵称 → 成员 openid」映射，供 Chat 会话解析 @ 使用。
+"""
+
+import asyncio
+import json
+from datetime import datetime, timedelta
+from typing import Any, Optional, Sequence
+
+from nonebot import get_bots, logger
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot_plugin_orm import get_session
+from sqlalchemy import select
+
+from ..config import config
+from ..models import GuestUser, QQGroupInfo, QQGroupMember, UserData
+from .client import QQGroupAPIError, fetch_all_group_members, fetch_group_info
+from .types import QQGroupInfo as QQGroupInfoData
+from .types import QQGroupMemberInfo
+
+# 自动补全的昵称来源标记，写入 UserData.config[NICK_SOURCE_KEY]
+NICK_SOURCE_KEY = "nick_source"
+NICK_SOURCE_GROUP_MEMBER = "group_member"
+
+# 单次 SQL IN 查询的元素上限（兼容 SQLite 的变量数限制）
+_SQL_CHUNK_SIZE = 200
+
+# 每个群同一时间只允许一次同步
+_sync_locks: dict[str, asyncio.Lock] = {}
+# 本进程内已经触发过同步的群，避免每条消息都去查库/打接口
+_triggered_groups: set[str] = set()
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _now() -> datetime:
+    return datetime.now()
+
+
+def _is_expired(timestamp: Optional[datetime], ttl_seconds: int) -> bool:
+    if timestamp is None:
+        return True
+    return _now() - timestamp > timedelta(seconds=ttl_seconds)
+
+
+def _get_sync_lock(group_openid: str) -> asyncio.Lock:
+    lock = _sync_locks.get(group_openid)
+    if lock is None:
+        lock = _sync_locks[group_openid] = asyncio.Lock()
+    return lock
+
+
+def get_qq_bot(bot_id: str = "") -> Optional[QQBot]:
+    """获取一个可用的 QQ 官方 Bot 实例。
+
+    指定 ``bot_id`` 时只返回该 Bot：group_openid 由平台按应用分配，换一个 Bot
+    查询同一个群必然取不到数据；不指定时返回任意一个在线的 QQ 官方 Bot。
+    """
+    bots = get_bots()
+    if bot_id:
+        bot = bots.get(bot_id)
+        return bot if isinstance(bot, QQBot) else None
+    for bot in bots.values():
+        if isinstance(bot, QQBot):
+            return bot
+    return None
+
+
+def _chunks(items: Sequence[str], size: int = _SQL_CHUNK_SIZE) -> list[Sequence[str]]:
+    return [items[index : index + size] for index in range(0, len(items), size)]
+
+
+async def remember_group(group_openid: str, bot_id: str = "") -> None:
+    """登记一个 QQ 群（不调用接口），已存在时只补全 bot_id。"""
+    async with get_session() as session:
+        record = await session.get(QQGroupInfo, {"group_openid": group_openid})
+        if record is None:
+            session.add(QQGroupInfo(group_openid=group_openid, bot_id=bot_id))
+            await session.commit()
+            logger.info(f"[larkuser] 登记 QQ 群 {group_openid}（bot={bot_id or '未知'}）")
+            return
+        if bot_id and record.bot_id != bot_id:
+            record.bot_id = bot_id
+            await session.commit()
+
+
+async def get_group_record(group_openid: str) -> Optional[QQGroupInfoData]:
+    """读取群的缓存信息（不调用接口），群未被登记时返回 ``None``。"""
+    async with get_session() as session:
+        record = await session.get(QQGroupInfo, {"group_openid": group_openid})
+        if record is None:
+            return None
+        return QQGroupInfoData(
+            group_openid=record.group_openid,
+            group_name=record.group_name,
+            description=record.description,
+            member_count=record.member_count,
+            info_updated_at=record.info_updated_at,
+            members_synced_at=record.members_synced_at,
+        )
+
+
+async def get_cached_group_members(group_openid: str) -> list[QQGroupMemberInfo]:
+    """读取缓存的群成员列表（不调用接口）。"""
+    async with get_session() as session:
+        rows = await session.scalars(
+            select(QQGroupMember)
+            .where(QQGroupMember.group_openid == group_openid)
+            .order_by(QQGroupMember.member_openid),
+        )
+        return [
+            QQGroupMemberInfo(
+                member_openid=row.member_openid,
+                nickname=row.nickname,
+                role=row.role,
+                is_bot=row.is_bot,
+                joined_at=row.joined_at,
+                union_openid=row.union_openid,
+            )
+            for row in rows
+        ]
+
+
+async def get_group_member(group_openid: str, member_openid: str) -> Optional[QQGroupMemberInfo]:
+    """按成员 openid 读取缓存的群成员信息，未缓存时返回 ``None``。"""
+    async with get_session() as session:
+        row = await session.get(QQGroupMember, {"group_openid": group_openid, "member_openid": member_openid})
+        if row is None:
+            return None
+        return QQGroupMemberInfo(
+            member_openid=row.member_openid,
+            nickname=row.nickname,
+            role=row.role,
+            is_bot=row.is_bot,
+            joined_at=row.joined_at,
+            union_openid=row.union_openid,
+        )
+
+
+async def get_group_name(bot: QQBot, group_openid: str) -> Optional[str]:
+    """获取群名称：优先使用缓存，缓存缺失或过期时调用接口刷新。"""
+    record = await get_group_record(group_openid)
+    if (
+        record is not None
+        and record.group_name
+        and not _is_expired(record.info_updated_at, config.qq_group_info_cache_ttl)
+    ):
+        return record.group_name
+    info = await refresh_group_info(bot, group_openid)
+    if info is not None and info.group_name:
+        return info.group_name
+    return record.group_name if record is not None and record.group_name else None
+
+
+async def refresh_group_info(bot: QQBot, group_openid: str) -> Optional[QQGroupInfoData]:
+    """调用接口刷新群基本信息，失败时返回 ``None``（错误信息记录到缓存表中）。"""
+    try:
+        info = await fetch_group_info(bot, group_openid)
+    except QQGroupAPIError as e:
+        await _mark_sync_failed(group_openid, "群信息", str(e))
+        return None
+    async with get_session() as session:
+        record = await session.get(QQGroupInfo, {"group_openid": group_openid})
+        if record is None:
+            record = QQGroupInfo(group_openid=group_openid, bot_id=bot.self_id)
+            session.add(record)
+        record.bot_id = bot.self_id
+        record.group_name = info.group_name
+        record.description = info.description
+        if info.member_count:
+            record.member_count = info.member_count
+        record.info_updated_at = _now()
+        record.last_error = ""
+        await session.commit()
+    return info
+
+
+async def _mark_sync_failed(group_openid: str, subject: str, error: str) -> None:
+    """记录一次同步失败，同时刷新对应时间戳以限制重试频率。"""
+    logger.warning(f"[larkuser] 同步 QQ 群 {group_openid} 的{subject}失败: {error}")
+    now = _now()
+    async with get_session() as session:
+        record = await session.get(QQGroupInfo, {"group_openid": group_openid})
+        if record is None:
+            record = QQGroupInfo(group_openid=group_openid)
+            session.add(record)
+        record.last_error = error[:512]
+        if subject == "群信息":
+            record.info_updated_at = now
+        else:
+            record.members_synced_at = now
+        await session.commit()
+
+
+async def _store_members(
+    group_openid: str,
+    members: list[QQGroupMemberInfo],
+    synced_at: datetime,
+) -> None:
+    """把全量成员列表写入缓存，并删除已经退群的成员。"""
+    async with get_session() as session:
+        record = await session.get(QQGroupInfo, {"group_openid": group_openid})
+        if record is None:
+            record = QQGroupInfo(group_openid=group_openid)
+            session.add(record)
+        rows = await session.scalars(select(QQGroupMember).where(QQGroupMember.group_openid == group_openid))
+        existing = {row.member_openid: row for row in rows}
+        seen: set[str] = set()
+        for member in members:
+            seen.add(member.member_openid)
+            row = existing.get(member.member_openid)
+            if row is None:
+                session.add(
+                    QQGroupMember(
+                        group_openid=group_openid,
+                        member_openid=member.member_openid,
+                        nickname=member.nickname,
+                        role=member.role,
+                        is_bot=member.is_bot,
+                        joined_at=member.joined_at,
+                        union_openid=member.union_openid,
+                        updated_at=synced_at,
+                    ),
+                )
+                continue
+            row.nickname = member.nickname
+            row.role = member.role
+            row.is_bot = member.is_bot
+            row.joined_at = member.joined_at
+            row.union_openid = member.union_openid
+            row.updated_at = synced_at
+        for member_openid, row in existing.items():
+            if member_openid not in seen:
+                await session.delete(row)
+        record.member_count = len(members)
+        record.members_synced_at = synced_at
+        record.last_error = ""
+        await session.commit()
+
+
+async def fill_user_nicknames(members: list[QQGroupMemberInfo]) -> int:
+    """用群成员列表里的昵称补全没有昵称的用户，返回被更新的用户数。
+
+    - 已经存在于 ``UserData``（已注册用户）但昵称为空时填入，并标记来源为
+      ``group_member``，不会覆盖用户自己设置的昵称；
+    - 未注册用户写入 ``GuestUser``，已存在时按最新昵称更新。
+    """
+    candidates = [member for member in members if member.nickname and not member.is_bot]
+    if not candidates:
+        return 0
+    by_openid = {member.member_openid: member for member in candidates}
+    updated = 0
+    async with get_session() as session:
+        for chunk in _chunks(list(by_openid)):
+            user_rows = {
+                row.user_id: row for row in await session.scalars(select(UserData).where(UserData.user_id.in_(chunk)))
+            }
+            guest_rows = {
+                row.user_id: row for row in await session.scalars(select(GuestUser).where(GuestUser.user_id.in_(chunk)))
+            }
+            for member_openid in chunk:
+                nickname = by_openid[member_openid].nickname
+                if (user := user_rows.get(member_openid)) is not None:
+                    if user.nickname:
+                        continue
+                    user.nickname = nickname
+                    user.config = _with_nick_source(user.config)
+                    updated += 1
+                    continue
+                if (guest := guest_rows.get(member_openid)) is None:
+                    session.add(GuestUser(user_id=member_openid, nickname=nickname))
+                    updated += 1
+                elif guest.nickname != nickname:
+                    guest.nickname = nickname
+                    updated += 1
+        await session.commit()
+    return updated
+
+
+def _with_nick_source(raw_config: Optional[str]) -> str:
+    """在用户配置里写入自动补全来源标记。"""
+    try:
+        user_config: dict[str, Any] = json.loads(raw_config or "{}")
+    except json.JSONDecodeError:
+        user_config = {}
+    user_config[NICK_SOURCE_KEY] = NICK_SOURCE_GROUP_MEMBER
+    return json.dumps(user_config)
+
+
+async def _resolve_user_nicknames(member_openids: list[str]) -> dict[str, str]:
+    """批量查询成员在 Moonlark 中的昵称（已注册用户优先）。"""
+    resolved: dict[str, str] = {}
+    if not member_openids:
+        return resolved
+    async with get_session() as session:
+        for chunk in _chunks(member_openids):
+            guest_rows = await session.execute(
+                select(GuestUser.user_id, GuestUser.nickname).where(GuestUser.user_id.in_(chunk)),
+            )
+            resolved.update({user_id: nickname for user_id, nickname in guest_rows if nickname})
+            user_rows = await session.execute(
+                select(UserData.user_id, UserData.nickname).where(UserData.user_id.in_(chunk)),
+            )
+            resolved.update({user_id: nickname for user_id, nickname in user_rows if nickname})
+    return resolved
+
+
+async def get_group_member_nickname_map(group_openid: str) -> dict[str, str]:
+    """构造「昵称 → 成员 openid」映射，用于解析会话里出现的 @昵称。
+
+    昵称优先取 Moonlark 中的昵称，没有时退回到群成员列表中的 QQ 昵称。
+    """
+    members = await get_cached_group_members(group_openid)
+    if not members:
+        return {}
+    nicknames = await _resolve_user_nicknames([member.member_openid for member in members])
+    result: dict[str, str] = {}
+    for member in members:
+        nickname = nicknames.get(member.member_openid) or member.nickname
+        if nickname:
+            result[nickname] = member.member_openid
+    return result
+
+
+async def refresh_group_members(bot: QQBot, group_openid: str) -> list[QQGroupMemberInfo]:
+    """全量刷新群成员缓存（含分页、频率限制与昵称补全），返回最新成员列表。"""
+    async with _get_sync_lock(group_openid):
+        synced_at = _now()
+        try:
+            members = await fetch_all_group_members(
+                bot,
+                group_openid,
+                max_members=config.qq_group_member_max_count,
+            )
+        except QQGroupAPIError as e:
+            await _mark_sync_failed(group_openid, "群成员列表", str(e))
+            return await get_cached_group_members(group_openid)
+        await _store_members(group_openid, members, synced_at)
+        updated = await fill_user_nicknames(members)
+        logger.info(f"[larkuser] 已同步 QQ 群 {group_openid} 的 {len(members)} 名成员（补全 {updated} 个昵称）")
+        return members
+
+
+async def ensure_group_members(bot: QQBot, group_openid: str) -> list[QQGroupMemberInfo]:
+    """确保群成员缓存可用：从未同步过（或缓存为空）时同步一次。
+
+    同步失败同样会刷新同步时间戳，因此不会在每次调用时反复打接口，
+    真正的周期性重试由 :func:`sync_all_groups` 按缓存有效期负责。
+    """
+    record = await get_group_record(group_openid)
+    if record is None or record.members_synced_at is None:
+        return await refresh_group_members(bot, group_openid)
+    members = await get_cached_group_members(group_openid)
+    if not members:
+        return await refresh_group_members(bot, group_openid)
+    return members
+
+
+async def get_group_member_ids(bot: QQBot, group_openid: str) -> list[str]:
+    """获取群成员 openid 列表（供 waifu 等插件使用）。"""
+    return [member.member_openid for member in await ensure_group_members(bot, group_openid)]
+
+
+async def _sync_group(bot: QQBot, group_openid: str) -> None:
+    try:
+        await remember_group(group_openid, bot.self_id)
+        await refresh_group_info(bot, group_openid)
+        await refresh_group_members(bot, group_openid)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.exception(f"[larkuser] 同步 QQ 群 {group_openid} 失败: {e}")
+
+
+def request_group_sync(bot: QQBot, group_openid: str) -> None:
+    """在后台同步一次群信息与群成员列表，不阻塞调用方。
+
+    同一个群在本进程内只会被触发一次，后续刷新由周期性任务负责。
+    """
+    if group_openid in _triggered_groups:
+        return
+    _triggered_groups.add(group_openid)
+    task = asyncio.ensure_future(_sync_group(bot, group_openid))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+async def ensure_group_known(bot: QQBot, group_openid: str) -> None:
+    """登记群并触发一次后台同步（供收到群消息时调用）。"""
+    if not group_openid:
+        return
+    if group_openid not in _triggered_groups:
+        await remember_group(group_openid, bot.self_id)
+    request_group_sync(bot, group_openid)
+
+
+async def sync_all_groups() -> None:
+    """周期任务：刷新所有已知群的群信息与群成员缓存。"""
+    if not config.qq_group_sync_enabled:
+        return
+    async with get_session() as session:
+        rows = await session.execute(
+            select(QQGroupInfo.group_openid, QQGroupInfo.bot_id, QQGroupInfo.members_synced_at),
+        )
+        groups = list(rows)
+    if not groups:
+        return
+    logger.debug(f"[larkuser] 开始同步 {len(groups)} 个 QQ 群的成员缓存")
+    for group_openid, bot_id, members_synced_at in groups:
+        if not _is_expired(members_synced_at, config.qq_group_member_cache_ttl):
+            continue
+        bot = get_qq_bot(bot_id)
+        if bot is None:
+            logger.debug(f"[larkuser] Bot {bot_id or '未记录'} 未连接，跳过群 {group_openid}")
+            continue
+        await _sync_group(bot, group_openid)

--- a/src/plugins/nonebot_plugin_larkuser/group/client.py
+++ b/src/plugins/nonebot_plugin_larkuser/group/client.py
@@ -1,0 +1,245 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+"""QQ 官方 Bot 群聊接口客户端。
+
+``nonebot-adapter-qq`` 目前没有提供下面两个接口，这里按 QQ 开放平台文档直接实现：
+
+- ``GET /v2/groups/{group_openid}/info``：获取群基本信息（30 QPM）；
+- ``GET /v2/groups/{group_openid}/members``：获取群成员列表（60 QPM，每页最多 30 条，游标分页）。
+
+两个接口都只对白名单机器人开放，没有权限时平台返回错误码 ``11253``。
+"""
+
+import asyncio
+import json
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from nonebot import logger
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot.drivers import Request, Response
+
+from .types import QQGroupInfo, QQGroupMemberInfo
+
+# 应用无接口访问权限（仅白名单机器人可用）
+PERMISSION_DENIED_CODE = 11253
+
+# 群基本信息：30 QPM，留出余量按 ~28 QPM 调用
+GROUP_INFO_MIN_INTERVAL = 2.2
+# 群成员列表：60 QPM，留出余量按 ~55 QPM 调用
+GROUP_MEMBERS_MIN_INTERVAL = 1.1
+
+# 群成员列表单页最多返回的成员数（平台固定值，仅用于日志说明）
+MEMBERS_PAGE_SIZE = 30
+
+
+class QQGroupAPIError(Exception):
+    """QQ 群接口调用失败"""
+
+    def __init__(self, message: str, *, code: Optional[int] = None, status_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
+
+class QQGroupPermissionError(QQGroupAPIError):
+    """当前应用没有调用该接口的权限（错误码 11253）"""
+
+
+class QQGroupRateLimitError(QQGroupAPIError):
+    """触发了平台的接口频率限制（HTTP 429）"""
+
+
+class _Throttle:
+    """请求节流器：串行化同一类接口的调用，保证调用间隔不小于 ``min_interval``。"""
+
+    def __init__(self, min_interval: float) -> None:
+        self._min_interval = min_interval
+        self._lock = asyncio.Lock()
+        self._last_call = 0.0
+
+    async def __aenter__(self) -> "_Throttle":
+        await self._lock.acquire()
+        wait = self._last_call + self._min_interval - time.monotonic()
+        if wait > 0:
+            await asyncio.sleep(wait)
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        self._last_call = time.monotonic()
+        self._lock.release()
+
+
+_info_throttle = _Throttle(GROUP_INFO_MIN_INTERVAL)
+_members_throttle = _Throttle(GROUP_MEMBERS_MIN_INTERVAL)
+
+
+def _parse_time(value: Any) -> Optional[datetime]:
+    """把接口返回的 RFC3339 时间转换为不带时区的 UTC 时间。"""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        logger.debug(f"无法解析 QQ 群成员入群时间: {value!r}")
+        return None
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def _extract_error(response: Response) -> tuple[Optional[int], Optional[str]]:
+    """从响应体中提取平台错误码与错误信息。"""
+    if not response.content:
+        return None, None
+    try:
+        body = json.loads(response.content)
+    except json.JSONDecodeError:
+        return None, None
+    if not isinstance(body, dict):
+        return None, None
+    code = body.get("code")
+    message = body.get("message")
+    return (int(code) if isinstance(code, int) else None), (str(message) if message else None)
+
+
+def _raise_for_response(response: Response) -> dict[str, Any]:
+    """检查响应，失败时抛出 :class:`QQGroupAPIError`，成功时返回响应体。"""
+    code, message = _extract_error(response)
+    if response.status_code == 429:
+        raise QQGroupRateLimitError("QQ 群接口触发频率限制", code=code, status_code=429)
+    if code == PERMISSION_DENIED_CODE:
+        raise QQGroupPermissionError(
+            f"应用没有该群接口的访问权限（11253）: {message or ''}".strip(),
+            code=code,
+            status_code=response.status_code,
+        )
+    if not 200 <= response.status_code < 300:
+        raise QQGroupAPIError(
+            f"QQ 群接口返回异常状态码 {response.status_code}: {message or response.content!r}",
+            code=code,
+            status_code=response.status_code,
+        )
+    if code is not None and code != 0:
+        raise QQGroupAPIError(f"QQ 群接口返回错误码 {code}: {message or ''}".strip(), code=code)
+    if not response.content:
+        return {}
+    try:
+        return json.loads(response.content)
+    except json.JSONDecodeError as e:
+        raise QQGroupAPIError(f"QQ 群接口返回了无法解析的响应: {response.content[:200]!r}") from e
+
+
+async def _request_json(
+    bot: QQBot,
+    path: tuple[str, ...],
+    *,
+    throttle: _Throttle,
+    params: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """调用 QQ 群接口并返回 JSON 响应体。"""
+    async with throttle:
+        request = Request(
+            "GET",
+            bot.adapter.get_api_base().joinpath("v2", "groups", *path),
+            params=params or {},
+            timeout=30,
+        )
+        request.headers.update(await bot.get_authorization_header())
+        try:
+            response = await bot.adapter.request(request)
+        except Exception as e:
+            # 网络层异常统一转换为接口异常，调用方只需处理 QQGroupAPIError
+            raise QQGroupAPIError(f"请求 QQ 群接口失败: {e}") from e
+    return _raise_for_response(response)
+
+
+async def fetch_group_info(bot: QQBot, group_openid: str) -> QQGroupInfo:
+    """获取群基本信息（群名称、简介、成员人数）。"""
+    data = await _request_json(
+        bot,
+        (group_openid, "info"),
+        throttle=_info_throttle,
+    )
+    member_count = data.get("group_member_num")
+    return QQGroupInfo(
+        group_openid=str(data.get("group_openid") or group_openid),
+        group_name=str(data.get("group_name") or ""),
+        description=str(data.get("group_finger_memo") or ""),
+        member_count=int(member_count) if isinstance(member_count, int) else 0,
+    )
+
+
+def parse_group_member(data: dict[str, Any]) -> QQGroupMemberInfo:
+    """把接口返回的单个成员对象转换为 :class:`QQGroupMemberInfo`。"""
+    role = str(data.get("member_role") or "member")
+    return QQGroupMemberInfo(
+        member_openid=str(data.get("member_openid") or ""),
+        nickname=str(data.get("username") or ""),
+        role=role if role in ("member", "admin", "owner") else "member",
+        is_bot=bool(data.get("bot")),
+        joined_at=_parse_time(data.get("joined_at")),
+        union_openid=(str(data["union_openid"]) if data.get("union_openid") else None),
+    )
+
+
+async def fetch_group_members_page(
+    bot: QQBot,
+    group_openid: str,
+    cursor: str = "",
+) -> tuple[list[QQGroupMemberInfo], str]:
+    """获取一页群成员列表，返回 ``(成员列表, 下一页游标)``。
+
+    下一页游标为空串表示已经到末页。
+    """
+    data = await _request_json(
+        bot,
+        (group_openid, "members"),
+        throttle=_members_throttle,
+        params={"cursor": cursor},
+    )
+    members = [
+        member for member in (parse_group_member(raw) for raw in data.get("members") or []) if member.member_openid
+    ]
+    return members, str(data.get("next_cursor") or "")
+
+
+async def fetch_all_group_members(
+    bot: QQBot,
+    group_openid: str,
+    *,
+    max_members: int,
+) -> list[QQGroupMemberInfo]:
+    """翻页拉取全部群成员（受 ``max_members`` 限制，防止异常游标导致死循环）。"""
+    members: list[QQGroupMemberInfo] = []
+    cursor = ""
+    seen_cursors = {""}
+    while True:
+        page, next_cursor = await fetch_group_members_page(bot, group_openid, cursor)
+        members.extend(page)
+        if not next_cursor or next_cursor in seen_cursors:
+            break
+        if len(members) >= max_members:
+            logger.warning(
+                f"[larkuser] 群 {group_openid} 成员数超过上限 {max_members}，停止继续拉取",
+            )
+            break
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+    return members[:max_members]

--- a/src/plugins/nonebot_plugin_larkuser/group/sync.py
+++ b/src/plugins/nonebot_plugin_larkuser/group/sync.py
@@ -1,0 +1,64 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+"""QQ 官方 Bot 群成员缓存的发现与周期性刷新。
+
+群成员列表接口自身没有「推送」能力，而 Moonlark 又需要知道群里有谁，因此这里：
+
+- 收到 QQ 群消息时登记该群，并在后台同步一次群信息与成员列表；
+- 周期性任务按缓存有效期刷新所有已登记群的群信息与成员列表。
+"""
+
+from nonebot import on_message
+from nonebot.adapters import Bot, Event
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot.adapters.qq.event import GroupMessageCreateEvent
+from nonebot.log import logger
+from nonebot_plugin_apscheduler import scheduler
+
+from ..config import config
+from .cache import ensure_group_known, sync_all_groups
+
+
+def _is_qq_group_message(bot: Bot) -> bool:
+    """规则：仅处理 QQ 官方 Bot 的群聊消息"""
+    return isinstance(bot, QQBot)
+
+
+group_sync_matcher = on_message(block=False, priority=9, rule=_is_qq_group_message)
+
+
+@group_sync_matcher.handle()
+async def _(bot: Bot, event: Event) -> None:
+    if not isinstance(bot, QQBot) or not isinstance(event, GroupMessageCreateEvent):
+        return
+    if not config.qq_group_sync_enabled:
+        return
+    await ensure_group_known(bot, event.group_openid)
+
+
+@scheduler.scheduled_job(
+    "interval",
+    seconds=config.qq_group_sync_interval,
+    id="larkuser_qq_group_cache_sync",
+    max_instances=1,
+)
+async def _sync_qq_group_cache() -> None:
+    try:
+        await sync_all_groups()
+    except Exception as e:
+        logger.exception(f"[larkuser] 刷新 QQ 群成员缓存失败: {e}")

--- a/src/plugins/nonebot_plugin_larkuser/group/types.py
+++ b/src/plugins/nonebot_plugin_larkuser/group/types.py
@@ -1,0 +1,46 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+"""QQ 官方 Bot 群聊相关的数据类型。"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class QQGroupMemberInfo:
+    """一个群成员的信息"""
+
+    member_openid: str
+    nickname: str = ""
+    role: str = "member"
+    is_bot: bool = False
+    joined_at: Optional[datetime] = None
+    union_openid: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class QQGroupInfo:
+    """群基本信息（附带本地缓存的同步时间）"""
+
+    group_openid: str
+    group_name: str = ""
+    description: str = ""
+    member_count: int = 0
+    info_updated_at: Optional[datetime] = None
+    members_synced_at: Optional[datetime] = None

--- a/src/plugins/nonebot_plugin_larkuser/models.py
+++ b/src/plugins/nonebot_plugin_larkuser/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 from nonebot_plugin_orm import Model
-from sqlalchemy import DateTime, String, Text
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 
@@ -21,3 +21,40 @@ class UserData(Model):
 class GuestUser(Model):
     user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     nickname: Mapped[str] = mapped_column(String(256))
+
+
+class QQGroupInfo(Model):
+    """QQ 官方 Bot 群聊缓存（群基本信息 + 群成员同步状态）
+
+    ``group_openid`` 由 QQ 开放平台按应用分配，同一个群在不同 Bot（不同 AppID）
+    下会有不同的 openid，因此这里把发现该群的 Bot 一并记录下来。
+    """
+
+    __tablename__ = "nonebot_plugin_larkuser_qq_group_info"
+
+    group_openid: Mapped[str] = mapped_column(String(128), primary_key=True)
+    bot_id: Mapped[str] = mapped_column(String(64), default="")
+    group_name: Mapped[str] = mapped_column(String(256), default="")
+    description: Mapped[str] = mapped_column(String(512), default="")
+    member_count: Mapped[int] = mapped_column(Integer(), default=0)
+    # 最后一次群信息刷新时间（无论成功与否，用于控制接口调用频率）
+    info_updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, default=None)
+    # 最后一次群成员列表同步时间（无论成功与否，用于控制接口调用频率）
+    members_synced_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, default=None)
+    # 最近一次同步失败的原因，空串表示最近一次同步成功
+    last_error: Mapped[str] = mapped_column(String(512), default="")
+
+
+class QQGroupMember(Model):
+    """QQ 官方 Bot 群成员缓存（来自 /v2/groups/{group_openid}/members）"""
+
+    __tablename__ = "nonebot_plugin_larkuser_qq_group_member"
+
+    group_openid: Mapped[str] = mapped_column(String(128), primary_key=True)
+    member_openid: Mapped[str] = mapped_column(String(128), primary_key=True)
+    nickname: Mapped[str] = mapped_column(String(256), default="")
+    role: Mapped[str] = mapped_column(String(16), default="member")
+    is_bot: Mapped[bool] = mapped_column(Boolean(), default=False)
+    joined_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, default=None)
+    union_openid: Mapped[Optional[str]] = mapped_column(String(128), nullable=True, default=None)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, default=None)

--- a/src/plugins/nonebot_plugin_message_summary/matcher.py
+++ b/src/plugins/nonebot_plugin_message_summary/matcher.py
@@ -3,6 +3,7 @@ from nonebot.typing import T_State
 from nonebot.adapters import Event, Bot, Message
 from nonebot.adapters.onebot.v11 import GroupMessageEvent
 from nonebot.adapters.onebot.v11 import Bot as OB11Bot
+from nonebot.adapters.qq import Bot as QQBot
 from nonebot.params import CommandArg
 from nonebot_plugin_alconna import on_alconna, Alconna, Subcommand, Args, UniMessage, Reply, At
 from nonebot_plugin_orm import async_scoped_session, get_session
@@ -12,7 +13,7 @@ from datetime import datetime, timedelta
 
 from nonebot_plugin_larkutils import get_user_id, get_group_id, open_file, FileType
 from nonebot_plugin_larkutils.file import FileManager
-from nonebot_plugin_larkuser import get_user
+from nonebot_plugin_larkuser import get_group_name, get_user
 from nonebot_plugin_ranking import generate_image
 from nonebot_plugin_chat.utils.group import parse_message_to_string
 from nonebot_plugin_chat.models import ChatGroup
@@ -448,7 +449,9 @@ async def handle_decision(
             numeric_group_id = int(group_id.split("_")[-1]) if "_" in group_id else int(group_id)
             group_info = await bot.get_group_info(group_id=numeric_group_id)
             group_name = group_info.get("group_name", "群")
-        # QQ 适配器没有直接获取群名称的 API，使用默认值
+        elif isinstance(bot, QQBot) and (group_openid := getattr(event, "group_openid", None)):
+            # QQ 官方 Bot：群名称取自 /v2/groups/{group_openid}/info 的缓存
+            group_name = await get_group_name(bot, str(group_openid)) or group_name
     except Exception as e:
         logger.warning(f"获取群名称失败: {e}")
 

--- a/tests/test_larkuser_qq_group.py
+++ b/tests/test_larkuser_qq_group.py
@@ -1,0 +1,474 @@
+"""QQ 官方 Bot 群聊信息与群成员缓存（larkuser）的回归测试。
+
+覆盖点：
+
+- 群成员列表接口的解析、游标翻页与上限保护；
+- 接口错误码（11253 无权限、429 频率限制）到异常类型的映射；
+- 群成员缓存的写入 / 淘汰；
+- 用群成员昵称补全 GuestUser（未注册用户）与昵称为空的已注册用户；
+- 「昵称 -> 成员 openid」映射优先使用 Moonlark 昵称，供 Chat 解析 @ 使用；
+- 群名称优先读取缓存，未过期时不调用接口。
+"""
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+
+@pytest.fixture(autouse=True)
+def fast_throttle(monkeypatch):
+    """去掉接口节流等待，避免测试变慢"""
+    from nonebot_plugin_larkuser.group import client
+
+    monkeypatch.setattr(client._info_throttle, "_min_interval", 0.0)
+    monkeypatch.setattr(client._members_throttle, "_min_interval", 0.0)
+
+
+@pytest.fixture
+async def db(monkeypatch):
+    """把缓存模块的数据库会话替换为临时内存数据库"""
+    from nonebot_plugin_larkuser.group import cache
+    from nonebot_plugin_larkuser.models import QQGroupInfo
+
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(QQGroupInfo.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(cache, "get_session", lambda **_: factory())
+    yield factory
+    await engine.dispose()
+
+
+def _bot() -> MagicMock:
+    bot = MagicMock()
+    bot.self_id = "bot-1"
+    return bot
+
+
+class _FakeAdapter:
+    """只返回固定响应的 QQ 适配器替身"""
+
+    def __init__(self, response) -> None:
+        self.response = response
+        self.requests = []
+
+    def get_api_base(self):
+        from nonebot.drivers import URL
+
+        return URL("https://api.sgroup.qq.com")
+
+    async def request(self, request):
+        self.requests.append(request)
+        return self.response
+
+
+class _FakeQQBot:
+    """最小化的 QQ 官方 Bot 替身"""
+
+    def __init__(self, response) -> None:
+        self.adapter = _FakeAdapter(response)
+        self.self_id = "bot-1"
+
+    async def get_authorization_header(self) -> dict[str, str]:
+        return {"Authorization": "QQBot test-token"}
+
+
+def _json_response(payload, status_code: int = 200):
+    from nonebot.drivers import Response
+
+    return Response(status_code, content=json.dumps(payload).encode())
+
+
+# ── 接口解析 ──
+
+
+def test_parse_group_member_converts_joined_at_to_utc_naive() -> None:
+    from nonebot_plugin_larkuser.group.client import parse_group_member
+
+    member = parse_group_member(
+        {
+            "member_openid": "openid-1",
+            "username": "阳光小助手",
+            "member_role": "admin",
+            "bot": False,
+            "joined_at": "2025-08-20T09:15:00+08:00",
+            "union_openid": "union-1",
+        },
+    )
+    assert member.member_openid == "openid-1"
+    assert member.nickname == "阳光小助手"
+    assert member.role == "admin"
+    assert member.is_bot is False
+    assert member.union_openid == "union-1"
+    assert member.joined_at == datetime(2025, 8, 20, 1, 15)
+
+
+def test_parse_group_member_tolerates_unknown_role_and_time() -> None:
+    from nonebot_plugin_larkuser.group.client import parse_group_member
+
+    member = parse_group_member({"member_openid": "openid-2", "member_role": "stranger", "joined_at": "not-a-time"})
+    assert member.role == "member"
+    assert member.joined_at is None
+    assert member.nickname == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_group_members_page_parses_response() -> None:
+    from nonebot_plugin_larkuser.group.client import fetch_group_members_page
+
+    bot = _FakeQQBot(
+        _json_response(
+            {
+                "members": [
+                    {"member_openid": "a1", "username": "AAA", "member_role": "member", "bot": False},
+                    {"member_openid": "", "username": "缺少 openid 的脏数据"},
+                ],
+                "next_cursor": "cursor-2",
+            },
+        ),
+    )
+    members, next_cursor = await fetch_group_members_page(bot, "group-openid", "cursor-1")
+    assert [member.member_openid for member in members] == ["a1"]
+    assert next_cursor == "cursor-2"
+    request = bot.adapter.requests[0]
+    assert request.method == "GET"
+    assert str(request.url).startswith("https://api.sgroup.qq.com/v2/groups/group-openid/members")
+    assert request.url.query.get("cursor") == "cursor-1"
+    assert request.headers["Authorization"] == "QQBot test-token"
+
+
+@pytest.mark.asyncio
+async def test_fetch_group_info_maps_fields() -> None:
+    from nonebot_plugin_larkuser.group.client import fetch_group_info
+
+    bot = _FakeQQBot(
+        _json_response(
+            {
+                "group_openid": "group-openid",
+                "group_name": "读书分享会",
+                "group_finger_memo": "每周共读一本好书",
+                "group_member_num": 256,
+            },
+        ),
+    )
+    info = await fetch_group_info(bot, "group-openid")
+    assert (info.group_name, info.description, info.member_count) == ("读书分享会", "每周共读一本好书", 256)
+    assert str(bot.adapter.requests[0].url).endswith("/v2/groups/group-openid/info")
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_group_members_follows_cursor(monkeypatch) -> None:
+    from nonebot_plugin_larkuser.group import client
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+
+    pages = {
+        "": ([QQGroupMemberInfo(member_openid="a1")], "cursor-1"),
+        "cursor-1": ([QQGroupMemberInfo(member_openid="a2")], ""),
+    }
+
+    async def fake_page(bot, group_openid, cursor=""):
+        return pages[cursor]
+
+    monkeypatch.setattr(client, "fetch_group_members_page", fake_page)
+    members = await client.fetch_all_group_members(_bot(), "group-openid", max_members=100)
+    assert [member.member_openid for member in members] == ["a1", "a2"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_group_members_stops_on_looping_cursor(monkeypatch) -> None:
+    """接口一直返回同一个游标时不会无限翻页"""
+    from nonebot_plugin_larkuser.group import client
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+
+    calls = 0
+
+    async def fake_page(bot, group_openid, cursor=""):
+        nonlocal calls
+        calls += 1
+        return [QQGroupMemberInfo(member_openid=f"member-{calls}")], "same-cursor"
+
+    monkeypatch.setattr(client, "fetch_group_members_page", fake_page)
+    members = await client.fetch_all_group_members(_bot(), "group-openid", max_members=100)
+    assert calls == 2
+    assert len(members) == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_group_members_respects_max_members(monkeypatch) -> None:
+    from nonebot_plugin_larkuser.group import client
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+
+    counter = iter(range(1000))
+
+    async def fake_page(bot, group_openid, cursor=""):
+        return [QQGroupMemberInfo(member_openid=f"member-{next(counter)}")], f"cursor-{next(counter)}"
+
+    monkeypatch.setattr(client, "fetch_group_members_page", fake_page)
+    members = await client.fetch_all_group_members(_bot(), "group-openid", max_members=3)
+    assert len(members) == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_group_info_maps_permission_error() -> None:
+    from nonebot_plugin_larkuser.group.client import QQGroupPermissionError, fetch_group_info
+
+    bot = _FakeQQBot(_json_response({"code": 11253, "message": "应用无接口访问权限"}, status_code=403))
+    with pytest.raises(QQGroupPermissionError) as exc_info:
+        await fetch_group_info(bot, "group-openid")
+    assert exc_info.value.code == 11253
+
+
+@pytest.mark.asyncio
+async def test_fetch_group_members_maps_rate_limit() -> None:
+    from nonebot.drivers import Response
+    from nonebot_plugin_larkuser.group.client import QQGroupRateLimitError, fetch_group_members_page
+
+    bot = _FakeQQBot(Response(429, content=b""))
+    with pytest.raises(QQGroupRateLimitError):
+        await fetch_group_members_page(bot, "group-openid")
+
+
+@pytest.mark.asyncio
+async def test_fetch_group_members_maps_other_errors() -> None:
+    from nonebot_plugin_larkuser.group.client import QQGroupAPIError, fetch_group_members_page
+
+    bot = _FakeQQBot(_json_response({"code": 10001, "message": "内部错误"}, status_code=500))
+    with pytest.raises(QQGroupAPIError) as exc_info:
+        await fetch_group_members_page(bot, "group-openid")
+    assert exc_info.value.code == 10001
+
+
+# ── 昵称补全 ──
+
+
+@pytest.mark.asyncio
+async def test_fill_user_nicknames_creates_guest_user(db) -> None:
+    from nonebot_plugin_larkuser.group.cache import fill_user_nicknames
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+    from nonebot_plugin_larkuser.models import GuestUser
+
+    updated = await fill_user_nicknames(
+        [
+            QQGroupMemberInfo(member_openid="guest-1", nickname="阳光小助手"),
+            QQGroupMemberInfo(member_openid="bot-1", nickname="Moonlark", is_bot=True),
+        ],
+    )
+    assert updated == 1
+    async with db() as session:
+        assert (await session.get(GuestUser, "guest-1")).nickname == "阳光小助手"
+        assert await session.get(GuestUser, "bot-1") is None
+
+
+@pytest.mark.asyncio
+async def test_fill_user_nicknames_updates_changed_guest_nickname(db) -> None:
+    from nonebot_plugin_larkuser.group.cache import fill_user_nicknames
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+    from nonebot_plugin_larkuser.models import GuestUser
+
+    async with db() as session:
+        session.add(GuestUser(user_id="guest-1", nickname="旧昵称"))
+        await session.commit()
+
+    await fill_user_nicknames([QQGroupMemberInfo(member_openid="guest-1", nickname="新昵称")])
+    async with db() as session:
+        assert (await session.get(GuestUser, "guest-1")).nickname == "新昵称"
+
+
+@pytest.mark.asyncio
+async def test_fill_user_nicknames_fills_empty_registered_nickname(db) -> None:
+    from nonebot_plugin_larkuser.group.cache import NICK_SOURCE_GROUP_MEMBER, NICK_SOURCE_KEY, fill_user_nicknames
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+    from nonebot_plugin_larkuser.models import UserData
+
+    async with db() as session:
+        session.add(UserData(user_id="user-1", nickname="", register_time=datetime.now(), config="{}"))
+        await session.commit()
+
+    assert await fill_user_nicknames([QQGroupMemberInfo(member_openid="user-1", nickname="已注册用户")]) == 1
+    async with db() as session:
+        user = await session.get(UserData, "user-1")
+        assert user.nickname == "已注册用户"
+        assert json.loads(user.config)[NICK_SOURCE_KEY] == NICK_SOURCE_GROUP_MEMBER
+
+
+@pytest.mark.asyncio
+async def test_fill_user_nicknames_keeps_user_set_nickname(db) -> None:
+    from nonebot_plugin_larkuser.group.cache import fill_user_nicknames
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+    from nonebot_plugin_larkuser.models import GuestUser, UserData
+
+    async with db() as session:
+        session.add(UserData(user_id="user-1", nickname="我自己设置的昵称", register_time=datetime.now(), config="{}"))
+        await session.commit()
+
+    assert await fill_user_nicknames([QQGroupMemberInfo(member_openid="user-1", nickname="QQ 昵称")]) == 0
+    async with db() as session:
+        assert (await session.get(UserData, "user-1")).nickname == "我自己设置的昵称"
+        assert await session.get(GuestUser, "user-1") is None
+
+
+# ── 缓存读写 ──
+
+
+@pytest.mark.asyncio
+async def test_refresh_group_members_stores_and_prunes(db, monkeypatch) -> None:
+    from nonebot_plugin_larkuser.group import cache
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+
+    async def first_sync(bot, group_openid, *, max_members):
+        return [
+            QQGroupMemberInfo(member_openid="a1", nickname="AAA", role="owner"),
+            QQGroupMemberInfo(member_openid="a2", nickname="BBB"),
+        ]
+
+    monkeypatch.setattr(cache, "fetch_all_group_members", first_sync)
+    await cache.refresh_group_members(_bot(), "group-openid")
+    members = await cache.get_cached_group_members("group-openid")
+    assert {member.member_openid for member in members} == {"a1", "a2"}
+    assert (await cache.get_group_member("group-openid", "a1")).role == "owner"
+
+    async def second_sync(bot, group_openid, *, max_members):
+        return [QQGroupMemberInfo(member_openid="a2", nickname="BBB-新")]
+
+    monkeypatch.setattr(cache, "fetch_all_group_members", second_sync)
+    await cache.refresh_group_members(_bot(), "group-openid")
+    members = await cache.get_cached_group_members("group-openid")
+    assert [member.member_openid for member in members] == ["a2"]
+    assert members[0].nickname == "BBB-新"
+
+
+@pytest.mark.asyncio
+async def test_refresh_group_members_keeps_cache_on_api_error(db, monkeypatch) -> None:
+    from nonebot_plugin_larkuser.group import cache
+    from nonebot_plugin_larkuser.group.client import QQGroupPermissionError
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+
+    async def ok(bot, group_openid, *, max_members):
+        return [QQGroupMemberInfo(member_openid="a1", nickname="AAA")]
+
+    monkeypatch.setattr(cache, "fetch_all_group_members", ok)
+    await cache.refresh_group_members(_bot(), "group-openid")
+
+    async def denied(bot, group_openid, *, max_members):
+        raise QQGroupPermissionError("无权限", code=11253)
+
+    monkeypatch.setattr(cache, "fetch_all_group_members", denied)
+    members = await cache.refresh_group_members(_bot(), "group-openid")
+    assert [member.member_openid for member in members] == ["a1"]
+
+
+@pytest.mark.asyncio
+async def test_get_group_member_nickname_map_prefers_moonlark_nickname(db, monkeypatch) -> None:
+    from nonebot_plugin_larkuser.group import cache
+    from nonebot_plugin_larkuser.group.types import QQGroupMemberInfo
+    from nonebot_plugin_larkuser.models import GuestUser, UserData
+
+    async with db() as session:
+        session.add(UserData(user_id="a1", nickname="自设昵称", register_time=datetime.now(), config="{}"))
+        await session.commit()
+
+    async def sync(bot, group_openid, *, max_members):
+        return [
+            QQGroupMemberInfo(member_openid="a1", nickname="QQ 上的昵称"),
+            QQGroupMemberInfo(member_openid="a2", nickname="只有 QQ 昵称"),
+            QQGroupMemberInfo(member_openid="a3", nickname=""),
+        ]
+
+    monkeypatch.setattr(cache, "fetch_all_group_members", sync)
+    await cache.refresh_group_members(_bot(), "group-openid")
+
+    # 已注册用户保留自己的昵称；未注册用户使用群成员列表里的昵称
+    async with db() as session:
+        assert (await session.get(UserData, "a1")).nickname == "自设昵称"
+        assert (await session.get(GuestUser, "a2")).nickname == "只有 QQ 昵称"
+        assert await session.get(GuestUser, "a3") is None
+
+    assert await cache.get_group_member_nickname_map("group-openid") == {
+        "自设昵称": "a1",
+        "只有 QQ 昵称": "a2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_group_member_nickname_map_is_empty_without_cache(db) -> None:
+    from nonebot_plugin_larkuser.group import cache
+
+    assert await cache.get_group_member_nickname_map("unknown-group") == {}
+
+
+@pytest.mark.asyncio
+async def test_get_group_name_uses_cache(db, monkeypatch) -> None:
+    from nonebot_plugin_larkuser.group import cache
+    from nonebot_plugin_larkuser.group.types import QQGroupInfo
+
+    async def sync_info(bot, group_openid):
+        return QQGroupInfo(group_openid=group_openid, group_name="读书分享会", member_count=3)
+
+    monkeypatch.setattr(cache, "fetch_group_info", sync_info)
+    assert await cache.refresh_group_info(_bot(), "group-openid") is not None
+    assert await cache.get_group_name(_bot(), "group-openid") == "读书分享会"
+
+    async def unexpected(*args, **kwargs):
+        raise AssertionError("缓存未过期时不应调用接口")
+
+    monkeypatch.setattr(cache, "fetch_group_info", unexpected)
+    assert await cache.get_group_name(_bot(), "group-openid") == "读书分享会"
+
+
+@pytest.mark.asyncio
+async def test_get_group_name_refreshes_when_cache_expired(db, monkeypatch) -> None:
+    from nonebot_plugin_larkuser.group import cache
+    from nonebot_plugin_larkuser.group.types import QQGroupInfo
+    from nonebot_plugin_larkuser.models import QQGroupInfo as QQGroupInfoModel
+
+    async with db() as session:
+        session.add(
+            QQGroupInfoModel(
+                group_openid="group-openid",
+                group_name="旧群名",
+                info_updated_at=datetime.now() - timedelta(days=7),
+            ),
+        )
+        await session.commit()
+
+    async def sync_info(bot, group_openid):
+        return QQGroupInfo(group_openid=group_openid, group_name="新群名")
+
+    monkeypatch.setattr(cache, "fetch_group_info", sync_info)
+    assert await cache.get_group_name(_bot(), "group-openid") == "新群名"
+
+
+@pytest.mark.asyncio
+async def test_refresh_group_info_records_error(db, monkeypatch) -> None:
+    from nonebot_plugin_larkuser.group import cache
+    from nonebot_plugin_larkuser.group.client import QQGroupPermissionError
+    from nonebot_plugin_larkuser.models import QQGroupInfo
+
+    async def denied(bot, group_openid):
+        raise QQGroupPermissionError("应用没有该群接口的访问权限（11253）", code=11253)
+
+    monkeypatch.setattr(cache, "fetch_group_info", denied)
+    assert await cache.refresh_group_info(_bot(), "group-openid") is None
+    async with db() as session:
+        record = await session.get(QQGroupInfo, {"group_openid": "group-openid"})
+        assert "11253" in record.last_error
+        assert record.info_updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_sync_all_groups_skips_fresh_cache(db, monkeypatch) -> None:
+    from nonebot_plugin_larkuser.group import cache
+    from nonebot_plugin_larkuser.models import QQGroupInfo
+
+    async with db() as session:
+        session.add(QQGroupInfo(group_openid="fresh-group", bot_id="bot-1", members_synced_at=datetime.now()))
+        await session.commit()
+
+    async def unexpected(*args, **kwargs):
+        raise AssertionError("缓存新鲜时不应触发同步")
+
+    monkeypatch.setattr(cache, "refresh_group_members", unexpected)
+    await cache.sync_all_groups()


### PR DESCRIPTION
## 背景

QQ 开放平台新增（开放白名单）了两个接口：

- [获取群基本信息](https://bot.q.qq.com/wiki/develop/api-v2/autogen/api/v2_groups_group_openid_info.get.html)
  `GET /v2/groups/{group_openid}/info`（30 QPM）
- [获取群成员列表](https://bot.q.qq.com/wiki/develop/api-v2/autogen/api/v2_groups_group_openid_members.get.html)
  `GET /v2/groups/{group_openid}/members`（60 QPM，每页最多 30 条，游标分页）

`nonebot-adapter-qq` 目前没有提供这两个接口（上游 `master` 仍只有已废弃的
`POST /v2/groups/{id}/members`，且不返回昵称），因此本次直接在 Moonlark 侧实现。

## 改动

**larkuser 新增 `group` 模块（接口客户端 + 缓存 + 周期同步）**

- `client.py`：按文档实现两个 GET 接口（手写 `Request`，复用适配器的
  `get_api_base()` / `get_authorization_header()`），包含：
  - 游标翻页（重复游标 / 成员数上限保护，避免异常时死循环）；
  - 按接口分别限流（群信息 ~28 QPM、群成员 ~55 QPM，串行化调用）；
  - 错误映射：`11253` → `QQGroupPermissionError`、`429` → `QQGroupRateLimitError`、
    其余 → `QQGroupAPIError`，网络异常也统一收敛为 `QQGroupAPIError`；
  - `joined_at`（RFC3339）转 UTC naive 时间、`member_role` 归一化。
- `cache.py`：群信息与群成员列表落库缓存，缓存同时负责：
  - 用群成员列表里的昵称补全没有昵称的用户 —— 已注册用户（`UserData`）昵称为空时填入并把
    `config.nick_source` 标记为 `group_member`（不会覆盖用户自己设置的昵称），
    未注册用户写入 `GuestUser`（新建 / 更新），跳过机器人成员；
  - 批量（分块 IN 查询）构造「昵称 → 成员 openid」映射：优先 Moonlark 昵称，
    没有时回退 QQ 昵称，供 Chat 解析 @ 使用；
  - 每次同步全量替换缓存并清理已退群成员；同步失败时保留旧缓存、记录 `last_error`，
    且同样刷新时间戳，避免反复打接口。
- `sync.py`：收到 QQ 群消息时登记该群并在后台同步一次（同群同进程只触发一次），
  外加 `interval` 周期任务（默认 30 分钟）按缓存有效期（默认 1 小时）刷新所有已登记群；
  没有在线的对应 Bot 时跳过（openid 按 AppID 分配，不能用别的 Bot 查询）。

**Chat 插件（Group Session）**

- `get_session_name()`：QQ 官方 Bot 返回群名称（缓存优先，缺失/过期时刷新，取不到仍返回 `None`）。
- `get_users()`：@ 解析改为与 OneBot 11 一致地基于群成员列表（QQ 走 larkuser 缓存），
  缓存不可用时回退到原先的消息缓存；顺带修掉 `users` 为空时空正则匹配每个字符的问题。
- `get_user_info()`：QQ 官方 Bot 返回缓存中的真实群角色与入群时间。

**其他**

- waifu 插件：`get_members_qq` 从已废弃的 `bot.post_group_members` 改为读取群成员缓存。
- message_summary：虚假处分通知改用缓存的群名称（原来注释写「QQ 适配器没有获取群名称的 API」）。
- 新增迁移 `a7f3c9e21b64`（两张表）与 `QQ_GROUP_*` 配置项（已写入 `.env.template`）。

## 验收

- `nb orm upgrade` + `nb orm check` → `没有检测到新的升级操作`
- `pytest tests/` → **222 passed**（新增 `tests/test_larkuser_qq_group.py` 22 个用例）
- `nb larkhelp-generate zh_hans COMMANDS.md` → 无 diff
- 新增/修改文件 `ruff`（新版规则集）/`black` 无新增问题
