### PR TITLE
fix(chat): 修复 request_image 工具注册错误导致的 AttributeError

### DIFF
--- a/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
+++ b/src/plugins/nonebot_plugin_chat/utils/tool_manager.py
@@ -273,7 +273,7 @@ class ToolManager:
             # - 主模型支持多模态：可以直接把 URL 图片拉进上下文（request_image）
             # - 否则模型看不到原图，只能依赖 VLM 生成的描述，需要 query_image 按需追问细节
             if processor.ENABLE_EMBEDDED_IMAGE:
-                tools.append(processor.request_image)
+                tools.append(self.request_image)
             else:
                 tools.append(processor.query_image)
             tools.append(processor.send_message)

--- a/tests/test_request_image.py
+++ b/tests/test_request_image.py
@@ -99,10 +99,49 @@ class _FakeMessageQueue:
         self.injected.append((image, mime_type, note))
 
 
+def _async_tool(name: str) -> Any:
+    """构造一个带指定 __name__ 的异步桩函数，供 select_tools 收集"""
+
+    async def tool() -> None:
+        return None
+
+    tool.__name__ = name
+    return tool
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.set_timer = _async_tool("set_timer")
+
+    def is_napcat_bot(self) -> bool:
+        return False
+
+
+class _FakeStickerTools:
+    def __init__(self) -> None:
+        self.save_sticker = _async_tool("save_sticker")
+        self.search_sticker = _async_tool("search_sticker")
+        self.recommend_sticker = _async_tool("recommend_sticker")
+        self.send_sticker = _async_tool("send_sticker")
+
+
+class _FakeAiAgent:
+    def __init__(self) -> None:
+        self.ask_ai = _async_tool("ask_ai")
+
+
 class _FakeProcessor:
+    """只实现 select_tools 需要的成员；刻意不提供 request_image（它属于 ToolManager）"""
+
     def __init__(self, enable_embedded_image: bool = True) -> None:
         self.ENABLE_EMBEDDED_IMAGE = enable_embedded_image
         self.openai_messages = _FakeMessageQueue()
+        self.session = _FakeSession()
+        self.sticker_tools = _FakeStickerTools()
+        self.ai_agent = _FakeAiAgent()
+        self.query_image = _async_tool("query_image")
+        self.send_message = _async_tool("send_message")
+        self.leave_for_a_while = _async_tool("leave_for_a_while")
 
 
 async def test_request_image_injects_into_context(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -140,3 +179,39 @@ async def test_request_image_skipped_for_text_only_model(monkeypatch: pytest.Mon
 
     assert processor.openai_messages.injected == []
     assert "不支持图像" in result
+
+
+async def _selected_tool_names(monkeypatch: pytest.MonkeyPatch, processor: _FakeProcessor) -> list[str]:
+    """执行 select_tools("group")，返回被注册工具的函数名列表"""
+    from nonebot_plugin_chat.utils import tool_manager as tm_mod
+
+    names: list[str] = []
+
+    async def _fake_create_function_list(functions: list[Any], **_kwargs: Any) -> list[Any]:
+        names.extend(func.__name__ for func in functions)
+        return []
+
+    monkeypatch.setattr(tm_mod, "create_function_list", _fake_create_function_list)
+    manager = tm_mod.ToolManager(processor=cast("Any", processor))
+    await manager.select_tools("group")
+    return names
+
+
+async def test_select_tools_registers_tool_manager_request_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    """回归：多模态模型下 select_tools 必须绑定 ToolManager.request_image
+
+    曾经错误地写成 processor.request_image，MessageProcessor 上并无该属性，
+    导致群聊定时任务在首次构建工具列表时抛 AttributeError。
+    """
+    names = await _selected_tool_names(monkeypatch, _FakeProcessor(enable_embedded_image=True))
+
+    assert "request_image" in names
+    assert "query_image" not in names
+
+
+async def test_select_tools_falls_back_to_processor_query_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    """非多模态模型下仍回退到 MessageProcessor.query_image"""
+    names = await _selected_tool_names(monkeypatch, _FakeProcessor(enable_embedded_image=False))
+
+    assert "query_image" in names
+    assert "request_image" not in names


### PR DESCRIPTION
## 问题

线上群聊定时任务持续报错（每分钟一次）：

```
File ".../nonebot_plugin_chat/core/session/group.py", line 152, in process_timer
    await self.processor.openai_messages._ensure_system_prompt()
File ".../nonebot_plugin_chat/core/message.py", line 68, in _create_fetcher
    functions=await self.processor.tool_manager.select_tools("group"),
File ".../nonebot_plugin_chat/utils/tool_manager.py", line 276, in select_tools
    tools.append(processor.request_image)
AttributeError: 'MessageProcessor' object has no attribute 'request_image'
```

## 根因

`request_image` 是 `ToolManager` 的方法（`tool_manager.py` 中定义，内部通过 `self.processor` 访问会话与 `openai_messages`），但 `select_tools` 在多模态分支里错误地写成了 `processor.request_image`。

由于 `MessageProcessor.ENABLE_EMBEDDED_IMAGE` 默认为 `True`，该分支必然被走到，于是每次构建工具列表（`_ensure_system_prompt` → `_create_fetcher`）都会抛 `AttributeError`，定时任务因此无法完成。

原 PR 的测试只直接调用了 `manager.request_image(...)`，没有覆盖 `select_tools` 的注册路径，因此漏掉了这个问题。

## 修改

- `src/plugins/nonebot_plugin_chat/utils/tool_manager.py`：`processor.request_image` → `self.request_image`（其余工具注册项已逐一核对，无同类错误）。
- `tests/test_request_image.py`：新增 `select_tools("group")` 回归测试，覆盖两条分支：
  - 多模态：注册 `request_image`，且不注册 `query_image`；
  - 非多模态：回退注册 `processor.query_image`，且不注册 `request_image`。

测试中的 `_FakeProcessor` 刻意不提供 `request_image`，因此旧代码会直接复现线上 `AttributeError`。

## 验证

- 已用真实的 `select_tools` 源码做隔离校验：修复后成功构建 26 个工具；把该行还原为 `processor.request_image` 则如期抛出 `AttributeError: 'FakeProcessor' object has no attribute 'request_image'`。
- `ruff format`/`ruff check` 对改动文件通过（`tool_manager.py` 的其余告警为既有问题，未新增）。
- 完整测试由 CI 执行（`poetry run pytest tests/ -v`）。