### PR TITLE
feat(shop): QQ 官方机器人下改用 markdown 商店列表

### DIFF
--- a/src/lang/zh_hans/shop.yaml
+++ b/src/lang/zh_hans/shop.yaml
@@ -1,7 +1,13 @@
 list:
   title: "【Moonlark 商店】当前持有：{} VimCoin"
+  title_md: |
+    ## 商店
+    > 当前持有：{} VimCoin
   item: "[{}] {} - {} VimCoin"
+  item_md: |
+    - <qqbot-cmd-input text="{__prefix__}shop buy {} 1" show="{} ({}vi)" reference="false" />
   footer: 使用 {__prefix__}shop buy <编号> [数量] 购买商品
+  footer_md: 点击可以进行购买
 buy:
   invalid_index: 无效的商品编号，请使用 {__prefix__}shop 查看商品列表。
   invalid_count: 购买数量必须大于 0

--- a/src/plugins/nonebot_plugin_shop/__main__.py
+++ b/src/plugins/nonebot_plugin_shop/__main__.py
@@ -1,5 +1,9 @@
-from nonebot_plugin_alconna import Alconna, Args, Subcommand, on_alconna
 import random
+
+from nonebot.adapters import Bot
+from nonebot.adapters.qq import Bot as QQBot
+from nonebot_plugin_alconna import Alconna, Args, Subcommand, on_alconna
+from nonebot_plugin_alconna.uniseg import UniMessage
 
 from nonebot_plugin_bag.utils.bag import give_item
 from nonebot_plugin_items.utils.get import get_item
@@ -25,10 +29,36 @@ async def get_goods_name(item_id: str, user_id: str) -> str:
     return await stack.getName()
 
 
+async def build_markdown_list(user_id: str, vimcoin: float) -> str:
+    """构建 QQ 官方机器人的商店列表 markdown。
+
+    商品条目使用 <qqbot-cmd-input>：点击即把 `{前缀}shop buy <编号> 1` 填入输入框，
+    编号只用于拼装指令，不展示在商品文本中。
+    """
+    items = []
+    for index, (item_id, price) in enumerate(GOODS, start=1):
+        name = await get_goods_name(item_id, user_id)
+        items.append(await lang.text("list.item_md", user_id, index, name, price))
+    return "\n".join(
+        [
+            await lang.text("list.title_md", user_id, vimcoin),
+            "",
+            *items,
+            "",
+            await lang.text("list.footer_md", user_id),
+        ],
+    )
+
+
 @shop.assign("$main")
-async def handle_main(user_id: str = get_user_id()) -> None:
+async def handle_main(bot: Bot, user_id: str = get_user_id()) -> None:
     user = await get_user(user_id)
-    lines = [await lang.text("list.title", user_id, round(user.get_vimcoin(), 1))]
+    vimcoin = round(user.get_vimcoin(), 1)
+    if isinstance(bot, QQBot):
+        await UniMessage().style(await build_markdown_list(user_id, vimcoin), "markdown").send()
+        await shop.finish()
+
+    lines = [await lang.text("list.title", user_id, vimcoin)]
     for index, (item_id, price) in enumerate(GOODS, start=1):
         name = await get_goods_name(item_id, user_id)
         lines.append(await lang.text("list.item", user_id, index, name, price))

--- a/tests/test_shop_qq_markdown.py
+++ b/tests/test_shop_qq_markdown.py
@@ -1,0 +1,127 @@
+"""nonebot_plugin_shop 的 QQ 官方机器人 Markdown 商店回归测试。
+
+QQ 官方机器人下 /shop 使用 markdown 渲染：标题与持有余额、可点击商品条目
+（<qqbot-cmd-input>，点击即把 `{前缀}shop buy <编号> 1` 填入输入框）、购买提示。
+商品文本只展示名称与单价，编号不出现在 show 属性中；其余平台仍发送纯文本列表。
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+_SHOP_LANG = Path(__file__).parent.parent / "src" / "lang" / "zh_hans" / "shop.yaml"
+_GOODS_NAMES = ["小鱼干", "毛线球", "铃铛项圈", "猫薄荷包", "逗猫棒", "猫罐头", "鸡蛋", "二十面骰子"]
+
+
+def _flatten(data: dict[str, Any], prefix: str = "") -> dict[str, str]:
+    flat: dict[str, str] = {}
+    for key, value in data.items():
+        path = f"{prefix}{key}"
+        if isinstance(value, dict):
+            flat.update(_flatten(value, f"{path}."))
+        else:
+            flat[path] = str(value)
+    return flat
+
+
+class _FakeUser:
+    def __init__(self, vimcoin: float) -> None:
+        self._vimcoin = vimcoin
+
+    def get_vimcoin(self) -> float:
+        return self._vimcoin
+
+
+@pytest.fixture
+def shop_env(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """打桩 LangHelper.text（按真实 shop.yaml 模板渲染）与商品名、用户查询。
+
+    注意：插件导入必须在 fixture 内部进行（collection 阶段 nonebot 尚未初始化）。"""
+    import nonebot_plugin_shop.__main__ as module
+    from nonebot_plugin_larklang.__main__ import LangHelper, remove_trailing_blank_lines
+
+    templates = _flatten(yaml.safe_load(_SHOP_LANG.read_text(encoding="utf-8")))
+    item_ids = [item_id for item_id, _ in module.GOODS]
+
+    async def fake_text(_self: LangHelper, key: str, _user_id: str, *args: object) -> str:
+        return remove_trailing_blank_lines(templates[key].format(*args, __prefix__="/"))
+
+    async def fake_get_goods_name(item_id: str, _user_id: str) -> str:
+        return _GOODS_NAMES[item_ids.index(item_id)]
+
+    async def fake_get_user(_user_id: str) -> _FakeUser:
+        return _FakeUser(40399.6)
+
+    monkeypatch.setattr(LangHelper, "text", fake_text)
+    monkeypatch.setattr(module, "get_goods_name", fake_get_goods_name)
+    monkeypatch.setattr(module, "get_user", fake_get_user)
+    return module
+
+
+def _expected_markdown(goods: list[tuple[str, int]]) -> str:
+    items = [
+        f'- <qqbot-cmd-input text="/shop buy {index} 1" show="{name} ({price}vi)" reference="false" />'
+        for index, (name, (_, price)) in enumerate(zip(_GOODS_NAMES, goods), start=1)
+    ]
+    return "\n".join(["## 商店", "> 当前持有：40399.6 VimCoin", "", *items, "", "点击可以进行购买"])
+
+
+@pytest.mark.asyncio
+async def test_build_markdown_list(shop_env: Any) -> None:
+    """markdown 列表：标题/余额引用块 + 可点击商品条目 + 购买提示，编号不出现在商品文本中"""
+    markdown = await shop_env.build_markdown_list("10", 40399.6)
+
+    assert markdown == _expected_markdown(shop_env.GOODS)
+    # 编号只用于拼装指令，不展示在商品文本里
+    assert 'text="/shop buy 1 1"' in markdown
+    assert 'show="小鱼干 (20vi)"' in markdown
+    assert "【Moonlark 商店】" not in markdown
+
+
+@pytest.mark.asyncio
+async def test_handle_main_qq_sends_markdown(shop_env: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """QQ 官方机器人：/shop 发送 markdown 消息，并单独结束处理器"""
+    from nonebot.adapters.qq import Bot as QQBot
+    from nonebot_plugin_alconna.uniseg import Text, UniMessage
+
+    module = shop_env
+    sent: list[UniMessage] = []
+
+    async def fake_send(self: UniMessage, *_args: object, **_kwargs: object) -> None:
+        sent.append(self)
+
+    finish = AsyncMock()
+    monkeypatch.setattr(UniMessage, "send", fake_send)
+    monkeypatch.setattr(module.shop, "finish", finish)
+
+    await module.handle_main(bot=MagicMock(spec=QQBot), user_id="10")
+
+    assert len(sent) == 1
+    text = next(seg for seg in sent[0] if isinstance(seg, Text))
+    assert any("markdown" in styles for styles in text.styles.values())
+    assert text.text == _expected_markdown(module.GOODS)
+    finish.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_main_other_adapter_sends_plain_text(shop_env: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """非 QQ 平台：/shop 仍发送纯文本列表，不发送 markdown"""
+    from nonebot_plugin_alconna.uniseg import UniMessage
+
+    module = shop_env
+    send = AsyncMock()
+    finish = AsyncMock()
+    monkeypatch.setattr(UniMessage, "send", send)
+    monkeypatch.setattr(module.shop, "finish", finish)
+
+    await module.handle_main(bot=MagicMock(), user_id="10")
+
+    send.assert_not_awaited()
+    finish.assert_awaited_once()
+    plain = finish.await_args.args[0]
+    assert plain.splitlines()[0] == "【Moonlark 商店】当前持有：40399.6 VimCoin"
+    assert "[1] 小鱼干 - 20 VimCoin" in plain
+    assert "qqbot-cmd-input" not in plain


### PR DESCRIPTION
## 变更内容

基于最新 `main`，为 Moonlark 商店（`nonebot_plugin_shop`）添加 QQ 官方机器人 Markdown 支持。

QQ 官方机器人下 `/shop` 现在发送 markdown 消息：

```
## 商店
> 当前持有：40399.6 VimCoin

- <qqbot-cmd-input text="/shop buy 1 1" show="小鱼干 (20vi)" reference="false" />
- <qqbot-cmd-input text="/shop buy 2 1" show="毛线球 (30vi)" reference="false" />
...

点击可以进行购买
```

客户端渲染效果：

```
## 商店
> 当前持有：40399.6 VimCoin

  • 小鱼干 (20vi)
  • 毛线球 (30vi)
  ...
点击可以进行购买
```

- 商品条目使用 `<qqbot-cmd-input>`，点击即把 `{前缀}shop buy <编号> 1` 填入输入框。
- 商品编号仅用于拼装指令，**不展示**在商品文本（`show`）中，只显示「名称 (单价vi)」。
- 非 QQ 平台（OneBot 等）保持原有纯文本列表，不受影响。

## 变更文件

- `src/lang/zh_hans/shop.yaml`：新增 `list.title_md`、`list.item_md`、`list.footer_md`。`en_us` / `zh_tw` 由 Crowdin 管理，未改动，缺失键按 LarkLang 既有逻辑回退。
- `src/plugins/nonebot_plugin_shop/__main__.py`：新增 `build_markdown_list()`，`handle_main` 按 `isinstance(bot, QQBot)` 选择 markdown 或纯文本。
- `tests/test_shop_qq_markdown.py`：新增回归测试，覆盖 markdown 生成、QQ 发送路径、非 QQ 纯文本路径。

## 测试

- `pytest tests/test_shop_qq_markdown.py`：3 passed
- 全量测试与 `origin/main` 基线对比：失败/错误数量一致（本地环境的既有失败），新增 3 项通过
- `ruff format` / `ruff check`（改动文件）：通过
