### PR TITLE
feat(quick_math): L5 一元二次方程题目信息改用 md_to_pic 渲染为图片

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -260,19 +260,19 @@ docs = ["sphinx (==7.2.6)", "sphinx-mdinclude (==0.5.3)"]
 
 [[package]]
 name = "alembic"
-version = "1.19.2"
+version = "1.20.0"
 description = "A database migration tool for SQLAlchemy."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2"},
-    {file = "alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0"},
+    {file = "alembic-1.20.0-py3-none-any.whl", hash = "sha256:77eb101048d95f982c0353e9233404889dcd7a6fc244c107836c0e2fc9cf7d9d"},
+    {file = "alembic-1.20.0.tar.gz", hash = "sha256:db505480647bc60386c5369402f4a57a506b7539c9e9ef5e270d45cbbe4939bf"},
 ]
 
 [package.dependencies]
 Mako = "*"
-SQLAlchemy = ">=1.4.23"
+SQLAlchemy = ">=2.0"
 typing-extensions = ">=4.12"
 
 [package.extras]
@@ -3355,58 +3355,65 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.11.1"
+version = "3.11.2"
 description = "Python plotting package"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "matplotlib-3.11.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b7cf158e7add54a8d51ac9b5a84abd6d4e13ed4951b4f25f1c5139f41c2addb2"},
-    {file = "matplotlib-3.11.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d2ace7273b9a5061a3b420918a16fae1f2dc5dfee1abcc13aba71b5d94b1820c"},
-    {file = "matplotlib-3.11.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aee55e9041211bf84302ab55ec3965df18dd90ae19f8b58332a7feaf208bfe83"},
-    {file = "matplotlib-3.11.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f4bdeea33a8d15a071dbfe6d119451b1d719c733ac666d65357082901a9099"},
-    {file = "matplotlib-3.11.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b4c78ceb2f11bcac7389d305cda17aeb1f4586a857854ab5780bd3dd8dbfc407"},
-    {file = "matplotlib-3.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:7f33a781e12b1e53b278deb2f5373c2e55ec4f10727be3440c0cfb5cda9f944f"},
-    {file = "matplotlib-3.11.1-cp311-cp311-win_arm64.whl", hash = "sha256:67e4c3cd578c65ebd81bdc09a1b6592ceafee6dfafe116dc85dfcb647b5bbb18"},
-    {file = "matplotlib-3.11.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e15ef41507f3d525f46154ac9e3ae785dacde9f20e593a25de8986267892ef74"},
-    {file = "matplotlib-3.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:21a67b961a6d597bca54fae826cd20695ba4a6e4d05424a08da6e13e3176fd6b"},
-    {file = "matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba8f811b8ddfac493734d6af0b2dff96919d0c28ca0d641858dab4262777c6ea"},
-    {file = "matplotlib-3.11.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c52f7ad20ef476806ed212380b1d54d20310c8b86bdc2c9a68b51f0024a44472"},
-    {file = "matplotlib-3.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8b14eb22961fe865efb0e4ff167e333e428908b00115a8d800ccb65ee108e481"},
-    {file = "matplotlib-3.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:88a2a27dd9691ae448dfae4b26f59036be90c3c28757edd3553a29559d00859f"},
-    {file = "matplotlib-3.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:480194afceca4df2f137c2721227d3cba67121fbf4397b69cee7f83714b0a58a"},
-    {file = "matplotlib-3.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6771b0cd7838c6a857a7209814158c0ad09bfef878db3033dd82d70ad101f191"},
-    {file = "matplotlib-3.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2abdee5ffa2fe11b2d19f7a5c63b785fb7c28cc46c7bc1814156341d9d1a33e1"},
-    {file = "matplotlib-3.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0a19dcf73406d3746d25a5ed42d713604c9a3e024d129b102852b0d941cb9f3"},
-    {file = "matplotlib-3.11.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7389b77ed2ab0552f46d9a90b81b7b8e6dfcdc42adc36c37a0865799843e0e3e"},
-    {file = "matplotlib-3.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c90be0b73568da4f662afac580956a76e308437e641b4a45aa08925eeb67d95f"},
-    {file = "matplotlib-3.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:68408341f2312836fbbdf6b3c78047f65b2d8752f5fd221c3e72d348f5b34f8b"},
-    {file = "matplotlib-3.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:0c1f44890d435c1b4ef52f701ad5828cb450ea97bcc83918fda6be74965d6cd2"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:5e510088c27a89d53580a752f959146893563e63c330e161d159b0fee652af6f"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:1524e2bdd48a93557aa47ddcfe9c225dfdd57d5a01a5c49128c20f0632980ee1"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:11664c551345553db92e61cae6cf1376f138f8c47cafdf13b64b18f3e3e9e464"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e1f8922ba31959cf6a9dfb51be64b7f7bc582801a3957dc0c2f3afcd3537adf"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83235693abde86e5e0129998f80ee39fc7f58e6d56a88fafb28a9278833e9d5f"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-win_amd64.whl", hash = "sha256:9a076f4fc5cdc43fdf510f5981418d25c2db4973418d9f22d8bb3dc8045ada78"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-win_arm64.whl", hash = "sha256:216fbb93a74add02ddb4cb38ef5348f59ac00b3e84567eaf16598772d40e150a"},
-    {file = "matplotlib-3.11.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c492d4ba9448595b6fd8708c6725963f8148e25c0d8842948da5b05f0ee8d3"},
-    {file = "matplotlib-3.11.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ac104be2768ffdd8655db9e71b768cbb45f2b9aa7b450cf1595e8f65d3822319"},
-    {file = "matplotlib-3.11.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6be943cb68bc6660ead58c55b3aa6366cba2ef7feb06460fbcce32360376f19f"},
-    {file = "matplotlib-3.11.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5af0dcda57d471440a7b5b623e70e0a61003518443d9098f211a96ecfbbc25be"},
-    {file = "matplotlib-3.11.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3d3fd84082b1afbd9398466c81309e20045be20d48fe0fb18c43504d164cbbb2"},
-    {file = "matplotlib-3.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:9601a1e90be21e4884c53b4f3dc3ee0544654946f9975258d691f1c2e2f119c6"},
-    {file = "matplotlib-3.11.1-cp314-cp314-win_arm64.whl", hash = "sha256:ae30c6109848ac0f9fa36c5d6270938487614c47ba31860bd5361266dabc5685"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dadfe80797174e2984aae3be0b77594a3c72d2c0a40fbd4a0de48d2728caf3ae"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:89b193b255f4f6f7948dbcee3691f4f341ab05d9a8874a67b45ddb4182922eda"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191163532cdefcb1571ca38a6d7e6474baccde64495783e6ba47aa07ec4b9bbb"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fdf1c818ab05d0e74002091ddaf414478a3a449ec9d51c8976d45be7e3a01e2"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b937b9dba5f5f6c1e31c47abe2186c865c0914fd18f2ce0dfc39c9adcef5951d"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f2912f647f3fbe1ccf085f91e213936f9101bead81a5e670565b1f1b3712f4fb"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-win_arm64.whl", hash = "sha256:54d47b8ae8b579633a3902ca5b4ad6c1e132a5626d64447b2e22a66394e79987"},
-    {file = "matplotlib-3.11.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:427258425f9a3fc4ed79a91f9e9b9aaf5a82cb6571e85dc14063cc6fbb993741"},
-    {file = "matplotlib-3.11.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:1ac697e591c11b6ad04679a73c2d2f9980fe9d9f0311fb414a2e329706343dfb"},
-    {file = "matplotlib-3.11.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4b9ac2f1f607ecda2af90a5232beee2af7582fce1cc30c4b6a1b012dc21ee99"},
-    {file = "matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30"},
+    {file = "matplotlib-3.11.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5e1e923a3fc3326b99ec0a6ff1ab1338ac6c6cc62ad9d8a9c944197c7f8c6221"},
+    {file = "matplotlib-3.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c27e577ece613ea12a0790e00b4eb80d901c59a3e16cad474f31d8b1529690b9"},
+    {file = "matplotlib-3.11.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:07d9b9fa60cd4c393692f50d0bb03123242ddf61c99bb0e95e75feb354e7c1a8"},
+    {file = "matplotlib-3.11.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30ec15d7eefee71de16b7c689b42ba49715a4644650b76a6c7c70d79daf24e91"},
+    {file = "matplotlib-3.11.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:116cdb0eb0eb5644fc98eb2975d4b4dd4ad35e5c8e6b851c22e6976f371f7ab5"},
+    {file = "matplotlib-3.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:a24d5fd36e4f0e742c3851dcd20810e56a95633a342e4bf6cb591c678e8fe61f"},
+    {file = "matplotlib-3.11.2-cp311-cp311-win_arm64.whl", hash = "sha256:57b9ea60a835937c2012861923cbb91f47db8565775d326d1c42fc926aa10351"},
+    {file = "matplotlib-3.11.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ef752769cd962f39ea0b6ffc82d1ea43a0012c5a6157c7a075212fa509cfcff2"},
+    {file = "matplotlib-3.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ef31985c4dedb5f1424e1aec6849a47dd37689cb7fa3c20b1b82187f26806261"},
+    {file = "matplotlib-3.11.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df4f7784aca81a94f254c0a2767d592ee25f407e488f5fa7203e51093fb6ca27"},
+    {file = "matplotlib-3.11.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b9a7ad579856284135e401ecc918c5f8a017ee30539298862a109f51b971710"},
+    {file = "matplotlib-3.11.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3aa4b8516fd26659e4363abbf317c703d9116496c5db2e9d0609a2866dd39dd2"},
+    {file = "matplotlib-3.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:c5c1c68ee401fc98271263410f0e5ce88285abacf7627132914e8adf3d70ff43"},
+    {file = "matplotlib-3.11.2-cp312-cp312-win_arm64.whl", hash = "sha256:643ff850d8e0f5b8319337f87ed3cb59506afb3df3cc48de777d85871233be7b"},
+    {file = "matplotlib-3.11.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d43ff8cebb50840648cb6429b2228621dbd709010f3117b3740abb20abf21c0"},
+    {file = "matplotlib-3.11.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2a8285cea8ef4d92aa041d1c33788bcae82248503300f93f1ca2136b9049452f"},
+    {file = "matplotlib-3.11.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1944895967f87c84c9b4bad29a707b31f5b36df4a3a2339ea1f8ea3ce5105539"},
+    {file = "matplotlib-3.11.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af2661f6ac6bbd1d081996f54fdd9385715c625ace8cec0869055c0cfbf38981"},
+    {file = "matplotlib-3.11.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e5a90f8a707ebb6004a713b1cff091a40cc5df4c7c1cb165e5a505ebc11c292"},
+    {file = "matplotlib-3.11.2-cp313-cp313-win_amd64.whl", hash = "sha256:bc067c462a86f0e57bf52fc6e058d90171a5420007dac00c46e90153050c69a7"},
+    {file = "matplotlib-3.11.2-cp313-cp313-win_arm64.whl", hash = "sha256:3e8576f7c47e02fd4f21f44171302d2d1d58d4471d46da3d71fe8899d19539d9"},
+    {file = "matplotlib-3.11.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c9721f81275499da1feeb36a2cf8192ea086283b3bd16b7dc4c9d7aedb7396d6"},
+    {file = "matplotlib-3.11.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a3040b209f3968b4e84161df7b174f07a9fad33b0f2d7e48ea3bbd3075e2863"},
+    {file = "matplotlib-3.11.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf3fe71fbfb8ec0e310e0bc8537c3405a01f38f25f9394ed2135e6202fed542b"},
+    {file = "matplotlib-3.11.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8c8255de28f986d935a64c9ca71c0ec2d2f41d355691f5ea684725dc91413f71"},
+    {file = "matplotlib-3.11.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a8756cc73d9af9a7fe0deb54ea2e75ef73b01d9e575877e72acad5458e660943"},
+    {file = "matplotlib-3.11.2-cp314-cp314-win_amd64.whl", hash = "sha256:ecea603dd2fbf8242fd31a305a8b12a4ece2de28096870c65fdd0d1e35b8d9a6"},
+    {file = "matplotlib-3.11.2-cp314-cp314-win_arm64.whl", hash = "sha256:01dc8eaaab5a9fce9ff615eca82345728f289e4715b186ee10c6d85272fc26bb"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79a258f58253dfa025af80a9e9bb228d75fced007f0e93ae7423fefbde81a74d"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c0b83f044ce10a98027b105b3931548719a6e8c7ef986b4362651e0b5367c8dc"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e43b188f0a5b75447bcc197728258166aa64365770ed1caa36595a5e1ca4bbba"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3304eb5a59442a8867f6920d484591c0fa09ffc29e9260be2feec3351e25869"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:02329432ae5c6af87cf208ee575b701d698bdf0b1a3bb28cc6d53c36e967e575"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-win_amd64.whl", hash = "sha256:f2ac30cf5eb5dff1b584627ae0b0e1186551a4f69ae3c75073911da497a29170"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-win_arm64.whl", hash = "sha256:cf41ecd1b0c0b6f7177ed965a54c2afbe888715c7cf6054dc12d53bc1494002c"},
+    {file = "matplotlib-3.11.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:894a9cbbecbe30ae6787d464df2e8fc7a8d475cfc68f87c3029f7c11152899b3"},
+    {file = "matplotlib-3.11.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:bbf1062991d826ed27e2144f3afa4461afbb8ff56e8f703043e191a8163b1ee9"},
+    {file = "matplotlib-3.11.2-cp315-cp315-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:399fef672f7046ef7d6a57572b2a6f9845f3f5afcff04e7b2df7a363a9f42190"},
+    {file = "matplotlib-3.11.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc82dde2a0d3e3ad472edce04897ad7146b8d8bfd1df8a32992eebb81af18fdc"},
+    {file = "matplotlib-3.11.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:930efb28f59fda124e39265d177bab302625297bb147d2910de725a2fc2aef54"},
+    {file = "matplotlib-3.11.2-cp315-cp315-win_amd64.whl", hash = "sha256:3da3bc0cbf7245e7db72cc6d29d12c5abef72cb73059c73b945f14e3545f3eb2"},
+    {file = "matplotlib-3.11.2-cp315-cp315-win_arm64.whl", hash = "sha256:f25446b2981717dca9786bac841cb3fd7efb568e3e3c755dd980481c5cb9228d"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:fea03cf56568cc1cba08b470be6a0559e71c3a5b688d54b7179bb35ba23d0821"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:254d4ddb2fa8df3b4c689c0c306063aee10521df82cfb438185e499c75fe37c1"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e60cf3047a51edecdc4535a9196bbd6a732936b8e9f8184aabf4d16165884aaf"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eb3712dc9b464793de0a4e42a7313d50293c751f94bddaf7332a1bc71bccdda9"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:75b6d88402770e181b5d06a67dda4129c31da7d05004d63a21c310ec78d1b83c"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-win_amd64.whl", hash = "sha256:a6939df7567114b6bac7f4c5e06c84a67f197c1b2f2e4b234d4eecb3bfec9482"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-win_arm64.whl", hash = "sha256:d480038c83691532ed52ff3147db51fa902fc78cb2d8349993a1cdb684435bff"},
+    {file = "matplotlib-3.11.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:854df8d7dfe9fdffcbaa6f39e44a6c24b409cb4d7561fbc09213b157d833f6a6"},
+    {file = "matplotlib-3.11.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:eac4b07d4e3743b172451e122ea964f72f152879d4f9adcf3f3d33e518f12ead"},
+    {file = "matplotlib-3.11.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ef7a53b66780e5d942923724f08577fbc5be1f7322da0f0f3f9dcaa45dd803d"},
+    {file = "matplotlib-3.11.2.tar.gz", hash = "sha256:cec596316640f2b394b8f0daa0ea61a8eae82d017b620b9f202befb972a59ea4"},
 ]
 
 [package.dependencies]
@@ -5345,14 +5352,14 @@ files = [
 
 [[package]]
 name = "pyjwt"
-version = "2.13.0"
+version = "2.14.0"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
-    {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
+    {file = "pyjwt-2.14.0-py3-none-any.whl", hash = "sha256:ad0cef71c756a56e74863c2919cf0985f72decbcfcb550ee2f422e7c62b5eedc"},
+    {file = "pyjwt-2.14.0.tar.gz", hash = "sha256:77283c83fb56ecf566a886c757a714bc83668e38156de2cce8263302f42e0b86"},
 ]
 
 [package.extras]
@@ -6869,14 +6876,14 @@ files = [
 
 [[package]]
 name = "tqdm"
-version = "4.70.0"
+version = "4.70.1"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953"},
-    {file = "tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220"},
+    {file = "tqdm-4.70.1-py3-none-any.whl", hash = "sha256:c293e525e6fef9c20e8728fd4612df02a0aa31bb5fe91ecd93e123b1b7bffa73"},
+    {file = "tqdm-4.70.1.tar.gz", hash = "sha256:cefd0eca11b2a37a3aee776544d4f4ae913f02688135b5556b8788dfa474afc4"},
 ]
 
 [package.dependencies]

--- a/src/plugins/nonebot_plugin_quick_math/utils/latex.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/latex.py
@@ -1,14 +1,19 @@
-"""LaTeX 到纯文本的轻量转换。
+"""LaTeX 公式的文本处理工具。
 
-QQ 官方机器人 markdown 消息不解析 LaTeX 数学公式，因此在 QQ 适配器下发送题目卡片时，
-将题目生成器产生的 LaTeX 字符串转换为可读的纯文本（Unicode 符号），
-以便直接嵌入 markdown 消息。转换失败时保持原样，由调用方兜底。
+题目生成器产生的是裸 LaTeX（例如选项 ``x_{1} = \\frac{1}{2}``）。题目信息在
+QQ 官方机器人下通过 md_to_pic 渲染成图片，因此需要 :func:`ensure_math_mode` 把
+裸 LaTeX 包进 ``$...$`` 交给 KaTeX；图床不可用需要回退为纯文本时，则用
+:func:`latex_to_plain` 把公式转换为可读的 Unicode 符号。转换失败时保持原样，
+由调用方兜底。
 """
 
 import re
 
 _SUPERSCRIPT_PATTERN = re.compile(r"\^\{([^{}]*)\}|\^([0-9+\-()a-zA-Z])")
 _SUBSCRIPT_PATTERN = re.compile(r"_\{([^{}]*)\}|_([0-9+\-()a-zA-Z])")
+
+# 裸 LaTeX 的特征：命令反斜杠、上下标、花括号
+_LATEX_HINT_PATTERN = re.compile(r"[\\_^{}]")
 
 _SUPERSCRIPT_MAP = str.maketrans("0123456789+-=()", "⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾")
 _SUBSCRIPT_MAP = str.maketrans("0123456789+-=()", "₀₁₂₃₄₅₆₇₈₉₊₋₌₍₎")
@@ -34,6 +39,18 @@ _COMMANDS = {
 def _translate_script(match: re.Match, script_map: str) -> str:
     content = match.group(1) or match.group(2)
     return content.translate(script_map)
+
+
+def ensure_math_mode(latex: str) -> str:
+    """把裸 LaTeX 包进 ``$...$``，供 md_to_pic 交给 KaTeX 渲染。
+
+    题目生成器给出的选项是裸 LaTeX（如 ``x_{1} = \\frac{1}{2}``），而 md_to_pic
+    只把 ``$...$``/``$$...$$`` 包裹的内容当作公式；纯数字选项（如 ``1/2``）没有
+    公式特征，保持原样以免平白变成数学字体。
+    """
+    if not latex or latex.lstrip().startswith("$") or _LATEX_HINT_PATTERN.search(latex) is None:
+        return latex
+    return f"${latex}$"
 
 
 def latex_to_plain(latex: str) -> str:

--- a/src/plugins/nonebot_plugin_quick_math/utils/question.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/question.py
@@ -1,15 +1,18 @@
 from typing import Awaitable, Callable, Optional
 
+from nonebot import logger
 from nonebot.adapters import Bot
 from nonebot.adapters.qq import Bot as QQBot
 from nonebot_plugin_alconna import Button, UniMessage
+from nonebot_plugin_htmlrender import md_to_pic
+from nonebot_plugin_larkutils.cache import create_image_markdown
 
 from ..__main__ import lang
 from ..config import config
 from ..types import QuestionData
 from .generator import generate_question
 from .image import generate_image
-from .latex import latex_to_plain
+from .latex import ensure_math_mode, latex_to_plain
 
 _OPTION_LETTERS = "ABCDEFGHIJKL"
 
@@ -51,6 +54,53 @@ def with_option_letters(question: QuestionData) -> QuestionData:
             "answer": build_option_answer_matcher(options, question["question"]["answer"]),
         },
     }
+
+
+async def build_choices_markdown(user_id: str, options: list[str], to_plain: bool = False) -> str:
+    """构建“请选择答案”标题与选项列表的 markdown。
+
+    ``to_plain`` 为 ``True``（回退到纯文本）时把 LaTeX 选项转成可读的普通文本，
+    否则把裸 LaTeX 选项包进 ``$...$`` 交给 md_to_pic 渲染成公式。
+    """
+    transform = latex_to_plain if to_plain else ensure_math_mode
+    return await lang.text(
+        "main.choices",
+        user_id,
+        "\n".join(
+            [
+                await lang.text("main.choice_item", user_id, _OPTION_LETTERS[index], transform(option))
+                for index, option in enumerate(options)
+            ],
+        ),
+    )
+
+
+async def build_question_info_markdown(user_id: str, question: QuestionData, to_plain: bool = False) -> str:
+    """构建题目信息（题干 + 选项）的 markdown。"""
+    content = question["question"]["question"]
+    if to_plain:
+        content = latex_to_plain(content)
+    options = question["question"].get("options") or []
+    if len(options) > 1:
+        content += "\n\n" + await build_choices_markdown(user_id, options, to_plain=to_plain)
+    return content
+
+
+async def build_question_info(user_id: str, question: QuestionData) -> str:
+    """构建 QQ 官方机器人的题目信息：用 md_to_pic 渲染成图片，并返回图床 markdown 代码。
+
+    QQ 官方机器人的 markdown 消息不解析 LaTeX，直接把题干与选项发出去只会显示成
+    ``√(57)2`` 这类难以辨认的纯文本；因此这里先用 md_to_pic 把题目信息（题干 +
+    “请选择答案” + 选项）渲染为图片，再上传图床并返回可供 markdown 引用的图片代码。
+    图床未配置或渲染失败时回退为 ``latex_to_plain`` 的纯文本，保证题目卡片仍可发送。
+    """
+    markdown = await build_question_info_markdown(user_id, question)
+    try:
+        image = await create_image_markdown(await md_to_pic(markdown, type="jpeg"))
+    except Exception:
+        logger.exception("Quick Math 题目信息渲染为图片失败，回退为纯文本")
+        return await build_question_info_markdown(user_id, question, to_plain=True)
+    return image
 
 
 async def get_question(
@@ -113,7 +163,7 @@ async def build_markdown_message(
     content = await lang.text(
         "main.markdown",
         user_id,
-        latex_to_plain(question["question"]["question"]),
+        await build_question_info(user_id, question),
         answered,
         question["limit_in_sec"],
         question["level"],
@@ -121,27 +171,13 @@ async def build_markdown_message(
         skipped_question,
         total_skipping_count,
     )
-    if len(options) > 1:
-        choices = await lang.text(
-            "main.choices",
-            user_id,
-            "\n".join(
-                [
-                    await lang.text("main.choice_item", user_id, _OPTION_LETTERS[index], latex_to_plain(option))
-                    for index, option in enumerate(options)
-                ],
-            ),
-        )
-        # 在题目文本与“请选择答案”标题之间补空行，否则 ## 标题与题目粘在同一行
-        # 导致 QQ markdown 无法识别标题，原样显示 ##
-        content += "\n\n" + choices
     if qq_user_id:
         content = f'<qqbot-at-user id="{qq_user_id}" />\n' + content
     message = UniMessage().style(content, "markdown")
-    # 按钮显示选项原文，但回传选项字母：服务端无需再判定长文本（例如 L7 需要
-    # 调用 AI 判定），直接按字母取选项即可，显著加快答案判定速度
+    # 选项原文已随题目信息渲染进图片，按钮只显示选项字母；回传的同样是字母，
+    # 服务端无需再判定长文本（例如 L7 需要调用 AI 判定），直接按字母取选项即可
     buttons: list[Button] = [
-        Button("enter", latex_to_plain(option), text=_OPTION_LETTERS[index]) for index, option in enumerate(options)
+        Button("enter", _OPTION_LETTERS[index], text=_OPTION_LETTERS[index]) for index in range(len(options))
     ]
     if total_skipping_count > skipped_question:
         buttons.append(Button("enter", await lang.text("button.skip", user_id), text="skip"))

--- a/src/plugins/nonebot_plugin_quick_math/utils/question.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/question.py
@@ -16,6 +16,12 @@ from .latex import ensure_math_mode, latex_to_plain
 
 _OPTION_LETTERS = "ABCDEFGHIJKL"
 
+# 仅一元二次方程（L5）的选项由 sympy 生成 LaTeX（\frac、\sqrt），QQ markdown 不解析
+# LaTeX，会把它显示成 "- (9)/(2) - √(57)2" 这类难以辨认的纯文本；因此只有该等级把
+# 题目信息渲染成图片，其余等级继续使用纯文本卡片，避免为简单题目平白增加一次浏览器
+# 渲染与图床上传。
+_QUESTION_IMAGE_LEVELS = frozenset({5})
+
 
 def build_option_answer_matcher(
     options: list[str], verify: Callable[[str], Awaitable[bool]]
@@ -90,13 +96,15 @@ async def build_question_info_markdown(user_id: str, question: QuestionData, to_
 
 
 async def build_question_info(user_id: str, question: QuestionData) -> str:
-    """构建 QQ 官方机器人的题目信息：用 md_to_pic 渲染成图片，并返回图床 markdown 代码。
+    """构建 QQ 官方机器人的题目信息。
 
-    QQ 官方机器人的 markdown 消息不解析 LaTeX，直接把题干与选项发出去只会显示成
-    ``√(57)2`` 这类难以辨认的纯文本；因此这里先用 md_to_pic 把题目信息（题干 +
-    “请选择答案” + 选项）渲染为图片，再上传图床并返回可供 markdown 引用的图片代码。
-    图床未配置或渲染失败时回退为 ``latex_to_plain`` 的纯文本，保证题目卡片仍可发送。
+    一元二次方程（见 ``_QUESTION_IMAGE_LEVELS``）的选项是 LaTeX，直接用 md_to_pic 把
+    题目信息（题干 + “请选择答案” + 选项）渲染为图片，再上传图床并返回可供 markdown
+    引用的图片代码；图床未配置或渲染失败时回退为 ``latex_to_plain`` 的纯文本。其余
+    等级继续使用纯文本题目信息。
     """
+    if question["level"] not in _QUESTION_IMAGE_LEVELS:
+        return await build_question_info_markdown(user_id, question, to_plain=True)
     markdown = await build_question_info_markdown(user_id, question)
     try:
         image = await create_image_markdown(await md_to_pic(markdown, type="jpeg"))
@@ -177,11 +185,17 @@ async def build_markdown_message(
     if qq_user_id:
         content = f'<qqbot-at-user id="{qq_user_id}" />\n' + content
     message = UniMessage().style(content, "markdown")
-    # 选项原文已随题目信息渲染进图片，按钮只显示选项字母；回传的同样是字母，
-    # 服务端无需再判定长文本（例如 L7 需要调用 AI 判定），直接按字母取选项即可
-    buttons: list[Button] = [
-        Button("enter", _OPTION_LETTERS[index], text=_OPTION_LETTERS[index]) for index in range(len(options))
-    ]
+    if question["level"] in _QUESTION_IMAGE_LEVELS:
+        # 选项原文已随题目信息渲染进图片，按钮只显示并回传选项字母
+        buttons: list[Button] = [
+            Button("enter", _OPTION_LETTERS[index], text=_OPTION_LETTERS[index]) for index in range(len(options))
+        ]
+    else:
+        # 选项仍以文本显示在卡片里，按钮保留选项原文便于直接辨认；回传的仍是字母，
+        # 服务端无需再判定长文本（例如 L7 需要调用 AI 判定），直接按字母取选项即可
+        buttons = [
+            Button("enter", latex_to_plain(option), text=_OPTION_LETTERS[index]) for index, option in enumerate(options)
+        ]
     if total_skipping_count > skipped_question:
         buttons.append(Button("enter", await lang.text("button.skip", user_id), text="skip"))
     if enable_leave_button:

--- a/src/plugins/nonebot_plugin_quick_math/utils/question.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/question.py
@@ -63,10 +63,13 @@ async def build_choices_markdown(user_id: str, options: list[str], to_plain: boo
     否则把裸 LaTeX 选项包进 ``$...$`` 交给 md_to_pic 渲染成公式。
     """
     transform = latex_to_plain if to_plain else ensure_math_mode
+    # 选项要逐行显示：markdown 会把段落内的单个换行折叠成空格，因此渲染图片时用
+    # 行尾双空格产生硬换行；回退的纯文本直接交给 QQ markdown，无需硬换行
+    separator = "\n" if to_plain else "  \n"
     return await lang.text(
         "main.choices",
         user_id,
-        "\n".join(
+        separator.join(
             [
                 await lang.text("main.choice_item", user_id, _OPTION_LETTERS[index], transform(option))
                 for index, option in enumerate(options)

--- a/tests/test_quick_math_qq_adapter.py
+++ b/tests/test_quick_math_qq_adapter.py
@@ -179,7 +179,8 @@ async def test_question_card_question_info_is_image(patched_image_renderer: dict
     markdown: str = patched_image_renderer["markdown"]
     assert markdown.startswith("1 + 2 = ?")
     assert "\n\n## 请选择答案\n\n" in markdown
-    assert "A. 1" in markdown
+    # 选项之间使用行尾双空格的硬换行，否则图片里所有选项会被折叠到同一行
+    assert "A. 1  \nB. 2  \nC. 3" in markdown
     assert patched_image_renderer["image"] == b"fake-image"
 
 
@@ -193,8 +194,7 @@ async def test_question_card_wraps_latex_options_in_math_mode(patched_image_rend
 
     await build_markdown_message("user", question, 0, 0, 0, 0)
     markdown: str = patched_image_renderer["markdown"]
-    assert "A. $x_{1} = \\frac{1}{2}$" in markdown
-    assert "B. -3" in markdown
+    assert "A. $x_{1} = \\frac{1}{2}$  \nB. -3" in markdown
 
 
 @pytest.mark.asyncio
@@ -213,7 +213,8 @@ async def test_question_card_falls_back_to_plain_text(monkeypatch: pytest.Monkey
     content = next(segment for segment in message if isinstance(segment, Text)).text
     assert "1 + 2 = ?" in content
     assert "\n\n## 请选择答案\n\n" in content
-    assert "A. 1" in content
+    # 回退的纯文本交给 QQ markdown 渲染，用普通换行分隔选项即可
+    assert "A. 1\nB. 2\nC. 3" in content
 
 
 @pytest.mark.asyncio

--- a/tests/test_quick_math_qq_adapter.py
+++ b/tests/test_quick_math_qq_adapter.py
@@ -5,9 +5,10 @@
 - 主界面模式按钮分行（keyboard 每行一个按钮），私聊（C2C）下禅模式按钮改为
   input 类型，点击后预填指令供用户自行填入等级，而不是直接发送固定等级 5 的
   ``/qm zen 5``；
-- 题目信息（题干 + “请选择答案” + 选项）改用 md_to_pic 渲染成图片后经图床发送，
-  避免 QQ markdown 不解析 LaTeX 导致根式、分式显示成 ``√(57)2`` 这类纯文本；
-- 选项按钮内容改为选项字母（A/B/C/D），选项原文已随题目信息进入图片；
+- 一元二次方程（L5）的题目信息（题干 + “请选择答案” + 选项）改用 md_to_pic 渲染成
+  图片后经图床发送，避免 QQ markdown 不解析 LaTeX 导致 ``\frac``/``\sqrt`` 显示成
+  ``√(57)2`` 这类纯文本；该等级的选项按钮内容改为选项字母（A/B/C/D），选项原文已随
+  题目信息进入图片。其余等级的题目信息与选项按钮保持原有纯文本表现；
 - 退出指令（leave/quit/q）仅在禅模式（``enable_leave_command``）下生效，且
   q 不再被 prompt 的快捷退出吞掉、超时以 ``ReplyType.TIMEOUT`` 返回，保证
   退出/超时后正常发送结算卡片；
@@ -96,8 +97,11 @@ def _make_question() -> dict[str, Any]:
     }
 
 
-def _make_choice_question(answer_fn: Any = None) -> dict[str, Any]:
-    """构造一个带选项的选择题（默认判定恒为正确）。"""
+def _make_choice_question(answer_fn: Any = None, level: int = 1) -> dict[str, Any]:
+    """构造一个带选项的选择题（默认判定恒为正确）。
+
+    ``level`` 决定题目信息是否渲染为图片：只有 L5（一元二次方程）走图片。
+    """
 
     if answer_fn is None:
 
@@ -113,7 +117,7 @@ def _make_choice_question(answer_fn: Any = None) -> dict[str, Any]:
             "options": ["1", "2", "3"],
         },
         "max_point": 10,
-        "level": 1,
+        "level": level,
         "limit_in_sec": 5,
     }
 
@@ -162,11 +166,11 @@ async def test_menu_group_zen_button_sends_default_level() -> None:
 
 @pytest.mark.asyncio
 async def test_question_card_question_info_is_image(patched_image_renderer: dict[str, Any]) -> None:
-    """“题目信息”标题后应是一张图片：题干与选项进图片，不再以纯文本出现在卡片里。"""
+    """L5（一元二次方程）的“题目信息”标题后应是一张图片，题干与选项都不再以纯文本出现。"""
     from nonebot_plugin_alconna import Text, UniMessage
     from nonebot_plugin_quick_math.utils.question import build_markdown_message
 
-    question = _make_choice_question()
+    question = _make_choice_question(level=5)
     message, _ = await build_markdown_message("user", question, 0, 0, 0, 0, "qq_openid")
     assert isinstance(message, UniMessage)
     content = next(segment for segment in message if isinstance(segment, Text)).text
@@ -185,11 +189,28 @@ async def test_question_card_question_info_is_image(patched_image_renderer: dict
 
 
 @pytest.mark.asyncio
-async def test_question_card_wraps_latex_options_in_math_mode(patched_image_renderer: dict[str, Any]) -> None:
-    """裸 LaTeX 选项应包进 $...$（md_to_pic 只渲染该形式），纯数字选项保持原样。"""
+async def test_question_card_other_levels_stay_plain_text(patched_image_renderer: dict[str, Any]) -> None:
+    """只有 L5 走图片：其余等级仍以纯文本发送题目信息，不触发渲染与图床上传。"""
+    from nonebot_plugin_alconna import Text
     from nonebot_plugin_quick_math.utils.question import build_markdown_message
 
-    question = _make_choice_question()
+    for level in (1, 3, 7):
+        patched_image_renderer["markdown"] = None
+        message, _ = await build_markdown_message("user", _make_choice_question(level=level), 0, 0, 0, 0)
+        content = next(segment for segment in message if isinstance(segment, Text)).text
+        assert "1 + 2 = ?" in content
+        assert "\n\n## 请选择答案\n\n" in content
+        assert "A. 1\nB. 2\nC. 3" in content
+        assert _FAKE_IMAGE_MARKDOWN not in content
+        assert patched_image_renderer["markdown"] is None
+
+
+@pytest.mark.asyncio
+async def test_question_card_wraps_latex_options_in_math_mode(patched_image_renderer: dict[str, Any]) -> None:
+    """L5 的裸 LaTeX 选项应包进 $...$（md_to_pic 只渲染该形式），纯数字选项保持原样。"""
+    from nonebot_plugin_quick_math.utils.question import build_markdown_message
+
+    question = _make_choice_question(level=5)
     question["question"]["options"] = ["x_{1} = \\frac{1}{2}", "-3"]
 
     await build_markdown_message("user", question, 0, 0, 0, 0)
@@ -199,7 +220,7 @@ async def test_question_card_wraps_latex_options_in_math_mode(patched_image_rend
 
 @pytest.mark.asyncio
 async def test_question_card_falls_back_to_plain_text(monkeypatch: pytest.MonkeyPatch) -> None:
-    """图床不可用时题目信息应回退为纯文本，保证题目卡片仍可发送。"""
+    """图床不可用时 L5 的题目信息应回退为纯文本，保证题目卡片仍可发送。"""
     from nonebot_plugin_alconna import Text
     from nonebot_plugin_quick_math.utils import question as question_module
     from nonebot_plugin_quick_math.utils.question import build_markdown_message
@@ -209,7 +230,7 @@ async def test_question_card_falls_back_to_plain_text(monkeypatch: pytest.Monkey
 
     monkeypatch.setattr(question_module, "create_image_markdown", failing_create_image_markdown)
 
-    message, _ = await build_markdown_message("user", _make_choice_question(), 0, 0, 0, 0)
+    message, _ = await build_markdown_message("user", _make_choice_question(level=5), 0, 0, 0, 0)
     content = next(segment for segment in message if isinstance(segment, Text)).text
     assert "1 + 2 = ?" in content
     assert "\n\n## 请选择答案\n\n" in content
@@ -239,15 +260,27 @@ async def test_question_card_leave_button_only_when_enabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_question_card_option_buttons_show_letters() -> None:
-    """选项按钮内容应为字母 A/B/C（选项原文已渲染进题目信息图片）。"""
+async def test_question_card_option_buttons_show_letters_for_image_level() -> None:
+    """L5 的选项原文已渲染进图片，按钮内容应为字母 A/B/C。"""
     from nonebot_plugin_alconna import Keyboard
     from nonebot_plugin_quick_math.utils.question import build_markdown_message
 
-    question = _make_choice_question()
+    question = _make_choice_question(level=5)
     message, _ = await build_markdown_message("user", question, 0, 0, 0, 0, "qq_openid")
     keyboard = next(segment for segment in message if isinstance(segment, Keyboard))
     assert [button.label for button in keyboard.children] == ["A", "B", "C"]
+    assert [button.text for button in keyboard.children] == ["A", "B", "C"]
+
+
+@pytest.mark.asyncio
+async def test_question_card_option_buttons_keep_text_for_other_levels() -> None:
+    """其余等级的选项仍以文本显示在卡片里，按钮保留选项原文，但回传字母。"""
+    from nonebot_plugin_alconna import Keyboard
+    from nonebot_plugin_quick_math.utils.question import build_markdown_message
+
+    message, _ = await build_markdown_message("user", _make_choice_question(level=1), 0, 0, 0, 0, "qq_openid")
+    keyboard = next(segment for segment in message if isinstance(segment, Keyboard))
+    assert [button.label for button in keyboard.children] == ["1", "2", "3"]
     assert [button.text for button in keyboard.children] == ["A", "B", "C"]
 
 

--- a/tests/test_quick_math_qq_adapter.py
+++ b/tests/test_quick_math_qq_adapter.py
@@ -5,8 +5,9 @@
 - 主界面模式按钮分行（keyboard 每行一个按钮），私聊（C2C）下禅模式按钮改为
   input 类型，点击后预填指令供用户自行填入等级，而不是直接发送固定等级 5 的
   ``/qm zen 5``；
-- 题目卡片“请选择答案”标题与题目之间补空行，避免标题与题目粘在同一行导致
-  QQ markdown 无法解析、原样显示 ``##``；
+- 题目信息（题干 + “请选择答案” + 选项）改用 md_to_pic 渲染成图片后经图床发送，
+  避免 QQ markdown 不解析 LaTeX 导致根式、分式显示成 ``√(57)2`` 这类纯文本；
+- 选项按钮内容改为选项字母（A/B/C/D），选项原文已随题目信息进入图片；
 - 退出指令（leave/quit/q）仅在禅模式（``enable_leave_command``）下生效，且
   q 不再被 prompt 的快捷退出吞掉、超时以 ``ReplyType.TIMEOUT`` 返回，保证
   退出/超时后正常发送结算卡片；
@@ -23,6 +24,9 @@ import pytest
 import yaml
 
 _LANG_FILE = Path(__file__).resolve().parents[1] / "src" / "lang" / "zh_hans" / "quick_math.yaml"
+
+# 图床返回的 markdown 图片代码（含 QQ 需要的宽高标注）
+_FAKE_IMAGE_MARKDOWN = "![text #100px #50px](https://example.com/question.jpg)"
 
 
 def _load_template(key: str) -> str:
@@ -52,6 +56,30 @@ def patched_lang(monkeypatch: pytest.MonkeyPatch) -> None:
         return remove_trailing_blank_lines(text.format(*args, **kwargs, **builtin_format))
 
     monkeypatch.setattr(lang, "text", fake_text)
+
+
+@pytest.fixture(autouse=True)
+def patched_image_renderer(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """拦截题目信息渲染与图床上传，避免测试依赖浏览器与对象存储。
+
+    返回的字典记录传给 md_to_pic 的 markdown 与上传的图片数据，便于断言题目信息
+    （题干 + 选项）确实被渲染为图片、而不是继续以纯文本发送。
+    """
+    from nonebot_plugin_quick_math.utils import question as question_module
+
+    captured: dict[str, Any] = {"markdown": None, "image": None}
+
+    async def fake_md_to_pic(markdown: str, **_kwargs: object) -> bytes:
+        captured["markdown"] = markdown
+        return b"fake-image"
+
+    async def fake_create_image_markdown(data: bytes, **_kwargs: object) -> str:
+        captured["image"] = data
+        return _FAKE_IMAGE_MARKDOWN
+
+    monkeypatch.setattr(question_module, "md_to_pic", fake_md_to_pic)
+    monkeypatch.setattr(question_module, "create_image_markdown", fake_create_image_markdown)
+    return captured
 
 
 def _make_question() -> dict[str, Any]:
@@ -133,19 +161,59 @@ async def test_menu_group_zen_button_sends_default_level() -> None:
 
 
 @pytest.mark.asyncio
-async def test_question_card_choices_heading_on_separate_line() -> None:
-    """“请选择答案”标题与题目之间应有空行，不能粘在同一行导致 ## 原样显示。"""
+async def test_question_card_question_info_is_image(patched_image_renderer: dict[str, Any]) -> None:
+    """“题目信息”标题后应是一张图片：题干与选项进图片，不再以纯文本出现在卡片里。"""
     from nonebot_plugin_alconna import Text, UniMessage
     from nonebot_plugin_quick_math.utils.question import build_markdown_message
 
     question = _make_choice_question()
     message, _ = await build_markdown_message("user", question, 0, 0, 0, 0, "qq_openid")
     assert isinstance(message, UniMessage)
-    text = next(segment for segment in message if isinstance(segment, Text))
-    content = text.text
-    assert "## 请选择答案" in content
-    assert "\n\n## 请选择答案" in content
-    assert "?## 请选择答案" not in content
+    content = next(segment for segment in message if isinstance(segment, Text)).text
+    # 图片紧跟在“题目信息”标题之后
+    assert f"## 题目信息\n\n{_FAKE_IMAGE_MARKDOWN}" in content
+    # 题干与选项都不再直接出现在 QQ markdown 里（否则仍会显示成难读的纯文本）
+    assert "1 + 2 = ?" not in content
+    assert "A. 1" not in content
+    # 图片内容包含题干 LaTeX 原文与“请选择答案”+ 选项列表
+    markdown: str = patched_image_renderer["markdown"]
+    assert markdown.startswith("1 + 2 = ?")
+    assert "\n\n## 请选择答案\n\n" in markdown
+    assert "A. 1" in markdown
+    assert patched_image_renderer["image"] == b"fake-image"
+
+
+@pytest.mark.asyncio
+async def test_question_card_wraps_latex_options_in_math_mode(patched_image_renderer: dict[str, Any]) -> None:
+    """裸 LaTeX 选项应包进 $...$（md_to_pic 只渲染该形式），纯数字选项保持原样。"""
+    from nonebot_plugin_quick_math.utils.question import build_markdown_message
+
+    question = _make_choice_question()
+    question["question"]["options"] = ["x_{1} = \\frac{1}{2}", "-3"]
+
+    await build_markdown_message("user", question, 0, 0, 0, 0)
+    markdown: str = patched_image_renderer["markdown"]
+    assert "A. $x_{1} = \\frac{1}{2}$" in markdown
+    assert "B. -3" in markdown
+
+
+@pytest.mark.asyncio
+async def test_question_card_falls_back_to_plain_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    """图床不可用时题目信息应回退为纯文本，保证题目卡片仍可发送。"""
+    from nonebot_plugin_alconna import Text
+    from nonebot_plugin_quick_math.utils import question as question_module
+    from nonebot_plugin_quick_math.utils.question import build_markdown_message
+
+    async def failing_create_image_markdown(_data: bytes, **_kwargs: object) -> str:
+        raise RuntimeError("S3 图床未配置")
+
+    monkeypatch.setattr(question_module, "create_image_markdown", failing_create_image_markdown)
+
+    message, _ = await build_markdown_message("user", _make_choice_question(), 0, 0, 0, 0)
+    content = next(segment for segment in message if isinstance(segment, Text)).text
+    assert "1 + 2 = ?" in content
+    assert "\n\n## 请选择答案\n\n" in content
+    assert "A. 1" in content
 
 
 @pytest.mark.asyncio
@@ -170,15 +238,15 @@ async def test_question_card_leave_button_only_when_enabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_question_card_option_buttons_send_letters() -> None:
-    """选项按钮应显示选项原文，但回传选项字母 A/B/C，而不是选项原文。"""
+async def test_question_card_option_buttons_show_letters() -> None:
+    """选项按钮内容应为字母 A/B/C（选项原文已渲染进题目信息图片）。"""
     from nonebot_plugin_alconna import Keyboard
     from nonebot_plugin_quick_math.utils.question import build_markdown_message
 
     question = _make_choice_question()
     message, _ = await build_markdown_message("user", question, 0, 0, 0, 0, "qq_openid")
     keyboard = next(segment for segment in message if isinstance(segment, Keyboard))
-    assert [button.label for button in keyboard.children] == ["1", "2", "3"]
+    assert [button.label for button in keyboard.children] == ["A", "B", "C"]
     assert [button.text for button in keyboard.children] == ["A", "B", "C"]
 
 


### PR DESCRIPTION
## 目标

优化二次函数（一元二次方程，L5）题目的显示效果：QQ 官方机器人下该等级的题目信息改用 `md_to_pic` 渲染发送（与 OneBot V11 下的图片题目一致），**其余等级保持原有纯文本卡片不变**。

## 修改

QQ 适配器的 markdown 消息不解析 LaTeX，L5 的选项由 sympy 生成 LaTeX，会被 `latex_to_plain` 转成难以辨认的纯文本：

```
A. x₁ = - (9)/(2) - √(57)2, x₂ = - (9)/(2) + √(57)2
```

现在这一部分（题干 + 「请选择答案」 + 选项）会整体渲染成图片，「题目信息」标题后面直接跟一张图片：

- 新增 `build_question_info`：`question["level"]` 命中 `_QUESTION_IMAGE_LEVELS = {5}` 时用 `md_to_pic` 渲染题目信息，再经 `create_image_markdown` 上传图床并作为 markdown 图片代码发送；其余等级直接返回原有纯文本题目信息（不触发渲染与上传）；
- 新增 `ensure_math_mode`：把生成器给出的裸 LaTeX 选项包进 `$...$` 交给 KaTeX 渲染，纯数字选项保持原样；
- 选项之间使用行尾双空格的硬换行，避免图片内 4 个选项被 markdown 折叠到同一行；
- L5 的选项按钮内容改为 `ABCD`（选项原文已在图片中）；其余等级选项仍以文本显示，按钮保留选项原文，回传字母的判定逻辑两种情况下都不变；
- 图床未配置或渲染失败时 L5 回退为原来的纯文本题目，保证题目卡片仍可发送。

## 验收

- [x] `tests/test_quick_math_qq_adapter.py`：27 passed（含「仅 L5 走图片，其余等级保持纯文本」的回归测试）
- [x] 全量 `pytest tests/`：通过
- [x] `ruff check` / `ruff format --check` 通过（仅存量 COM812 告警）
- [x] CI `check`、Codacy、CodeFactor、pre-commit.ci、WIP 全部通过
