### PR TITLE
refactor(chat): 移除和风天气每日天气缓存

### DIFF
--- a/src/plugins/nonebot_plugin_chat/utils/weather.py
+++ b/src/plugins/nonebot_plugin_chat/utils/weather.py
@@ -6,7 +6,7 @@
 """
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Optional
 
 import httpx
 
@@ -17,9 +17,6 @@ DEV_API_BASE = (config.qweather_api_host or "https://devapi.qweather.com").rstri
 GEO_API_BASE = (config.qweather_geo_api_host or "https://geoapi.qweather.com").rstrip("/")
 
 WEEKDAYS = ["星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日"]
-
-# 每日天气缓存：成功 30 分钟、失败 5 分钟，避免频繁请求
-_daily_cache: dict[str, Any] = {"time": None, "text": None, "success": False}
 
 
 def is_weather_configured() -> bool:
@@ -59,20 +56,10 @@ async def get_daily_weather_text() -> Optional[str]:
     if not is_weather_configured() or not is_moonlark_location_configured():
         return None
 
-    now = datetime.now()
-    cached = _daily_cache.get("time")
-    if cached is not None:
-        ttl = 1800 if _daily_cache.get("success") else 300
-        if (now - cached).total_seconds() < ttl:
-            return _daily_cache.get("text")
-
     location = f"{config.moonlark_longitude},{config.moonlark_latitude}"
     data = await _qweather_request(DEV_API_BASE, "v7/weather/3d", {"location": location})
     if data is None or not data.get("daily"):
-        _daily_cache.update(time=now, text=None, success=False)
         return None
 
     today = data["daily"][0]
-    text = f"{today.get('textDay', '未知')}，{today.get('tempMin', '?')}℃~{today.get('tempMax', '?')}℃"
-    _daily_cache.update(time=now, text=text, success=True)
-    return text
+    return f"{today.get('textDay', '未知')}，{today.get('tempMin', '?')}℃~{today.get('tempMax', '?')}℃"


### PR DESCRIPTION
## 变更内容

移除 `get_daily_weather_text()` 的模块级缓存 `_daily_cache`，改为每次调用都实时请求和风天气接口。

## 背景

`src/plugins/nonebot_plugin_chat/utils/weather.py` 原先对「当天天气」文本做了缓存：成功缓存 30 分钟、失败缓存 5 分钟。会话信息、博客、日记、计划生成都会调用它，因此天气文本在 TTL 窗口内不会刷新。现按要求删除缓存机制。

## 影响

- `_daily_cache` 字典与 TTL 判断全部删除，不再保留任何天气缓存
- 未配置 `QWEATHER_API_KEY` / 经纬度时仍直接返回 `None`（行为不变）
- 实时天气工具 `get_weather()` 本来就没有缓存，未改动
- 上述调用路径现在每次都会真实请求一次和风天气 API，注意免费额度消耗

## 验证

- `ruff format --check` 通过
- `ruff check` 未新增告警，仅剩 1 条 main 上已存在的 `call-datetime-now-without-tzinfo`（本次改动反而消除了其中一条）
- 全仓库仅 `weather.py` 引用 `_daily_cache`，且无相关测试依赖
