### PR TITLE
feat(chat): 主模型启用多模态图片，新增 request_image 工具

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -260,19 +260,19 @@ docs = ["sphinx (==7.2.6)", "sphinx-mdinclude (==0.5.3)"]
 
 [[package]]
 name = "alembic"
-version = "1.19.2"
+version = "1.20.0"
 description = "A database migration tool for SQLAlchemy."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2"},
-    {file = "alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0"},
+    {file = "alembic-1.20.0-py3-none-any.whl", hash = "sha256:77eb101048d95f982c0353e9233404889dcd7a6fc244c107836c0e2fc9cf7d9d"},
+    {file = "alembic-1.20.0.tar.gz", hash = "sha256:db505480647bc60386c5369402f4a57a506b7539c9e9ef5e270d45cbbe4939bf"},
 ]
 
 [package.dependencies]
 Mako = "*"
-SQLAlchemy = ">=1.4.23"
+SQLAlchemy = ">=2.0"
 typing-extensions = ">=4.12"
 
 [package.extras]
@@ -3355,58 +3355,65 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.11.1"
+version = "3.11.2"
 description = "Python plotting package"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "matplotlib-3.11.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b7cf158e7add54a8d51ac9b5a84abd6d4e13ed4951b4f25f1c5139f41c2addb2"},
-    {file = "matplotlib-3.11.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d2ace7273b9a5061a3b420918a16fae1f2dc5dfee1abcc13aba71b5d94b1820c"},
-    {file = "matplotlib-3.11.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aee55e9041211bf84302ab55ec3965df18dd90ae19f8b58332a7feaf208bfe83"},
-    {file = "matplotlib-3.11.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f4bdeea33a8d15a071dbfe6d119451b1d719c733ac666d65357082901a9099"},
-    {file = "matplotlib-3.11.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b4c78ceb2f11bcac7389d305cda17aeb1f4586a857854ab5780bd3dd8dbfc407"},
-    {file = "matplotlib-3.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:7f33a781e12b1e53b278deb2f5373c2e55ec4f10727be3440c0cfb5cda9f944f"},
-    {file = "matplotlib-3.11.1-cp311-cp311-win_arm64.whl", hash = "sha256:67e4c3cd578c65ebd81bdc09a1b6592ceafee6dfafe116dc85dfcb647b5bbb18"},
-    {file = "matplotlib-3.11.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e15ef41507f3d525f46154ac9e3ae785dacde9f20e593a25de8986267892ef74"},
-    {file = "matplotlib-3.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:21a67b961a6d597bca54fae826cd20695ba4a6e4d05424a08da6e13e3176fd6b"},
-    {file = "matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba8f811b8ddfac493734d6af0b2dff96919d0c28ca0d641858dab4262777c6ea"},
-    {file = "matplotlib-3.11.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c52f7ad20ef476806ed212380b1d54d20310c8b86bdc2c9a68b51f0024a44472"},
-    {file = "matplotlib-3.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8b14eb22961fe865efb0e4ff167e333e428908b00115a8d800ccb65ee108e481"},
-    {file = "matplotlib-3.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:88a2a27dd9691ae448dfae4b26f59036be90c3c28757edd3553a29559d00859f"},
-    {file = "matplotlib-3.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:480194afceca4df2f137c2721227d3cba67121fbf4397b69cee7f83714b0a58a"},
-    {file = "matplotlib-3.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6771b0cd7838c6a857a7209814158c0ad09bfef878db3033dd82d70ad101f191"},
-    {file = "matplotlib-3.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2abdee5ffa2fe11b2d19f7a5c63b785fb7c28cc46c7bc1814156341d9d1a33e1"},
-    {file = "matplotlib-3.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0a19dcf73406d3746d25a5ed42d713604c9a3e024d129b102852b0d941cb9f3"},
-    {file = "matplotlib-3.11.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7389b77ed2ab0552f46d9a90b81b7b8e6dfcdc42adc36c37a0865799843e0e3e"},
-    {file = "matplotlib-3.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c90be0b73568da4f662afac580956a76e308437e641b4a45aa08925eeb67d95f"},
-    {file = "matplotlib-3.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:68408341f2312836fbbdf6b3c78047f65b2d8752f5fd221c3e72d348f5b34f8b"},
-    {file = "matplotlib-3.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:0c1f44890d435c1b4ef52f701ad5828cb450ea97bcc83918fda6be74965d6cd2"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:5e510088c27a89d53580a752f959146893563e63c330e161d159b0fee652af6f"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:1524e2bdd48a93557aa47ddcfe9c225dfdd57d5a01a5c49128c20f0632980ee1"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:11664c551345553db92e61cae6cf1376f138f8c47cafdf13b64b18f3e3e9e464"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e1f8922ba31959cf6a9dfb51be64b7f7bc582801a3957dc0c2f3afcd3537adf"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83235693abde86e5e0129998f80ee39fc7f58e6d56a88fafb28a9278833e9d5f"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-win_amd64.whl", hash = "sha256:9a076f4fc5cdc43fdf510f5981418d25c2db4973418d9f22d8bb3dc8045ada78"},
-    {file = "matplotlib-3.11.1-cp313-cp313t-win_arm64.whl", hash = "sha256:216fbb93a74add02ddb4cb38ef5348f59ac00b3e84567eaf16598772d40e150a"},
-    {file = "matplotlib-3.11.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c492d4ba9448595b6fd8708c6725963f8148e25c0d8842948da5b05f0ee8d3"},
-    {file = "matplotlib-3.11.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ac104be2768ffdd8655db9e71b768cbb45f2b9aa7b450cf1595e8f65d3822319"},
-    {file = "matplotlib-3.11.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6be943cb68bc6660ead58c55b3aa6366cba2ef7feb06460fbcce32360376f19f"},
-    {file = "matplotlib-3.11.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5af0dcda57d471440a7b5b623e70e0a61003518443d9098f211a96ecfbbc25be"},
-    {file = "matplotlib-3.11.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3d3fd84082b1afbd9398466c81309e20045be20d48fe0fb18c43504d164cbbb2"},
-    {file = "matplotlib-3.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:9601a1e90be21e4884c53b4f3dc3ee0544654946f9975258d691f1c2e2f119c6"},
-    {file = "matplotlib-3.11.1-cp314-cp314-win_arm64.whl", hash = "sha256:ae30c6109848ac0f9fa36c5d6270938487614c47ba31860bd5361266dabc5685"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dadfe80797174e2984aae3be0b77594a3c72d2c0a40fbd4a0de48d2728caf3ae"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:89b193b255f4f6f7948dbcee3691f4f341ab05d9a8874a67b45ddb4182922eda"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191163532cdefcb1571ca38a6d7e6474baccde64495783e6ba47aa07ec4b9bbb"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fdf1c818ab05d0e74002091ddaf414478a3a449ec9d51c8976d45be7e3a01e2"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b937b9dba5f5f6c1e31c47abe2186c865c0914fd18f2ce0dfc39c9adcef5951d"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f2912f647f3fbe1ccf085f91e213936f9101bead81a5e670565b1f1b3712f4fb"},
-    {file = "matplotlib-3.11.1-cp314-cp314t-win_arm64.whl", hash = "sha256:54d47b8ae8b579633a3902ca5b4ad6c1e132a5626d64447b2e22a66394e79987"},
-    {file = "matplotlib-3.11.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:427258425f9a3fc4ed79a91f9e9b9aaf5a82cb6571e85dc14063cc6fbb993741"},
-    {file = "matplotlib-3.11.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:1ac697e591c11b6ad04679a73c2d2f9980fe9d9f0311fb414a2e329706343dfb"},
-    {file = "matplotlib-3.11.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4b9ac2f1f607ecda2af90a5232beee2af7582fce1cc30c4b6a1b012dc21ee99"},
-    {file = "matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30"},
+    {file = "matplotlib-3.11.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5e1e923a3fc3326b99ec0a6ff1ab1338ac6c6cc62ad9d8a9c944197c7f8c6221"},
+    {file = "matplotlib-3.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c27e577ece613ea12a0790e00b4eb80d901c59a3e16cad474f31d8b1529690b9"},
+    {file = "matplotlib-3.11.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:07d9b9fa60cd4c393692f50d0bb03123242ddf61c99bb0e95e75feb354e7c1a8"},
+    {file = "matplotlib-3.11.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30ec15d7eefee71de16b7c689b42ba49715a4644650b76a6c7c70d79daf24e91"},
+    {file = "matplotlib-3.11.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:116cdb0eb0eb5644fc98eb2975d4b4dd4ad35e5c8e6b851c22e6976f371f7ab5"},
+    {file = "matplotlib-3.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:a24d5fd36e4f0e742c3851dcd20810e56a95633a342e4bf6cb591c678e8fe61f"},
+    {file = "matplotlib-3.11.2-cp311-cp311-win_arm64.whl", hash = "sha256:57b9ea60a835937c2012861923cbb91f47db8565775d326d1c42fc926aa10351"},
+    {file = "matplotlib-3.11.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ef752769cd962f39ea0b6ffc82d1ea43a0012c5a6157c7a075212fa509cfcff2"},
+    {file = "matplotlib-3.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ef31985c4dedb5f1424e1aec6849a47dd37689cb7fa3c20b1b82187f26806261"},
+    {file = "matplotlib-3.11.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df4f7784aca81a94f254c0a2767d592ee25f407e488f5fa7203e51093fb6ca27"},
+    {file = "matplotlib-3.11.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b9a7ad579856284135e401ecc918c5f8a017ee30539298862a109f51b971710"},
+    {file = "matplotlib-3.11.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3aa4b8516fd26659e4363abbf317c703d9116496c5db2e9d0609a2866dd39dd2"},
+    {file = "matplotlib-3.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:c5c1c68ee401fc98271263410f0e5ce88285abacf7627132914e8adf3d70ff43"},
+    {file = "matplotlib-3.11.2-cp312-cp312-win_arm64.whl", hash = "sha256:643ff850d8e0f5b8319337f87ed3cb59506afb3df3cc48de777d85871233be7b"},
+    {file = "matplotlib-3.11.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d43ff8cebb50840648cb6429b2228621dbd709010f3117b3740abb20abf21c0"},
+    {file = "matplotlib-3.11.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2a8285cea8ef4d92aa041d1c33788bcae82248503300f93f1ca2136b9049452f"},
+    {file = "matplotlib-3.11.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1944895967f87c84c9b4bad29a707b31f5b36df4a3a2339ea1f8ea3ce5105539"},
+    {file = "matplotlib-3.11.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af2661f6ac6bbd1d081996f54fdd9385715c625ace8cec0869055c0cfbf38981"},
+    {file = "matplotlib-3.11.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e5a90f8a707ebb6004a713b1cff091a40cc5df4c7c1cb165e5a505ebc11c292"},
+    {file = "matplotlib-3.11.2-cp313-cp313-win_amd64.whl", hash = "sha256:bc067c462a86f0e57bf52fc6e058d90171a5420007dac00c46e90153050c69a7"},
+    {file = "matplotlib-3.11.2-cp313-cp313-win_arm64.whl", hash = "sha256:3e8576f7c47e02fd4f21f44171302d2d1d58d4471d46da3d71fe8899d19539d9"},
+    {file = "matplotlib-3.11.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c9721f81275499da1feeb36a2cf8192ea086283b3bd16b7dc4c9d7aedb7396d6"},
+    {file = "matplotlib-3.11.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a3040b209f3968b4e84161df7b174f07a9fad33b0f2d7e48ea3bbd3075e2863"},
+    {file = "matplotlib-3.11.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf3fe71fbfb8ec0e310e0bc8537c3405a01f38f25f9394ed2135e6202fed542b"},
+    {file = "matplotlib-3.11.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8c8255de28f986d935a64c9ca71c0ec2d2f41d355691f5ea684725dc91413f71"},
+    {file = "matplotlib-3.11.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a8756cc73d9af9a7fe0deb54ea2e75ef73b01d9e575877e72acad5458e660943"},
+    {file = "matplotlib-3.11.2-cp314-cp314-win_amd64.whl", hash = "sha256:ecea603dd2fbf8242fd31a305a8b12a4ece2de28096870c65fdd0d1e35b8d9a6"},
+    {file = "matplotlib-3.11.2-cp314-cp314-win_arm64.whl", hash = "sha256:01dc8eaaab5a9fce9ff615eca82345728f289e4715b186ee10c6d85272fc26bb"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79a258f58253dfa025af80a9e9bb228d75fced007f0e93ae7423fefbde81a74d"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c0b83f044ce10a98027b105b3931548719a6e8c7ef986b4362651e0b5367c8dc"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e43b188f0a5b75447bcc197728258166aa64365770ed1caa36595a5e1ca4bbba"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3304eb5a59442a8867f6920d484591c0fa09ffc29e9260be2feec3351e25869"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:02329432ae5c6af87cf208ee575b701d698bdf0b1a3bb28cc6d53c36e967e575"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-win_amd64.whl", hash = "sha256:f2ac30cf5eb5dff1b584627ae0b0e1186551a4f69ae3c75073911da497a29170"},
+    {file = "matplotlib-3.11.2-cp314-cp314t-win_arm64.whl", hash = "sha256:cf41ecd1b0c0b6f7177ed965a54c2afbe888715c7cf6054dc12d53bc1494002c"},
+    {file = "matplotlib-3.11.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:894a9cbbecbe30ae6787d464df2e8fc7a8d475cfc68f87c3029f7c11152899b3"},
+    {file = "matplotlib-3.11.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:bbf1062991d826ed27e2144f3afa4461afbb8ff56e8f703043e191a8163b1ee9"},
+    {file = "matplotlib-3.11.2-cp315-cp315-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:399fef672f7046ef7d6a57572b2a6f9845f3f5afcff04e7b2df7a363a9f42190"},
+    {file = "matplotlib-3.11.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc82dde2a0d3e3ad472edce04897ad7146b8d8bfd1df8a32992eebb81af18fdc"},
+    {file = "matplotlib-3.11.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:930efb28f59fda124e39265d177bab302625297bb147d2910de725a2fc2aef54"},
+    {file = "matplotlib-3.11.2-cp315-cp315-win_amd64.whl", hash = "sha256:3da3bc0cbf7245e7db72cc6d29d12c5abef72cb73059c73b945f14e3545f3eb2"},
+    {file = "matplotlib-3.11.2-cp315-cp315-win_arm64.whl", hash = "sha256:f25446b2981717dca9786bac841cb3fd7efb568e3e3c755dd980481c5cb9228d"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:fea03cf56568cc1cba08b470be6a0559e71c3a5b688d54b7179bb35ba23d0821"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:254d4ddb2fa8df3b4c689c0c306063aee10521df82cfb438185e499c75fe37c1"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e60cf3047a51edecdc4535a9196bbd6a732936b8e9f8184aabf4d16165884aaf"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eb3712dc9b464793de0a4e42a7313d50293c751f94bddaf7332a1bc71bccdda9"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:75b6d88402770e181b5d06a67dda4129c31da7d05004d63a21c310ec78d1b83c"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-win_amd64.whl", hash = "sha256:a6939df7567114b6bac7f4c5e06c84a67f197c1b2f2e4b234d4eecb3bfec9482"},
+    {file = "matplotlib-3.11.2-cp315-cp315t-win_arm64.whl", hash = "sha256:d480038c83691532ed52ff3147db51fa902fc78cb2d8349993a1cdb684435bff"},
+    {file = "matplotlib-3.11.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:854df8d7dfe9fdffcbaa6f39e44a6c24b409cb4d7561fbc09213b157d833f6a6"},
+    {file = "matplotlib-3.11.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:eac4b07d4e3743b172451e122ea964f72f152879d4f9adcf3f3d33e518f12ead"},
+    {file = "matplotlib-3.11.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ef7a53b66780e5d942923724f08577fbc5be1f7322da0f0f3f9dcaa45dd803d"},
+    {file = "matplotlib-3.11.2.tar.gz", hash = "sha256:cec596316640f2b394b8f0daa0ea61a8eae82d017b620b9f202befb972a59ea4"},
 ]
 
 [package.dependencies]
@@ -5345,14 +5352,14 @@ files = [
 
 [[package]]
 name = "pyjwt"
-version = "2.13.0"
+version = "2.14.0"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
-    {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
+    {file = "pyjwt-2.14.0-py3-none-any.whl", hash = "sha256:ad0cef71c756a56e74863c2919cf0985f72decbcfcb550ee2f422e7c62b5eedc"},
+    {file = "pyjwt-2.14.0.tar.gz", hash = "sha256:77283c83fb56ecf566a886c757a714bc83668e38156de2cce8263302f42e0b86"},
 ]
 
 [package.extras]
@@ -6869,14 +6876,14 @@ files = [
 
 [[package]]
 name = "tqdm"
-version = "4.70.0"
+version = "4.70.1"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953"},
-    {file = "tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220"},
+    {file = "tqdm-4.70.1-py3-none-any.whl", hash = "sha256:c293e525e6fef9c20e8728fd4612df02a0aa31bb5fe91ecd93e123b1b7bffa73"},
+    {file = "tqdm-4.70.1.tar.gz", hash = "sha256:cefd0eca11b2a37a3aee776544d4f4ae913f02688135b5556b8788dfa474afc4"},
 ]
 
 [package.dependencies]

--- a/src/plugins/nonebot_plugin_chat/core/message.py
+++ b/src/plugins/nonebot_plugin_chat/core/message.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import re
 import traceback
@@ -426,6 +427,27 @@ class MessageQueue:
                 self.fetcher = await self._create_fetcher()
             await self._ensure_system_prompt()
             self.fetcher.session.insert_message(msg)
+
+    async def inject_image(self, image: bytes, mime_type: str, note: str) -> None:
+        """把图片立即注入当前对话，使主模型能够直接看到图片内容
+
+        工具调用发生在一次请求内部，此时 fetcher_lock 已被持有，append_user_message
+        会把消息放入 waiting_sequence 而无法在本轮生效；这里直接插入正在进行的会话，
+        消息会在本轮工具调用结束后、下一次请求之前送出。
+
+        Args:
+            image: 图片二进制数据
+            mime_type: 图片 MIME 类型，如 image/png
+            note: 随图片一起发送的说明文本
+        """
+        if self.fetcher is None:
+            self.fetcher = await self._create_fetcher()
+        image_base64 = base64.b64encode(image).decode("utf-8")
+        content = [
+            {"type": "text", "text": note},
+            {"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{image_base64}"}},
+        ]
+        self.fetcher.session.insert_message(generate_message(content, "user"))
 
     def is_last_message_from_user(self) -> bool:
         return get_role(self.messages[-1]) == "user"

--- a/src/plugins/nonebot_plugin_chat/core/processor.py
+++ b/src/plugins/nonebot_plugin_chat/core/processor.py
@@ -60,7 +60,9 @@ if TYPE_CHECKING:
 
 class MessageProcessor:
     def __init__(self, session: "BaseSession"):
-        self.ENABLE_EMBEDDED_IMAGE = False
+        # Chat 主模型支持图像（多模态）：图片直接嵌入上下文，不再生成 VLM 描述。
+        # 关闭时回退为「VLM 描述图片 + query_image 按需追问」的方案。
+        self.ENABLE_EMBEDDED_IMAGE = True
         self.openai_messages = MessageQueue(self)
         self.session = session
         self.enabled = True

--- a/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
@@ -46,6 +46,8 @@ from .tools import (
     is_vm_available,
     fetch_history_messages,
     get_weather,
+    download_image,
+    ImageDownloadError,
 )
 from ..utils.emoji import QQ_EMOJI_MAP
 from .note_manager import check_note, get_context_notes
@@ -116,6 +118,32 @@ class ToolManager:
         await message.send(target=self.processor.session.target, bot=self.processor.session.bot)
 
         return "图片已生成并发送"
+
+    async def request_image(self, url: str) -> str:
+        """下载指定 URL 的图片并加入当前对话，以便你直接查看图片内容
+
+        Args:
+            url: 图片的 URL 地址
+
+        Returns:
+            工具执行结果
+        """
+        if self.processor is None:
+            raise RuntimeError("processor is None")
+        if not self.processor.ENABLE_EMBEDDED_IMAGE:
+            return "当前模型不支持图像，无法查看下载的图片"
+
+        try:
+            image, mime_type = await download_image(url)
+        except ImageDownloadError as e:
+            return f"图片获取失败：{e}"
+
+        await self.processor.openai_messages.inject_image(
+            image,
+            mime_type,
+            f"[图片] 这是你通过 request_image 加载的图片（来源：{url}），请查看其内容。",
+        )
+        return "图片已加入当前对话，你可以在接下来的回复中直接查看"
 
     async def calculate_luck_value(self, nickname: str) -> str:
         """计算用户的人品值
@@ -241,9 +269,12 @@ class ToolManager:
 
         # # === Group 模式特有工具 ===
         if processor and mode == "group":
-            # query_image：仅在图片未嵌入上下文时才需要
-            # （此时模型看不到原图，只能依赖 VLM 生成的描述，需要该工具按需追问细节）
-            if not processor.ENABLE_EMBEDDED_IMAGE:
+            # 图片相关工具二选一：
+            # - 主模型支持多模态：可以直接把 URL 图片拉进上下文（request_image）
+            # - 否则模型看不到原图，只能依赖 VLM 生成的描述，需要 query_image 按需追问细节
+            if processor.ENABLE_EMBEDDED_IMAGE:
+                tools.append(processor.request_image)
+            else:
                 tools.append(processor.query_image)
             tools.append(processor.send_message)
 

--- a/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
@@ -241,8 +241,10 @@ class ToolManager:
 
         # # === Group 模式特有工具 ===
         if processor and mode == "group":
-            # query_image
-            tools.append(processor.query_image)
+            # query_image：仅在图片未嵌入上下文时才需要
+            # （此时模型看不到原图，只能依赖 VLM 生成的描述，需要该工具按需追问细节）
+            if not processor.ENABLE_EMBEDDED_IMAGE:
+                tools.append(processor.query_image)
             tools.append(processor.send_message)
 
             # leave_for_a_while

--- a/src/plugins/nonebot_plugin_chat/utils/tools/__init__.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tools/__init__.py
@@ -30,3 +30,4 @@ from .vm import (
 from .bilibili import describe_bilibili_video, resolve_b23_url
 from .query_history import fetch_history_messages
 from .weather import get_weather
+from .image import download_image, ImageDownloadError

--- a/src/plugins/nonebot_plugin_chat/utils/tools/image.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tools/image.py
@@ -1,0 +1,155 @@
+#  Moonlark - A new ChatBot
+#  Copyright (C) 2026  Moonlark Development Team
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ##############################################################################
+
+from __future__ import annotations
+
+import io
+from urllib.parse import urljoin, urlparse
+
+import httpx
+from nonebot import logger
+from PIL import Image, UnidentifiedImageError
+
+from nonebot_plugin_larkutils.url_validator import resolve_internal
+
+# 允许下载的单张图片最大体积
+MAX_IMAGE_SIZE = 10 * 1024 * 1024
+# 允许的最大重定向次数
+MAX_REDIRECTS = 3
+# 单张图片允许的最大像素数（防御解压缩炸弹）
+MAX_IMAGE_PIXELS = 40_000_000
+# 下载超时时间（秒）
+REQUEST_TIMEOUT = 15.0
+REQUEST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+    ),
+    "Accept": "image/*,*/*;q=0.8",
+}
+
+# 可以直接透传给模型的图片格式，其余格式统一转换为 JPEG
+_FORMAT_TO_MIME = {
+    "JPEG": "image/jpeg",
+    "PNG": "image/png",
+    "WEBP": "image/webp",
+    "GIF": "image/gif",
+}
+
+
+class ImageDownloadError(Exception):
+    """图片下载失败，异常信息可以直接返回给模型"""
+
+
+async def _fetch_image(url: str) -> bytes:
+    """下载 URL 内容
+
+    会校验每一跳地址（含重定向目标）是否指向内网，并限制下载体积。
+
+    Args:
+        url: 图片 URL
+
+    Returns:
+        bytes: 图片二进制数据
+    """
+    current_url = url
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT, follow_redirects=False) as client:
+        for _ in range(MAX_REDIRECTS + 1):
+            parsed = urlparse(current_url)
+            if parsed.scheme not in ("http", "https"):
+                raise ImageDownloadError("仅支持 http/https 链接")
+            if await resolve_internal(parsed):
+                raise ImageDownloadError("不允许访问内网地址")
+            async with client.stream("GET", current_url, headers=REQUEST_HEADERS) as response:
+                if response.is_redirect:
+                    location = response.headers.get("location")
+                    if not location:
+                        raise ImageDownloadError("重定向响应缺少 Location")
+                    current_url = urljoin(str(response.url), location)
+                    continue
+                if response.status_code != 200:
+                    raise ImageDownloadError(f"请求失败 (HTTP {response.status_code})")
+                content_length = response.headers.get("content-length")
+                if content_length and content_length.isdigit() and int(content_length) > MAX_IMAGE_SIZE:
+                    raise ImageDownloadError("图片体积超过 10 MB")
+                chunks: list[bytes] = []
+                size = 0
+                async for chunk in response.aiter_bytes():
+                    size += len(chunk)
+                    if size > MAX_IMAGE_SIZE:
+                        raise ImageDownloadError("图片体积超过 10 MB")
+                    chunks.append(chunk)
+                return b"".join(chunks)
+    raise ImageDownloadError("重定向次数过多")
+
+
+def _check_image_pixels(image: Image.Image) -> None:
+    """校验图片像素规模，防御解压缩炸弹
+
+    Args:
+        image: 已打开的 Pillow 图片对象
+    """
+    if image.width * image.height > MAX_IMAGE_PIXELS:
+        raise ImageDownloadError("图片尺寸过大")
+
+
+def _normalize_image(data: bytes) -> tuple[bytes, str]:
+    """校验图片内容并识别 MIME 类型
+
+    Pillow 无法直接输出的格式会转换为 JPEG，避免把非图片数据塞进上下文。
+
+    Args:
+        data: 下载得到的二进制数据
+
+    Returns:
+        tuple[bytes, str]: (图片数据, MIME 类型)
+    """
+    try:
+        with Image.open(io.BytesIO(data)) as image:
+            _check_image_pixels(image)
+            image_format = (image.format or "").upper()
+            mime_type = _FORMAT_TO_MIME.get(image_format)
+            if mime_type is not None:
+                image.load()
+                return data, mime_type
+            buffer = io.BytesIO()
+            image.convert("RGB").save(buffer, format="JPEG", quality=90)
+            return buffer.getvalue(), "image/jpeg"
+    except ImageDownloadError:
+        raise
+    except (UnidentifiedImageError, OSError, ValueError, Image.DecompressionBombError) as e:
+        raise ImageDownloadError("链接内容不是可识别的图片") from e
+
+
+async def download_image(url: str) -> tuple[bytes, str]:
+    """从 URL 下载图片
+
+    Args:
+        url: 图片 URL
+
+    Returns:
+        tuple[bytes, str]: (图片数据, MIME 类型)
+
+    Raises:
+        ImageDownloadError: 下载失败、内容不是图片或体积超限
+    """
+    data = await _fetch_image(url)
+    if not data:
+        raise ImageDownloadError("图片内容为空")
+    image, mime_type = _normalize_image(data)
+    logger.debug(f"request_image 已下载图片: {url} -> {mime_type}, {len(image)} bytes")
+    return image, mime_type

--- a/src/prompt/__tools__/request_image.yaml
+++ b/src/prompt/__tools__/request_image.yaml
@@ -1,0 +1,12 @@
+description: |
+  下载指定 URL 的图片并放入当前对话，使你能够直接查看图片内容。
+  **使用场景**:
+  1. 群友发送了图片链接，而你需要看懂图片内容才能回复。
+  2. 你在网页或搜索结果中发现了值得一看的图片地址（截图、插画、表情包等）。
+  **限制**: 仅支持指向图片文件本身的 http/https 链接（jpg/png/webp/gif/bmp 等），
+  普通网页请使用 browse_webpage，不要用本工具访问网页。
+parameters:
+  - name: url
+    description: "图片的 URL 地址（以 http:// 或 https:// 开头）。"
+    type: string
+    required: true

--- a/tests/test_request_image.py
+++ b/tests/test_request_image.py
@@ -1,0 +1,142 @@
+"""request_image 工具：URL 图片下载、校验与上下文注入"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_SCHEMA = REPO_ROOT / "src" / "prompt" / "__tools__" / "request_image.yaml"
+
+
+def _load_helper() -> Any:
+    from nonebot_plugin_chat.utils.tools import image as mod
+
+    return mod
+
+
+def test_tool_schema_declares_url() -> None:
+    """工具定义文件存在，且 url 为必填参数"""
+    schema = yaml.safe_load(TOOL_SCHEMA.read_text(encoding="utf-8"))
+    assert "图片" in schema["description"]
+    params = {param["name"]: param for param in schema["parameters"]}
+    assert params["url"]["required"] is True
+    assert params["url"]["type"] == "string"
+
+
+async def test_download_image_normalizes_png(monkeypatch: pytest.MonkeyPatch) -> None:
+    """下载到的 PNG 应原样返回并标记为 image/png"""
+    mod = _load_helper()
+
+    async def _fake_fetch_image(_url: str) -> bytes:
+        return _png_bytes()
+
+    monkeypatch.setattr(mod, "_fetch_image", _fake_fetch_image)
+    data, mime_type = await mod.download_image("https://example.com/a.png")
+    assert mime_type == "image/png"
+    assert data == _png_bytes()
+
+
+async def test_download_image_converts_unsupported_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pillow 能读但模型不一定接受的格式（如 BMP）应转换为 JPEG"""
+    mod = _load_helper()
+
+    async def _fake_fetch_image(_url: str) -> bytes:
+        return _bmp_bytes()
+
+    monkeypatch.setattr(mod, "_fetch_image", _fake_fetch_image)
+    data, mime_type = await mod.download_image("https://example.com/a.bmp")
+    assert mime_type == "image/jpeg"
+    assert data.startswith(b"\xff\xd8")
+
+
+async def test_download_image_rejects_non_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    """不是图片的内容应被拒绝，不会进入上下文"""
+    mod = _load_helper()
+
+    async def _fake_fetch_image(_url: str) -> bytes:
+        return b"<html>not an image</html>"
+
+    monkeypatch.setattr(mod, "_fetch_image", _fake_fetch_image)
+    with pytest.raises(mod.ImageDownloadError):
+        await mod.download_image("https://example.com/index.html")
+
+
+async def test_download_image_rejects_internal_url() -> None:
+    """内网地址与非 http(s) 协议应被拦截（SSRF 防护）"""
+    mod = _load_helper()
+    for url in ("http://127.0.0.1/a.png", "http://localhost/a.png", "file:///etc/passwd", "ftp://host/a.png"):
+        with pytest.raises(mod.ImageDownloadError):
+            await mod.download_image(url)
+
+
+def _png_bytes() -> bytes:
+    import io
+
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (4, 4), (255, 0, 0)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _bmp_bytes() -> bytes:
+    import io
+
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (4, 4), (0, 255, 0)).save(buffer, format="BMP")
+    return buffer.getvalue()
+
+
+class _FakeMessageQueue:
+    def __init__(self) -> None:
+        self.injected: list[tuple[bytes, str, str]] = []
+
+    async def inject_image(self, image: bytes, mime_type: str, note: str) -> None:
+        self.injected.append((image, mime_type, note))
+
+
+class _FakeProcessor:
+    def __init__(self, enable_embedded_image: bool = True) -> None:
+        self.ENABLE_EMBEDDED_IMAGE = enable_embedded_image
+        self.openai_messages = _FakeMessageQueue()
+
+
+async def test_request_image_injects_into_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """多模态模型下，下载到的图片会被注入当前对话"""
+    from nonebot_plugin_chat.utils import tool_manager as tm_mod
+
+    processor = _FakeProcessor(enable_embedded_image=True)
+    manager = tm_mod.ToolManager(processor=cast("Any", processor))
+
+    async def _fake_download(_url: str) -> tuple[bytes, str]:
+        return b"image-bytes", "image/png"
+
+    monkeypatch.setattr(tm_mod, "download_image", _fake_download)
+    result = await manager.request_image("https://example.com/a.png")
+
+    assert processor.openai_messages.injected
+    image, mime_type, note = processor.openai_messages.injected[0]
+    assert (image, mime_type) == (b"image-bytes", "image/png")
+    assert "example.com" in note
+    assert "已加入" in result
+
+
+async def test_request_image_skipped_for_text_only_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """非多模态模型下，不下载图片，直接返回提示"""
+    from nonebot_plugin_chat.utils import tool_manager as tm_mod
+
+    processor = _FakeProcessor(enable_embedded_image=False)
+    manager = tm_mod.ToolManager(processor=cast("Any", processor))
+
+    async def _fail_download(_url: str) -> tuple[bytes, str]:
+        raise AssertionError("不支持图像时不应发起下载")
+
+    monkeypatch.setattr(tm_mod, "download_image", _fail_download)
+    result = await manager.request_image("https://example.com/a.png")
+
+    assert processor.openai_messages.injected == []
+    assert "不支持图像" in result


### PR DESCRIPTION
## 改动

把 Chat 主模型当作支持图像的多模态模型使用：图片直接嵌入上下文，并新增按 URL 拉取图片的 `request_image` 工具。

### 1. 主模型支持图像（`ENABLE_EMBEDDED_IMAGE = True`）

- `core/processor.py`：`ENABLE_EMBEDDED_IMAGE` 置为 `True`
  - `MessageParser` 以 `describe_image=False` 解析，图片只输出占位符 `[图片(图片ID)]`，原始图片随消息一起送入主模型
  - system prompt 走 `image_placeholder=True` 分支，与输入格式说明保持一致
- `utils/tool_manager.py`：图片工具按模型能力二选一
  - 支持多模态：注册 `request_image`
  - 不支持：注册 `query_image`（保留原来的「VLM 描述 + 按需追问细节」回退方案）

### 2. 新增 `request_image` 工具

模型在对话中可以把一个 URL 交给工具，工具下载图片并注入当前上下文，让模型直接看到这张图。

- `utils/tools/image.py`（新增）
  - 逐跳校验 URL（含重定向目标）是否为内网地址，复用 `nonebot_plugin_larkutils.url_validator.resolve_internal` 防 SSRF
  - 仅允许 http/https，最多 3 次重定向，单张图片 ≤ 10 MB、≤ 4000 万像素
  - 用 Pillow 校验内容确实为图片；JPEG/PNG/WebP/GIF 原样透传，BMP 等其它格式转 JPEG
- `core/message.py`：新增 `MessageQueue.inject_image`
  - 工具调用发生在一次请求内部，`fetcher_lock` 已被持有，`append_user_message` 会把消息丢进 `waiting_sequence` 导致本轮看不到图；这里直接插入正在进行的会话，图片会在本轮工具调用结束后、下一次请求前送出
- `tool_manager.py`：`ToolManager.request_image`，失败时返回可读原因，不中断对话
- `src/prompt/__tools__/request_image.yaml`（新增）：工具定义
- `tests/test_request_image.py`（新增）：下载与格式归一化、非图片内容、内网/非法协议拦截、上下文注入、开关分支

## 注意事项

- 该改动要求 `Chat` 应用标识（`/model <模型名> Chat` 或 `MODEL_OVERRIDE` 的 `"Chat"`）配置的模型**本身支持图像输入**。`.env.template` 中当前为 `deepseek/deepseek-v3.2-exp`（纯文本），合并前需要换成多模态模型，否则带图消息会被上游拒绝。
- 图片以 base64 形式进入上下文并会随消息队列持久化到 `MessageQueueCache`，长图较多的会话会让该表体积增长（这是图片嵌入方案的既有特性）。
- 回复 / 合并转发等嵌套消息中的图片仍走原来的 VLM 描述路径，本次未改动嵌套解析逻辑。

## 验证

- `ruff format --check` / `black --check` 通过；新增文件 `ruff check` 无告警
- `pytest tests/ -q`：**238 passed**（含新增的 7 个用例）
