### PR TITLE
refactor(quick_math): 所有题目统一按选项字母判题并删除 ABCD 映射兼容层

### DIFF
--- a/src/plugins/nonebot_plugin_quick_math/types.py
+++ b/src/plugins/nonebot_plugin_quick_math/types.py
@@ -1,12 +1,14 @@
 from enum import Enum
 from typing import Awaitable, Callable, Literal
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import TypedDict
 
 
 class Question(TypedDict):
     question: str
-    answer: Callable[[str], Awaitable[bool]]
-    options: NotRequired[list[str]]
+    options: list[str]
+    # 正确选项对应的字母（A/B/C/D…）。所有题目都是选择题，判题直接比较字母，
+    # 不再解析用户输入或调用 AI 判定答案文本。
+    answer: str
 
 
 class QuestionData(TypedDict):

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l1.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l1.py
@@ -1,7 +1,7 @@
 import random
 from ....types import Question
 from ....__main__ import lang
-from .options import build_options, int_distractors
+from .options import build_choices, int_distractors
 
 
 async def generate_question(user_id: str) -> Question:
@@ -26,11 +26,9 @@ async def generate_question(user_id: str) -> Question:
             question = await lang.text("question.l1-4", user_id, a, b)
             answer = a * b
 
-    async def verify(string: str) -> bool:
-        return string.strip() == str(answer)
-
+    options, answer_letter = build_choices(answer, int_distractors(answer))
     return {
         "question": question,
-        "answer": verify,
-        "options": build_options(answer, int_distractors(answer)),
+        "answer": answer_letter,
+        "options": options,
     }

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l2.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l2.py
@@ -1,7 +1,7 @@
 import random
 from ....types import Question
 from ....__main__ import lang
-from .options import build_options, int_distractors
+from .options import build_choices, int_distractors
 
 
 async def generate_question(user_id: str) -> Question:
@@ -14,11 +14,9 @@ async def generate_question(user_id: str) -> Question:
     else:
         question = await lang.text("question.l2-2", user_id, a, b)
 
-    async def verify(string: str) -> bool:
-        return string.strip() == str(answer)
-
+    options, answer_letter = build_choices(answer, int_distractors(answer))
     return {
         "question": question,
-        "answer": verify,
-        "options": build_options(answer, int_distractors(answer)),
+        "answer": answer_letter,
+        "options": options,
     }

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l3.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l3.py
@@ -2,7 +2,7 @@ import random
 from fractions import Fraction
 from ....types import Question
 from ....__main__ import lang
-from .options import build_options, fraction_distractors, int_distractors
+from .options import build_choices, fraction_distractors, int_distractors
 
 
 async def generate_question(user_id: str) -> Question:
@@ -26,20 +26,14 @@ async def generate_question(user_id: str) -> Question:
     if int_answer:
         answer_value: int = int(answer)
         distractors = int_distractors(answer_value)
-
-        async def verify(string: str) -> bool:
-            return string.strip() == str(answer_value)
-
     else:
+        # 分数答案统一以最简分数形式作为选项展示
         answer_value = Fraction(answer).limit_denominator()
         distractors = fraction_distractors(answer_value)
 
-        async def verify(string: str) -> bool:
-            # 同时接受小数与最简分数形式
-            return string.strip() in {str(answer_value), str(answer)}
-
+    options, answer_letter = build_choices(str(answer_value), distractors)
     return {
         "question": question,
-        "answer": verify,
-        "options": build_options(str(answer_value), distractors),
+        "answer": answer_letter,
+        "options": options,
     }

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l4.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l4.py
@@ -1,7 +1,7 @@
 import random
 from ....types import Question
 from ....__main__ import lang
-from .options import build_options, int_distractors
+from .options import build_choices, int_distractors
 
 
 async def generate_question(user_id: str) -> Question:
@@ -24,11 +24,9 @@ async def generate_question(user_id: str) -> Question:
         case 6:
             answer = (a - b) ** 2 - c
 
-    async def verify(string: str) -> bool:
-        return string.strip() == str(answer)
-
+    options, answer_letter = build_choices(answer, int_distractors(answer))
     return {
         "question": question,
-        "answer": verify,
-        "options": build_options(answer, int_distractors(answer)),
+        "answer": answer_letter,
+        "options": options,
     }

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l5.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l5.py
@@ -1,8 +1,8 @@
 import random
 import sympy as sp
 
-from .options import build_options
-from .utils import parse_int, get_verify_function
+from .options import build_choices
+from .utils import parse_int
 from ....types import Question
 from ....__main__ import lang
 
@@ -51,8 +51,9 @@ async def generate_question(user_id: str) -> Question:
         question = question.replace(t, await lang.text("question.l5-o", user_id, t))
     right_answer = quadratic_solver(a, b, c)
     question = await lang.text("question.l5", user_id, question)
+    options, answer_letter = build_choices(right_answer, quadratic_variants(a, b, c))
     return {
         "question": question,
-        "answer": get_verify_function(right_answer, user_id),
-        "options": build_options(right_answer, quadratic_variants(a, b, c)),
+        "answer": answer_letter,
+        "options": options,
     }

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l6.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l6.py
@@ -1,19 +1,9 @@
-import copy
-import json
 import random
-from typing import Generator, Optional
 import sympy as sp
-import re
 
-from .options import build_options
-from .utils import parse_int, get_verify_function
+from .options import build_choices
+from .utils import parse_int
 
-from nonebot_plugin_openai.utils.message import generate_message
-
-from ....exceptions import GenerateFailed
-
-from ....config import config
-from nonebot_plugin_openai.utils.chat import fetch_message
 from ....types import Question
 from ....__main__ import lang
 
@@ -53,9 +43,10 @@ async def generate_question(user_id: str) -> Question:
                 a = random.choice([i for i in range(-75, 76) if i != 0])
                 question += parse_int(a)
                 answer += sp.Integer(a)
-    options = [str(answer + k) for k in range(1, 5)] + [str(answer - k) for k in range(1, 5)]
+    distractors = [str(answer + k) for k in range(1, 5)] + [str(answer - k) for k in range(1, 5)]
+    options, answer_letter = build_choices(str(answer), distractors)
     return {
-        "answer": get_verify_function(answer, user_id),
+        "answer": answer_letter,
         "question": await lang.text("question.l6", user_id, question),
-        "options": build_options(str(answer), options),
+        "options": options,
     }

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l7.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/l7.py
@@ -3,8 +3,7 @@ from typing import Any
 
 from sympy import Symbol, diff, exp, latex, limit, log
 
-from .options import build_options
-from .utils import get_verify_function
+from .options import build_choices
 from ....types import Question
 from ....__main__ import lang
 
@@ -185,8 +184,9 @@ async def generate_question(user_id: str) -> Question:
         question, answer, variants = await generate_derivative_question(user_id)
     else:
         question, answer, variants = await generate_derivative_question(user_id, 2)
+    options, answer_letter = build_choices(answer, variants)
     return {
         "question": question,
-        "answer": get_verify_function(answer, user_id),
-        "options": build_options(answer, variants),
+        "answer": answer_letter,
+        "options": options,
     }

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/options.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/options.py
@@ -1,8 +1,9 @@
 """选择题选项生成工具。
 
-各等级题目生成器在已知标准答案的前提下，生成若干干扰项，
-并由 :func:`build_options` 去重、剔除与正确答案相同的项后乱序返回。
-QQ 官方机器人下这些选项会渲染为可点击的键盘按钮。
+QuickMath 的所有题目都是选择题：各等级题目生成器在已知标准答案的前提下生成若干
+干扰项，由 :func:`build_choices` 去重、剔除与正确答案相同的项后乱序，并返回正确
+答案对应的选项字母。QQ 官方机器人下选项渲染为可点击的键盘按钮，其余适配器则把
+选项随题目一起渲染进图片，用户同样回复字母作答。
 """
 
 import random
@@ -10,6 +11,18 @@ from fractions import Fraction
 from typing import Iterable
 
 from ....config import config
+
+# 选项字母表：第 index 个选项对应 OPTION_LETTERS[index]
+OPTION_LETTERS = "ABCDEFGHIJKL"
+
+
+def _distractor_limit() -> int:
+    """返回干扰项数量上限。
+
+    选项必须始终存在（否则题目无法作答），因此即使 ``config.qm_choice_options``
+    被配置为 0 或负数，也至少生成 1 个干扰项；同时不超过字母表长度。
+    """
+    return min(max(1, config.qm_choice_options), len(OPTION_LETTERS) - 1)
 
 
 def int_distractors(answer: int, count: int = 3) -> list[str]:
@@ -51,20 +64,21 @@ def fraction_distractors(answer: Fraction, count: int = 3) -> list[str]:
     return distractors
 
 
-def build_options(correct: str, distractors: Iterable[str]) -> list[str]:
-    """将正确答案与干扰项合并、去重并乱序，返回选项列表。
+def build_choices(correct: str, distractors: Iterable[str]) -> tuple[list[str], str]:
+    """合并正确答案与干扰项、去重乱序，返回 ``(选项列表, 正确选项字母)``。
 
-    选项总数受 ``config.qm_choice_options``（干扰项数量）控制；
-    配置为 0 时返回空列表，表示不启用选择题。
+    选项数量由 ``config.qm_choice_options``（干扰项数量）控制，至少 1 个干扰项，
+    保证题目始终可作答。返回值中的字母即题目的 ``answer`` 字段，判题时只需把用户
+    输入标准化后与字母比较。
     """
-    if config.qm_choice_options <= 0:
-        return []
-    options = [str(correct)]
+    correct_text = str(correct)
+    options = [correct_text]
+    limit = _distractor_limit()
     for distractor in distractors:
         text = str(distractor)
-        if text != str(correct) and text not in options:
+        if text != correct_text and text not in options:
             options.append(text)
-        if len(options) > config.qm_choice_options:
+        if len(options) > limit:
             break
     random.shuffle(options)
-    return options
+    return options, OPTION_LETTERS[options.index(correct_text)]

--- a/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/utils.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/generator/levels/utils.py
@@ -14,10 +14,6 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ##############################################################################
-from typing import Callable, Awaitable
-from nonebot.log import logger
-from nonebot_plugin_openai.utils.chat import fetch_message
-from nonebot_plugin_openai.utils.message import generate_message
 
 
 def parse_int(a: int) -> str:
@@ -26,29 +22,3 @@ def parse_int(a: int) -> str:
         1: "",
     }.get(a, str(a))
     return f"+{num}" if a > 0 else f"{num}"
-
-
-AI_PROMPT_SYSTEM = """
-请判断用户输入的表达式和标准答案的表达式的内容是否相符，用户输入的表达式可能是纯文本、latex 或其他任何格式，而标准答案的表达式的格式为 latex，只要在数学上这两个输入具有同样的意义且用户输入的表达式化到了最简，那么就判断这用户的回答是相符的。
-如果用户的输入和标准答案的表达式内容是相符的，你需要回答“true”，否则，回答“false”。
-你的回答只能包含这两个单词中的一个。
-"""
-AI_PROMPT_TEMPLATE = """
-标准答案：{}
-用户输入：{}
-"""
-
-
-def get_verify_function(answer: str, user_id: str) -> Callable[[str], Awaitable[bool]]:
-    logger.debug(answer)
-
-    async def verify(string: str) -> bool:
-        reply = await fetch_message(
-            [
-                generate_message(AI_PROMPT_SYSTEM, "system"),
-                generate_message(AI_PROMPT_TEMPLATE.format(answer, string), "user"),
-            ]
-        )
-        return reply == "true"
-
-    return verify

--- a/src/plugins/nonebot_plugin_quick_math/utils/message.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/message.py
@@ -79,7 +79,8 @@ async def wait_answer(
             return ReplyType.SKIP
         elif enable_leave_command and r.lower() in ["leave", "quit", "q"]:
             return ExtendReplyType.LEAVE
-        elif await question["question"]["answer"](r):
+        elif r.strip().upper() == question["question"]["answer"]:
+            # 所有题目都是选择题，answer 是正确选项字母；直接比较字母，忽略大小写与空白
             return ReplyType.RIGHT
         message = UniMessage.text(await lang.text(f"answer.wrong", user_id, config.qm_retry_count - i))
     return ReplyType.WRONG

--- a/src/plugins/nonebot_plugin_quick_math/utils/question.py
+++ b/src/plugins/nonebot_plugin_quick_math/utils/question.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Optional
+from typing import Optional
 
 from nonebot import logger
 from nonebot.adapters import Bot
@@ -11,55 +11,15 @@ from ..__main__ import lang
 from ..config import config
 from ..types import QuestionData
 from .generator import generate_question
+from .generator.levels.options import OPTION_LETTERS
 from .image import generate_image
 from .latex import ensure_math_mode, latex_to_plain
-
-_OPTION_LETTERS = "ABCDEFGHIJKL"
 
 # 仅一元二次方程（L5）的选项由 sympy 生成 LaTeX（\frac、\sqrt），QQ markdown 不解析
 # LaTeX，会把它显示成 "- (9)/(2) - √(57)2" 这类难以辨认的纯文本；因此只有该等级把
 # 题目信息渲染成图片，其余等级继续使用纯文本卡片，避免为简单题目平白增加一次浏览器
 # 渲染与图床上传。
 _QUESTION_IMAGE_LEVELS = frozenset({5})
-
-
-def build_option_answer_matcher(
-    options: list[str], verify: Callable[[str], Awaitable[bool]]
-) -> Callable[[str], Awaitable[bool]]:
-    """包装原始判定函数，使选项按钮发送的选项字母（A/B/C/D）也能被直接判定。
-
-    题目卡片上的选项按钮只回传 ``A``/``B``/``C``/``D``，因此这里先把字母翻译回
-    对应选项文本再交给原始判定函数，避免把字母送进 AI 判定等慢速路径；用户手动
-    输入选项字母或选项原文时同样走这条捷径。
-    """
-
-    async def verify_option(string: str) -> bool:
-        answer = string.strip()
-        if len(answer) == 1:
-            index = _OPTION_LETTERS.find(answer.upper())
-            if 0 <= index < len(options):
-                return await verify(options[index])
-        return await verify(string)
-
-    return verify_option
-
-
-def with_option_letters(question: QuestionData) -> QuestionData:
-    """返回一份新的题目数据：选项按钮回传选项字母，而不是选项原文。
-
-    仅在题目带选项（选择题）时包装判定函数；选项原文仍会被翻译回来交给原始
-    判定函数判定，保证手输答案的行为不变。
-    """
-    options = question["question"].get("options") or []
-    if len(options) < 2:
-        return question
-    return {
-        **question,
-        "question": {
-            **question["question"],
-            "answer": build_option_answer_matcher(options, question["question"]["answer"]),
-        },
-    }
 
 
 async def build_choices_markdown(user_id: str, options: list[str], to_plain: bool = False) -> str:
@@ -77,7 +37,7 @@ async def build_choices_markdown(user_id: str, options: list[str], to_plain: boo
         user_id,
         separator.join(
             [
-                await lang.text("main.choice_item", user_id, _OPTION_LETTERS[index], transform(option))
+                await lang.text("main.choice_item", user_id, OPTION_LETTERS[index], transform(option))
                 for index, option in enumerate(options)
             ],
         ),
@@ -85,14 +45,15 @@ async def build_choices_markdown(user_id: str, options: list[str], to_plain: boo
 
 
 async def build_question_info_markdown(user_id: str, question: QuestionData, to_plain: bool = False) -> str:
-    """构建题目信息（题干 + 选项）的 markdown。"""
+    """构建题目信息（题干 + 选项）的 markdown。
+
+    所有题目都是选择题，选项列表（``A. ...``）一并渲染：QQ 官方机器人把它作为卡片
+    文本，其余适配器则随题干一起渲染进题目图片。
+    """
     content = question["question"]["question"]
     if to_plain:
         content = latex_to_plain(content)
-    options = question["question"].get("options") or []
-    if len(options) > 1:
-        content += "\n\n" + await build_choices_markdown(user_id, options, to_plain=to_plain)
-    return content
+    return content + "\n\n" + await build_choices_markdown(user_id, question["question"]["options"], to_plain=to_plain)
 
 
 async def build_question_info(user_id: str, question: QuestionData) -> str:
@@ -141,11 +102,12 @@ async def get_question(
             qq_user_id,
             enable_leave_button,
         )
+    # 非 QQ 官方机器人没有键盘按钮：选项随题干一起渲染进题目图片，用户同样回复字母
     return (
         UniMessage().image(
             raw=await generate_image(
                 user_id,
-                question["question"]["question"],
+                await build_question_info_markdown(user_id, question),
                 answered,
                 question["limit_in_sec"],
                 question["level"],
@@ -170,7 +132,7 @@ async def build_markdown_message(
     enable_leave_button: bool = False,
 ) -> tuple[UniMessage, QuestionData]:
     """构建 QQ 官方机器人的 markdown 题目卡片，并附带选项/操作按钮。"""
-    options = question["question"].get("options") or []
+    options = question["question"]["options"]
     content = await lang.text(
         "main.qq_markdown",
         user_id,
@@ -185,15 +147,15 @@ async def build_markdown_message(
     )
     message = UniMessage().style(content, "markdown")
     if question["level"] in _QUESTION_IMAGE_LEVELS:
-        # 选项原文已随题目信息渲染进图片，按钮只显示并回传选项字母
+        # L5 的选项原文（LaTeX）已随题目信息渲染进图片，按钮只显示并回传选项字母
         buttons: list[Button] = [
-            Button("enter", _OPTION_LETTERS[index], text=_OPTION_LETTERS[index]) for index in range(len(options))
+            Button("enter", OPTION_LETTERS[index], text=OPTION_LETTERS[index]) for index in range(len(options))
         ]
     else:
-        # 选项仍以文本显示在卡片里，按钮保留选项原文便于直接辨认；回传的仍是字母，
-        # 服务端无需再判定长文本（例如 L7 需要调用 AI 判定），直接按字母取选项即可
+        # 其余等级的选项仍以文本显示在卡片里，按钮保留选项原文便于直接辨认；
+        # 无论按钮显示什么，回传的都是选项字母，判题直接比较字母即可
         buttons = [
-            Button("enter", latex_to_plain(option), text=_OPTION_LETTERS[index]) for index, option in enumerate(options)
+            Button("enter", latex_to_plain(option), text=OPTION_LETTERS[index]) for index, option in enumerate(options)
         ]
     if total_skipping_count > skipped_question:
         buttons.append(Button("enter", await lang.text("button.skip", user_id), text="skip"))
@@ -201,4 +163,4 @@ async def build_markdown_message(
         buttons.append(Button("enter", await lang.text("button.leave", user_id), text="leave"))
     if buttons:
         message.keyboard(*buttons, row=4)
-    return message, with_option_letters(question)
+    return message, question

--- a/tests/test_quick_math_qq_adapter.py
+++ b/tests/test_quick_math_qq_adapter.py
@@ -9,6 +9,8 @@
   图片后经图床发送，避免 QQ markdown 不解析 LaTeX 导致 ``\frac``/``\sqrt`` 显示成
   ``√(57)2`` 这类纯文本；该等级的选项按钮内容改为选项字母（A/B/C/D），选项原文已随
   题目信息进入图片。其余等级的题目信息与选项按钮保持原有纯文本表现；
+- 所有题目统一为选择题，判题只比较选项字母（A/B/C/D），不再把字母映射回选项原文、
+  也不再把答案文本送进 AI 判定；非 QQ 适配器的题目图片同样渲染选项列表；
 - 退出指令（leave/quit/q）仅在禅模式（``enable_leave_command``）下生效，且
   q 不再被 prompt 的快捷退出吞掉、超时以 ``ReplyType.TIMEOUT`` 返回，保证
   退出/超时后正常发送结算卡片；
@@ -83,54 +85,27 @@ def patched_image_renderer(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     return captured
 
 
-def _make_question() -> dict[str, Any]:
-    """构造一个答案恒为错误的题目，避免依赖真实题目生成器。"""
-
-    async def answer_fn(_: str) -> bool:
-        return False
-
+def _make_question(answer: str = "A") -> dict[str, Any]:
+    """构造一个最简题目（用于不关心选项的流程测试），答案为选项字母。"""
     return {
-        "question": {"question": "1 + 1 = ?", "answer": answer_fn},
+        "question": {"question": "1 + 1 = ?", "options": ["1", "2"], "answer": answer},
         "max_point": 10,
         "level": 1,
         "limit_in_sec": 5,
     }
 
 
-def _make_choice_question(answer_fn: Any = None, level: int = 1) -> dict[str, Any]:
-    """构造一个带选项的选择题（默认判定恒为正确）。
+def _make_choice_question(answer: str = "C", level: int = 1) -> dict[str, Any]:
+    """构造一个带选项的选择题：选项为 ["1", "2", "3"]，默认正确字母 ``C``（即选项 "3"）。
 
     ``level`` 决定题目信息是否渲染为图片：只有 L5（一元二次方程）走图片。
     """
-
-    if answer_fn is None:
-
-        async def always_right(_: str) -> bool:
-            return True
-
-        answer_fn = always_right
-
     return {
-        "question": {
-            "question": "1 + 2 = ?",
-            "answer": answer_fn,
-            "options": ["1", "2", "3"],
-        },
+        "question": {"question": "1 + 2 = ?", "options": ["1", "2", "3"], "answer": answer},
         "max_point": 10,
         "level": level,
         "limit_in_sec": 5,
     }
-
-
-def _make_recorded_verify(correct: str = "3") -> tuple[dict[str, Any], list[str]]:
-    """构造“慢速判定”题目：记录判定函数收到的每次输入，便于断言是否绕过慢速路径。"""
-    calls: list[str] = []
-
-    async def answer_fn(string: str) -> bool:
-        calls.append(string)
-        return string == correct
-
-    return _make_choice_question(answer_fn), calls
 
 
 # ---------- 主界面按钮 ----------
@@ -256,7 +231,7 @@ async def test_question_card_leave_button_only_when_enabled() -> None:
     assert all(button.text != "leave" for button in keyboard.children)
 
 
-# ---------- 选项按钮回传选项字母（加快判定） ----------
+# ---------- 所有题目按选项字母判题 ----------
 
 
 @pytest.mark.asyncio
@@ -285,161 +260,128 @@ async def test_question_card_option_buttons_keep_text_for_other_levels() -> None
 
 
 @pytest.mark.asyncio
-async def test_button_letter_answers_without_slow_verify(monkeypatch: pytest.MonkeyPatch) -> None:
-    """点击正确选项按钮（回传字母）应直接答对，且不把字母送进慢速判定函数。"""
+async def test_button_letter_answer_is_right(monkeypatch: pytest.MonkeyPatch) -> None:
+    """点击正确选项按钮（回传字母）应判定为正确，且不区分大小写与首尾空白。"""
     from nonebot_plugin_alconna import UniMessage
     from nonebot_plugin_quick_math.types import ReplyType
     from nonebot_plugin_quick_math.utils import message as message_module
-    from nonebot_plugin_quick_math.utils.question import with_option_letters
 
-    question, calls = _make_recorded_verify("3")
-    question = with_option_letters(question)
-
-    async def prompt_stub(_message: UniMessage, _user_id: str, **_kwargs: object) -> str:
-        return "c"
-
-    monkeypatch.setattr(message_module, "prompt", prompt_stub)
-
-    assert await message_module.wait_answer(question, UniMessage(), "user") is ReplyType.RIGHT
-    # 字母被翻译为选项原文后再判定，慢速判定函数从未收到单个字母
-    assert calls == ["3"]
-
-
-@pytest.mark.asyncio
-async def test_button_letter_answers_accepted_by_generator_questions() -> None:
-    """真实题目生成器（L1）下，选项按钮回传的字母同样应被判定为正确。"""
-    from nonebot_plugin_quick_math.utils.generator.levels import l1
-    from nonebot_plugin_quick_math.utils.question import with_option_letters
-
-    letters = "ABCDEFGHIJKL"
-    for _ in range(20):
-        data = await l1.generate_question("user")
-        options = data.get("options") or []
-        assert len(options) > 1
-        wrapped = with_option_letters({"question": data, "max_point": 10, "level": 1, "limit_in_sec": 5})
-        for index, option in enumerate(options):
-            # 每个选项：字母答案与选项原文答案的判定结果必须一致
-            by_letter = await wrapped["question"]["answer"](letters[index])
-            by_text = await data["answer"](option)
-            assert by_letter is by_text
-
-
-@pytest.mark.asyncio
-async def test_button_letter_answers_are_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
-    """用户手输选项字母时应忽略大小写与首尾空白。"""
-    from nonebot_plugin_alconna import UniMessage
-    from nonebot_plugin_quick_math.types import ReplyType
-    from nonebot_plugin_quick_math.utils import message as message_module
-    from nonebot_plugin_quick_math.utils.question import with_option_letters
-
-    for typed in ("B", "b", " b "):
-        question, calls = _make_recorded_verify("2")
-        question = with_option_letters(question)
+    for typed in ("C", "c", " c "):
+        question = _make_choice_question("C")
 
         async def prompt_stub(_message: UniMessage, _user_id: str, _typed: str = typed, **_kwargs: object) -> str:
             return _typed
 
         monkeypatch.setattr(message_module, "prompt", prompt_stub)
         assert await message_module.wait_answer(question, UniMessage(), "user") is ReplyType.RIGHT
-        assert calls == ["2"]
 
 
 @pytest.mark.asyncio
-async def test_wrong_button_letter_answers_wrong(monkeypatch: pytest.MonkeyPatch) -> None:
-    """点击错误选项按钮（回传字母）应判定为错误，而不是重试耗尽。"""
+async def test_wrong_button_letter_answer_is_wrong(monkeypatch: pytest.MonkeyPatch) -> None:
+    """点击错误选项按钮（回传字母）应判定为错误。"""
     from nonebot_plugin_alconna import UniMessage
     from nonebot_plugin_quick_math.types import ReplyType
     from nonebot_plugin_quick_math.utils import message as message_module
-    from nonebot_plugin_quick_math.utils.question import with_option_letters
-
-    question, calls = _make_recorded_verify("3")
-    question = with_option_letters(question)
 
     async def prompt_stub(_message: UniMessage, _user_id: str, **_kwargs: object) -> str:
         return "A"
 
     monkeypatch.setattr(message_module, "prompt", prompt_stub)
-
-    assert await message_module.wait_answer(question, UniMessage(), "user") is ReplyType.WRONG
-    assert calls == ["1", "1"]
+    assert await message_module.wait_answer(_make_choice_question("C"), UniMessage(), "user") is ReplyType.WRONG
 
 
 @pytest.mark.asyncio
-async def test_typed_option_text_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
-    """用户手动输入选项原文（而非字母）时行为保持不变。"""
+async def test_option_text_is_no_longer_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """校验已统一为选项字母：手输选项原文（正确答案 "3"）不再算对。"""
     from nonebot_plugin_alconna import UniMessage
     from nonebot_plugin_quick_math.types import ReplyType
     from nonebot_plugin_quick_math.utils import message as message_module
-    from nonebot_plugin_quick_math.utils.question import with_option_letters
-
-    question, calls = _make_recorded_verify("3")
-    question = with_option_letters(question)
 
     async def prompt_stub(_message: UniMessage, _user_id: str, **_kwargs: object) -> str:
         return "3"
 
     monkeypatch.setattr(message_module, "prompt", prompt_stub)
-
-    assert await message_module.wait_answer(question, UniMessage(), "user") is ReplyType.RIGHT
-    assert calls == ["3"]
+    assert await message_module.wait_answer(_make_choice_question("C"), UniMessage(), "user") is ReplyType.WRONG
 
 
 @pytest.mark.asyncio
-async def test_letter_beyond_options_delegates_to_original(monkeypatch: pytest.MonkeyPatch) -> None:
-    """超出选项范围的字母（如 3 个选项却输入 D）应原样交给原始判定函数。"""
+async def test_letter_beyond_options_is_wrong(monkeypatch: pytest.MonkeyPatch) -> None:
+    """超出选项范围的字母（如 3 个选项却输入 D）不算对。"""
     from nonebot_plugin_alconna import UniMessage
     from nonebot_plugin_quick_math.types import ReplyType
     from nonebot_plugin_quick_math.utils import message as message_module
-    from nonebot_plugin_quick_math.utils.question import with_option_letters
-
-    question, calls = _make_recorded_verify("D")
-    question = with_option_letters(question)
 
     async def prompt_stub(_message: UniMessage, _user_id: str, **_kwargs: object) -> str:
         return "D"
 
     monkeypatch.setattr(message_module, "prompt", prompt_stub)
-
-    assert await message_module.wait_answer(question, UniMessage(), "user") is ReplyType.RIGHT
-    assert calls == ["D"]
+    assert await message_module.wait_answer(_make_choice_question("C"), UniMessage(), "user") is ReplyType.WRONG
 
 
-@pytest.mark.asyncio
-async def test_non_choice_question_delegates_to_original() -> None:
-    """无选项（非选择题）的题目不应被包装，判定函数保持原样。"""
-    from nonebot_plugin_quick_math.utils.question import with_option_letters
+def test_build_choices_letter_points_to_correct_option() -> None:
+    """``build_choices`` 返回的字母必须指向正确答案所在的选项。"""
+    from nonebot_plugin_quick_math.utils.generator.levels.options import OPTION_LETTERS, build_choices
 
-    async def answer_fn(_: str) -> bool:
-        return True
-
-    question = {
-        "question": {"question": "1 + 1 = ?", "answer": answer_fn},
-        "max_point": 10,
-        "level": 1,
-        "limit_in_sec": 5,
-    }
-    assert with_option_letters(question)["question"]["answer"] is answer_fn
+    for _ in range(50):
+        options, letter = build_choices("42", ["1", "2", "3", "42"])
+        assert len(options) == 4
+        assert sorted(options) == ["1", "2", "3", "42"]
+        assert options[OPTION_LETTERS.index(letter)] == "42"
 
 
 @pytest.mark.asyncio
-async def test_non_qq_adapter_questions_keep_original_answer(monkeypatch: pytest.MonkeyPatch) -> None:
-    """非 QQ 官方机器人（图片题目）不携带选项按钮，答案判定应保持原样。"""
+async def test_all_generator_levels_answer_by_letter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """所有等级的题目都生成至少 2 个选项与合法字母，字母作答必定判定为正确。"""
+    from nonebot_plugin_alconna import UniMessage
+    from nonebot_plugin_quick_math.types import ReplyType
+    from nonebot_plugin_quick_math.utils import message as message_module
+    from nonebot_plugin_quick_math.utils.generator import GENERATOR_LIST
+    from nonebot_plugin_quick_math.utils.generator.levels.options import OPTION_LETTERS
+
+    for level, generator in GENERATOR_LIST.items():
+        for _ in range(2):
+            raw = await generator["function"]("user")
+            assert len(raw["options"]) >= 2
+            assert OPTION_LETTERS.index(raw["answer"]) < len(raw["options"])
+            question = {"question": raw, "max_point": 10, "level": level, "limit_in_sec": 5}
+
+            async def prompt_stub(
+                _message: UniMessage,
+                _user_id: str,
+                _answer: str = raw["answer"],
+                **_kwargs: object,
+            ) -> str:
+                return _answer
+
+            monkeypatch.setattr(message_module, "prompt", prompt_stub)
+            assert await message_module.wait_answer(question, UniMessage(), "user") is ReplyType.RIGHT
+
+
+@pytest.mark.asyncio
+async def test_non_qq_adapter_question_image_contains_choices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """非 QQ 官方机器人（图片题目）也把选项列表渲染进题目图片，用户回复字母作答。"""
     from nonebot.adapters.console import Bot as ConsoleBot
     from nonebot_plugin_quick_math.utils import question as question_module
 
+    captured: dict[str, str] = {}
     raw = _make_choice_question()
 
     async def generate_question(_user_id: str, _level: int) -> dict[str, Any]:
         return raw
 
-    async def generate_image(*_args: object, **_kwargs: object) -> bytes:
+    async def fake_generate_image(_user_id: str, content: str, *_args: object, **_kwargs: object) -> bytes:
+        captured["content"] = content
         return b""
 
     monkeypatch.setattr(question_module, "generate_question", generate_question)
-    monkeypatch.setattr(question_module, "generate_image", generate_image)
+    monkeypatch.setattr(question_module, "generate_image", fake_generate_image)
 
     _, question = await question_module.get_question(ConsoleBot.__new__(ConsoleBot), 1, "user", 0, 0, 0, 0)
-    assert question["question"]["answer"] is raw["question"]["answer"]
+    assert question["question"]["answer"] == "C"
+    assert "1 + 2 = ?" in captured["content"]
+    assert "A. 1" in captured["content"]
+    assert "B. 2" in captured["content"]
+    assert "C. 3" in captured["content"]
 
 
 # ---------- 等待回答 / 退出 / 超时 ----------


### PR DESCRIPTION
## 变更内容

把 QuickMath 的判题从「解析答案文本 / 调用 AI」统一为「比较选项字母（A/B/C/D）」，并彻底删除此前为 QQ Adapter 按钮添加的 ABCD 映射兼容代码。

### 数据模型
- `Question.answer` 由 `Callable[[str], Awaitable[bool]]` 改为正确选项字母（`str`），`options` 由可选改为必填；所有题目都是选择题。

### 选项生成
- `build_options` 改为 `build_choices(correct, distractors) -> (options, answer_letter)`：去重乱序后直接返回正确选项字母，并保证选项始终生成（`qm_choice_options` 配置为 0 时也至少 1 个干扰项）。

### 删除的兼容层
- `utils/question.py` 中的 `build_option_answer_matcher` / `with_option_letters`（PR #1419 为按钮回传字母而加的「字母 → 选项原文」翻译）。
- `utils/generator/levels/utils.py` 中的 `get_verify_function` 与 AI 判定提示词：L5/L6/L7 判题不再请求模型，选择题判定即时完成。
- 清理随之失效的导入（`nonebot_plugin_openai`、`copy`/`json`/`re` 等）。

### 判题与各适配器表现
- `wait_answer` 直接把用户输入 `strip().upper()` 后与正确字母比较（忽略大小写与首尾空白），选项原文不再被接受。
- QQ 官方机器人：按钮回传字母不变，L5 按钮显示字母、其余等级按钮显示选项原文。
- 非 QQ 官方适配器（OneBot）：题目图片现在同样渲染 `A. ... / B. ...` 选项列表，用户回复字母作答。

### 测试
- 重写 `tests/test_quick_math_qq_adapter.py` 中选择题相关回归测试：字母判题、大小写/空白、错误选项、越界字母、选项原文不再算对、`build_choices` 字母指向正确选项、全部 7 个等级生成选项与合法字母、非 QQ 题目图片包含选项。
- 本地全量 `pytest tests/`：246 passed。

Signed-off-by: XiaoDeng3386 <1744793737@qq.com>
